### PR TITLE
Add headers to the Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,6 +11,11 @@ pkcs11_provider_la_SOURCES = \
 	kdf.c \
 	keymgmt.c \
 	keys.c \
+	oasis/pkcs11.h \
+	oasis/pkcs11f.h \
+	oasis/pkcs11t.h \
+	pkcs11.h \
+	provider.h \
 	provider.c \
 	signature.c \
 	store.c \


### PR DESCRIPTION
The automake needs to know what files are part of the distribution
when making distribution tarball and to calculate the dependencies.
Add all used headers to the pkcs11_provider_la_SOURCES.