### PR TITLE
Add support to return errors to OpenSSL

### DIFF
--- a/src/kdf.c
+++ b/src/kdf.c
@@ -165,7 +165,8 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
 
     pkey_handle = p11prov_key_handle(hkdfctx->key);
     if (pkey_handle == CK_INVALID_HANDLE) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY);
+        P11PROV_raise(hkdfctx->provctx, CKR_KEY_HANDLE_INVALID,
+                      "Provided key has invalid handle");
         return RET_OSSL_ERR;
     }
 
@@ -175,10 +176,7 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     }
 
     f = p11prov_ctx_fns(hkdfctx->provctx);
-    if (f == NULL) {
-        /* TODO: ERR_raise(ERR_LIB_PROV, ?? ); */
-        return RET_OSSL_ERR;
-    }
+    if (f == NULL) return RET_OSSL_ERR;
 
     ret = f->C_DeriveKey(hkdfctx->session, &mechanism, pkey_handle,
                          key_template, 5, &dkey_handle);
@@ -194,7 +192,8 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
             p11prov_debug("hkdf failed to retrieve secret %d\n", ret);
         }
     } else {
-        p11prov_debug("hkdf C_DeriveKey failed %d\n", ret);
+        P11PROV_raise(hkdfctx->provctx, ret,
+                      "Error returned by C_DeriveKey");
         return RET_OSSL_ERR;
     }
 

--- a/src/provider.c
+++ b/src/provider.c
@@ -355,6 +355,11 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_BUFFER_TOO_SMALL,
             "The output of the function is too large to fit in "
             "the supplied buffer" },
+        { CKR_SAVED_STATE_INVALID,
+            "The supplied saved cryptographic operations state is invalid" },
+        { CKR_STATE_UNSAVEABLE,
+            "The cryptographic operations state of the specified "
+            "session cannot be saved" },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
             "PKCS11 Module has not been intialized yet" },
         { 0, NULL }

--- a/src/provider.c
+++ b/src/provider.c
@@ -276,6 +276,13 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_ARGUMENTS_BAD,
             "Invalid or improper arguments were provided to the "
             "invoked function" },
+        { CKR_ATTRIBUTE_READ_ONLY,
+            "Attempted to set or modify an attribute that is Read "
+            "Only for applications" },
+        { CKR_ATTRIBUTE_TYPE_INVALID,
+            "Invalid attribute type specified in a template" },
+        { CKR_ATTRIBUTE_VALUE_INVALID,
+            "Invalid value specified for attribute in a template" },
         { CKR_DATA_INVALID,
             "The plaintext input data to a cryptographic "
             "operation is invalid" },
@@ -323,17 +330,28 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
             "A read-only session already exists" },
         { CKR_SESSION_READ_WRITE_SO_EXISTS,
             "A read/write SO session already exists" },
+        { CKR_TEMPLATE_INCOMPLETE,
+            "The template to create an object is incomplete" },
+        { CKR_TEMPLATE_INCONSISTENT,
+            "The template to create an object has conflicting attributes" },
         { CKR_TOKEN_NOT_PRESENT,
             "The token was not present in its slot when the "
             "function was invoked" },
         { CKR_TOKEN_NOT_RECOGNIZED,
             "The token in the slot is not recognized" },
         { CKR_TOKEN_WRITE_PROTECTED,
+            "Action denied because the token is write-protected" },
+        { CKR_TOKEN_WRITE_PROTECTED,
             "Can't perform action because the token is write-protected" },
         { CKR_USER_NOT_LOGGED_IN,
             "The desired action cannot be performed because an "
             "appropriate user is not logged in" },
         { CKR_OPERATION_CANCEL_FAILED, "The operation cannot be cancelled" },
+        { CKR_DOMAIN_PARAMS_INVALID,
+            "Invalid or unsupported domain parameters were "
+            "supplied to the function" },
+        { CKR_CURVE_NOT_SUPPORTED,
+            "The specified curve is not supported by this token" },
         { CKR_BUFFER_TOO_SMALL,
             "The output of the function is too large to fit in "
             "the supplied buffer" },

