### PR TITLE
Instead of listing the exported symbols, use GCC Visibility

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,13 +17,10 @@ pkcs11_provider_la_SOURCES = \
 	util.c \
 	$(NULL)
 
-pkcs11_provider_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
+pkcs11_provider_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS) -fvisibility=hidden
 pkcs11_provider_la_LIBADD = $(OPENSSL_LIBS)
 
 pkcs11_provider_la_LDFLAGS = \
 	$(AM_LDFLAGS) -module \
 	-shared -shrext $(SHARED_EXT) \
-	-avoid-version \
-	-export-symbols "$(srcdir)/provider.exports"
-
-
+	-avoid-version

--- a/src/provider.c
+++ b/src/provider.c
@@ -590,10 +590,10 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     return 0;
 }
 
-int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
-                       const OSSL_DISPATCH *in,
-                       const OSSL_DISPATCH **out,
-                       void **provctx)
+PUBLIC int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+                              const OSSL_DISPATCH *in,
+                              const OSSL_DISPATCH **out,
+                              void **provctx)
 {
     OSSL_PARAM core_params[3] = { 0 };
     P11PROV_CTX *ctx;

--- a/src/provider.exports
+++ b/src/provider.exports
@@ -1,1 +1,0 @@
-OSSL_provider_init

--- a/src/provider.h
+++ b/src/provider.h
@@ -17,7 +17,13 @@
 #include <openssl/proverr.h>
 #include <openssl/core_names.h>
 
-#define UNUSED  __attribute__((unused))
+#if __GNUC__ >= 4
+  #define PUBLIC __attribute__ ((__visibility__("default")))
+#else
+  #define PUBLIC
+#endif
+
+#define UNUSED  __attribute__((__unused__))
 #define RET_OSSL_OK 1
 #define RET_OSSL_ERR 0
 #define RET_OSSL_BAD -1


### PR DESCRIPTION
Set the default symbol visibility to hidden and add PUBLIC macro that
expands to __attribute__((__visibility__("default"))) and use the
macro to export the OSSL_provider_init symbol.