### PR TITLE
Add minimal CI via github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: CI with softoken
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout Repository
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libnss3 libnss3-tools libnss3-dev
+    - name: Setup
+      run: |
+        autoreconf -fiv
+        ./configure
+    - name: Build and Test
+      run: |
+        make
+        make check
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: Test logs
+        path: |
+          tests/test.sh.log
+          tests/openssl.cnf
+          tests/tmp/p11prov-debug.log
+          tests/tmp/debugvars
+          config.log

--- a/configure.ac
+++ b/configure.ac
@@ -21,12 +21,17 @@ PKG_CHECK_MODULES(
 )
 AC_SUBST([SHARED_EXT], $(eval echo "${shrext_cmds}"))
 
+# Try nss-softoken first as used on Fedora,
+# fallback to "nss" as used on Debian
 PKG_CHECK_EXISTS(
         [nss-softokn],
-        ,
-        [AC_MSG_WARN([nss-softokn is required to run tests])]
+        [PKG_CHECK_VAR([SOFTOKENDIR], [nss-softokn], [libdir])],
+        [PKG_CHECK_EXISTS(
+                [nss],
+                [PKG_CHECK_VAR([SOFTOKENDIR], [nss], [libdir], [AC_SUBST([SOFTOKEN_SUBDIR], "nss/")])]
+        )]
 )
-PKG_CHECK_VAR([SOFTOKENDIR], [nss-softokn], [libdir])
+
 AS_IF([test "x$SOFTOKENDIR" = "x"], [
   AC_MSG_WARN([Unable to identify softoken plugin path.])
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = pkcs11_provider.la
 SHARED_EXT=@SHARED_EXT@
 
 pkcs11_provider_la_SOURCES = \
-	asymmetric_cipher.c
+	asymmetric_cipher.c \
 	debug.c \
 	exchange.c \
 	kdf.c \

--- a/src/debug.c
+++ b/src/debug.c
@@ -69,7 +69,7 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
                       "  flags (%#08lx):\n",
                       mechname, type,
                       info.ulMinKeySize, info.ulMaxKeySize, info.flags);
-        for (int i; mechanism_flags[i].name != NULL; i++) {
+        for (int i = 0; mechanism_flags[i].name != NULL; i++) {
             if (info.flags & mechanism_flags[i].value) {
                 p11prov_debug("    %-25s (%#08lx)\n",
                               mechanism_flags[i].name,
@@ -91,7 +91,7 @@ void p11prov_debug_token_info(CK_TOKEN_INFO info)
                   "  Flags (%#08lx):\n",
                   info.label, info.manufacturerID, info.model,
                   info.serialNumber, info.flags);
-    for (int i; token_flags[i].name != NULL; i++) {
+    for (int i = 0; token_flags[i].name != NULL; i++) {
         if (info.flags & token_flags[i].value) {
             p11prov_debug("    %-35s (%#08lx)\n",
                           token_flags[i].name,
@@ -132,7 +132,7 @@ void p11prov_debug_slot(struct p11prov_slot *slot)
                   "  Flags (%#08lx):\n",
                   slot->id, slot->slot.slotDescription,
                   slot->slot.manufacturerID, slot->slot.flags);
-    for (int i; slot_flags[i].name != NULL; i++) {
+    for (int i = 0; slot_flags[i].name != NULL; i++) {
         if (slot->slot.flags & slot_flags[i].value) {
             p11prov_debug("    %-25s (%#08lx)\n",
                           slot_flags[i].name,
@@ -152,7 +152,7 @@ void p11prov_debug_slot(struct p11prov_slot *slot)
         p11prov_debug("  Available profiles:\n");
         for (int c = 0; c < 5; c++) {
             CK_ULONG profile = slot->profiles[c];
-            for (int i; profile_ids[i].name != NULL; i++) {
+            for (int i = 0; profile_ids[i].name != NULL; i++) {
                 if (profile == slot_flags[i].value) {
                     p11prov_debug("    %-35s (%#08lx)\n",
                                   profile_ids[i].name,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 EXTRA_DIST = openssl.cnf.in
 noinst_DATA = openssl.cnf
 
-softokenpath=@SOFTOKENDIR@/libsoftokn3.so
+softokenpath=@SOFTOKENDIR@/@SOFTOKEN_SUBDIR@libsoftokn3.so
 libtoollibs=@abs_top_builddir@/src/.libs
 testsdir=@abs_top_builddir@/tests
 

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -20,7 +20,7 @@ activate = 1
 activate = 1
 
 [pkcs11_sect]
-module = @libtoollibs@/pkcs11prov.so
+module = @libtoollibs@/pkcs11_provider.so
 pkcs11-module-path = @softokenpath@
 pkcs11-module-init-args = configDir=@testsdir@/tokens
 activate = 1


### PR DESCRIPTION
Includes fixes to make this work:
- some changes to configure to account for differences in debian/ubuntu packaging of NSS
- some fixes for breakage I caused when pushed a barely tested rename earlier.
- some unexpected segfaults as apparently for loops variables are initialized to 0 in Fedora but not in Debian, probably different default flags between the two.