### PR TITLE
Fix operator precedence errors

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -405,7 +405,7 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                       "Error returned by C_GetSessionInfo");
         return NULL;
     }
-    if ((session_info.flags & CKF_RW_SESSION == 0) &&
+    if (((session_info.flags & CKF_RW_SESSION) == 0) &&
         val_token == CK_TRUE) {
         p11prov_debug("Invalid read only session for token key request\n");
         return NULL;

--- a/src/store.c
+++ b/src/store.c
@@ -444,8 +444,8 @@ static int p11prov_store_load(void *ctx,
 	CK_TOKEN_INFO token;
 
         /* ignore slots that are not initialized */
-        if (slots[i].slot.flags & CKF_TOKEN_PRESENT == 0) continue;
-        if (slots[i].token.flags & CKF_TOKEN_INITIALIZED == 0) continue;
+        if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) continue;
+        if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) continue;
 
         token = slots[i].token;
 
@@ -698,4 +698,3 @@ const OSSL_DISPATCH p11prov_store_functions[] = {
     DISPATCH_STORE_ELEM(EXPORT_OBJECT, export_object),
     { 0, NULL }
 };
-


### PR DESCRIPTION
As reported by clang, the & has lower precedence than == operator.
Use parentheses as needed when checking for a set bit.