--- a/src/provider.c
+++ b/src/provider.c
@@ -276,6 +276,12 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_ARGUMENTS_BAD,
             "Invalid or improper arguments were provided to the "
             "invoked function" },
+        { CKR_DATA_INVALID,
+            "The plaintext input data to a cryptographic "
+            "operation is invalid" },
+        { CKR_DATA_LEN_RANGE,
+            "The size of plaintext input data to a cryptographic "
+            "operation is invalid (Out of range)" },
         { CKR_DEVICE_ERROR,
             "Some problem has occurred with the token and/or slot" },
         { CKR_DEVICE_MEMORY,
@@ -284,6 +290,28 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_DEVICE_REMOVED,
             "The token was removed from its slot during the "
             "execution of the function" },
+        { CKR_FUNCTION_CANCELED,
+            "The function was canceled in mid-execution" },
+        { CKR_KEY_HANDLE_INVALID, "The specified key handle is not valid" },
+        { CKR_KEY_SIZE_RANGE,
+            "Unable to handle the specified key size (Out of range)" },
+        { CKR_KEY_TYPE_INCONSISTENT,
+            "The specified key is not the correct type of key to "
+            "use with the specified mechanism" },
+        { CKR_KEY_FUNCTION_NOT_PERMITTED,
+            "The key attributes do not allow this operation to be executed" },
+        { CKR_MECHANISM_INVALID,
+            "An invalid mechanism was specified to the "
+            "cryptographic operation" },
+        { CKR_MECHANISM_PARAM_INVALID,
+            "Invalid mechanism parameters were supplied" },
+        { CKR_OPERATION_ACTIVE,
+            "There is already an active operation that prevents "
+            "executing the requested function" },
+        { CKR_OPERATION_NOT_INITIALIZED,
+            "There is no active operation of appropriate type "
+            "in the specified session" },
+        { CKR_PIN_EXPIRED, "The specified PIN has expired" },
         { CKR_SESSION_CLOSED, "Session is already closed" },
         { CKR_SESSION_COUNT, "Too many sessions open" },
         { CKR_SESSION_HANDLE_INVALID, "Invalid Session Handle" },
@@ -302,6 +330,13 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
             "The token in the slot is not recognized" },
         { CKR_TOKEN_WRITE_PROTECTED,
             "Can't perform action because the token is write-protected" },
+        { CKR_USER_NOT_LOGGED_IN,
+            "The desired action cannot be performed because an "
+            "appropriate user is not logged in" },
+        { CKR_OPERATION_CANCEL_FAILED, "The operation cannot be cancelled" },
+        { CKR_BUFFER_TOO_SMALL,
+            "The output of the function is too large to fit in "
+            "the supplied buffer" },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
             "PKCS11 Module has not been intialized yet" },
         { 0, NULL }

--- a/src/provider.c
+++ b/src/provider.c
@@ -318,7 +318,9 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_OPERATION_NOT_INITIALIZED,
             "There is no active operation of appropriate type "
             "in the specified session" },
+        { CKR_PIN_INCORRECT, "The specified PIN is incorrect" },
         { CKR_PIN_EXPIRED, "The specified PIN has expired" },
+        { CKR_PIN_LOCKED, "The specified PIN is locked, and cannot be used" },
         { CKR_SESSION_CLOSED, "Session is already closed" },
         { CKR_SESSION_COUNT, "Too many sessions open" },
         { CKR_SESSION_HANDLE_INVALID, "Invalid Session Handle" },
@@ -346,6 +348,12 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_USER_NOT_LOGGED_IN,
             "The desired action cannot be performed because an "
             "appropriate user is not logged in" },
