### PR TITLE
Fix logical error in p11prov_rsakm_secbits

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -166,7 +166,7 @@ static int p11prov_rsakm_secbits(int bits)
     if (bits > 4096) return 152;
     if (bits > 3072) return 128;
     if (bits > 2048) return 112;
-    if (bits < 2048) return 0;
+    if (bits <= 2048) return 0;
 }
 
 static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])


### PR DESCRIPTION
The branching in p11prov_rsakm_secbits() has missed the 2048 value
because of < 2048 and > 2048 checks.  Fix the off-by-one check.