+        { CKR_USER_PIN_NOT_INITIALIZED, "The user PIN is not initialized" },
+        { CKR_USER_TYPE_INVALID, "An invalid user type was specified" },
+        { CKR_USER_ANOTHER_ALREADY_LOGGED_IN,
+            "Another user is already logged in" },
+        { CKR_USER_TOO_MANY_TYPES,
+            "Attempted to log in more users than the token can support" },
         { CKR_OPERATION_CANCEL_FAILED, "The operation cannot be cancelled" },
         { CKR_DOMAIN_PARAMS_INVALID,
             "Invalid or unsupported domain parameters were "

--- a/src/provider.h
+++ b/src/provider.h
@@ -51,6 +51,20 @@ CK_FUNCTION_LIST *p11prov_ctx_fns(P11PROV_CTX *ctx);
 int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 
+/* Errors */
+void p11prov_raise(P11PROV_CTX *ctx,
+                   const char *file, int line, const char *func,
+                   int errnum, const char *fmt, ...);
+
+#define P11PROV_raise(ctx, errnum, ...) \
+do { \
+    p11prov_raise((ctx), OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC, \
+                  (errnum), __VA_ARGS__); \
+    if (errnum) \
+        p11prov_debug("Error: %lu", (unsigned long)(errnum)); \
+    p11prov_debug(__VA_ARGS__); \
+} while(0)
+
 /* Debugging */
 void p11prov_debug(const char *fmt, ...);
 void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,

--- a/src/store.c
+++ b/src/store.c
@@ -477,8 +477,9 @@ static int p11prov_store_load(void *ctx,
                 ret = f->C_OpenSession(slots[i].id, CKF_SERIAL_SESSION, NULL,
                                        NULL, &obj->login_session);
                 if (ret != CKR_OK) {
-                    p11prov_debug("OpenSession failed %d\n", ret);
-                    /* TODO: Err message */
+                    P11PROV_raise(obj->provctx, ret,
+                                  "Failed to open session on slot %lu",
+                                  slots[i].id);
                     continue;
                 }
             }
@@ -486,7 +487,8 @@ static int p11prov_store_load(void *ctx,
             /* Supports only USER login sessions for now */
             ret = f->C_Login(obj->login_session, CKU_USER, pin, pinlen);
             if (ret && ret != CKR_USER_ALREADY_LOGGED_IN) {
-                p11prov_debug("C_Login failed (%d)\n", ret);
+                P11PROV_raise(obj->provctx, ret,
+                              "Error returned by C_Login");
                 continue;
             }
         }

--- a/src/util.c
+++ b/src/util.c
@@ -114,17 +114,12 @@ CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx,
     if (slotid == CK_UNAVAILABLE_INFORMATION) goto done;
 
     f = p11prov_ctx_fns(provctx);
-    if (f == NULL) {
-        /* TODO: Return uninitialized error ?
-         * ERR_raise(ERR_LIB_PROV??, ??); */
-        goto done;
-    }
+    if (f == NULL) goto done;
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
-        p11prov_debug("OpenSession failed %d\n", ret);
-        /* TODO: Err message
-         * ERR_raise(ERR_LIB_PROV??, ??); */
+        P11PROV_raise(provctx, ret,
+                      "Failed to open session on slot %lu", slotid);
     }
 
 done:
@@ -137,16 +132,11 @@ void p11prov_put_session(P11PROV_CTX *provctx, CK_SESSION_HANDLE session)
     CK_RV ret;
 
     f = p11prov_ctx_fns(provctx);
-    if (f == NULL) {
-        /* TODO: Return uninitialized error ?
-         * ERR_raise(ERR_LIB_PROV??, ??); */
-        return;
-    }
+    if (f == NULL) return;
 
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        p11prov_debug("CloseSession failed %d\n", ret);
-        /* TODO: Err message
-         * ERR_raise(ERR_LIB_PROV??, ??); */
+        P11PROV_raise(provctx, ret,
+                      "Failed to close session %lu", session);
     }
 }


### PR DESCRIPTION
This allow OpenSSL application to see and return more meaningful errors directly returned from the provider.