### PR TITLE
Add initial .clang-format style and reformat the sources using it

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,72 @@
+BasedOnStyle: LLVM
+ColumnLimit: 80
+IndentWidth: 4
+UseTab: Never
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Linux
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: DontAlign
+AllowAllArgumentsOnNextLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackArguments: true
+BinPackParameters: true
+#InsertTrailingCommas: Wrapped
+ReflowComments: false
+Cpp11BracedListStyle: false
+AlignArrayOfStructures: None
+AlignTrailingComments: false
+AllowShortFunctionsOnASingleLine: Empty
+AlwaysBreakBeforeMultilineStrings: true
+IndentGotoLabels: false
+SortIncludes: Never
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: false
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Leave third party code untouched
+./src/oasis/*

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Check Style
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout Repository
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+    - name: Setup
+      if: ${{ github.event.pull_request.base.sha }}
+      run: |
+        git fetch origin main ${{ github.event.pull_request.base.sha }}
+    - name: Generate Makefile
+      run: |
+        autoreconf -fiv
+        ./configure
+    - name: Check the Style
+      run: make check-style
+    - name: Show Style diff in case of failure
+      if: failure()
+      run: make check-style-show

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -18,6 +18,7 @@ Files: **/Makefile.am
        tests/Makefile.am
        tests/README
        tests/openssl.cnf.in
+       .clang-format
 Copyright: (C) 2022 Simo Sorce <simo@redhat.com>
 License: Apache-2.0
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -19,6 +19,7 @@ Files: **/Makefile.am
        tests/README
        tests/openssl.cnf.in
        .clang-format
+       .clang-format-ignore
 Copyright: (C) 2022 Simo Sorce <simo@redhat.com>
 License: Apache-2.0
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,3 +2,18 @@ ACLOCAL_AMFLAGS = -Im4
 
 SUBDIRS = src tests
 dist_doc_DATA = README
+
+check-style:
+	@lines=`git diff -U0 --no-color --relative origin/main | clang-format-diff -p1 |wc -l`; \
+	if [ "$$lines" != "0" ]; then \
+		echo "Coding Style issues detected"; \
+		exit 1; \
+	else \
+		echo "Coding Styles checks out"; \
+	fi
+
+check-style-show:
+	git diff -U0 --no-color --relative origin/main | clang-format-diff -p1
+
+check-style-fix:
+	git diff -U0 --no-color --relative origin/main | clang-format-diff -i -p1

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -311,7 +311,7 @@ static struct {
     { CKM_RSA_PKCS, RSA_PKCS1_PADDING, OSSL_PKEY_RSA_PAD_MODE_PKCSV15 },
     { CKM_RSA_PKCS_OAEP, RSA_PKCS1_OAEP_PADDING, OSSL_PKEY_RSA_PAD_MODE_OAEP },
     { CKM_RSA_X9_31, RSA_X931_PADDING, OSSL_PKEY_RSA_PAD_MODE_X931 },
-    { CK_UNAVAILABLE_INFORMATION, 0, NULL }
+    { CK_UNAVAILABLE_INFORMATION, 0, NULL },
 };
 
 /* only the ones we can support */
@@ -329,7 +329,7 @@ static struct {
     { "SHA256", CKM_SHA256, CKG_MGF1_SHA256 },
     { "SHA224", CKM_SHA224, CKG_MGF1_SHA224 },
     { "SHA1", CKM_SHA_1, CKG_MGF1_SHA1 },
-    { NULL, 0, 0 }
+    { NULL, 0, 0 },
 };
 
 static const char *p11prov_rsaenc_digest_name(CK_MECHANISM_TYPE digest)
@@ -531,11 +531,11 @@ static const OSSL_PARAM *p11prov_rsaenc_gettable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL, NULL, 0),
-/*
+        /*
         OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION, NULL),
         OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION, NULL),
-*/
-        OSSL_PARAM_END
+        */
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -549,11 +549,11 @@ static const OSSL_PARAM *p11prov_rsaenc_settable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL, NULL, 0),
-/*
+        /*
         OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION, NULL),
         OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION, NULL),
-*/
-        OSSL_PARAM_END
+        */
+        OSSL_PARAM_END,
     };
     return params;
 }

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -70,8 +70,8 @@ static void *p11prov_rsaenc_dupctx(void *ctx)
     if (encctx->oaep_params.pSourceData) {
         CK_RSA_PKCS_OAEP_PARAMS_PTR src = &encctx->oaep_params;
         CK_RSA_PKCS_OAEP_PARAMS_PTR dst = &newctx->oaep_params;
-        dst->pSourceData = OPENSSL_memdup(src->pSourceData,
-                                          src->ulSourceDataLen);
+        dst->pSourceData =
+            OPENSSL_memdup(src->pSourceData, src->ulSourceDataLen);
         if (dst->pSourceData == NULL) {
             p11prov_rsaenc_freectx(newctx);
             return NULL;
@@ -89,7 +89,7 @@ static int p11prov_rsaenc_set_mechanism(void *ctx, CK_MECHANISM *mechanism)
 
     mechanism->mechanism = encctx->mechtype;
     mechanism->pParameter = NULL;
-    mechanism->ulParameterLen  = 0;
+    mechanism->ulParameterLen = 0;
 
     if (mechanism->mechanism == CKM_RSA_PKCS_OAEP) {
         encctx->oaep_params.source = CKZ_DATA_SPECIFIED;
@@ -97,7 +97,7 @@ static int p11prov_rsaenc_set_mechanism(void *ctx, CK_MECHANISM *mechanism)
         mechanism->ulParameterLen = sizeof(encctx->oaep_params);
     }
 
-    return  CKR_OK;
+    return CKR_OK;
 }
 
 static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
@@ -106,8 +106,8 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
 
-    p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
+                  params);
 
     encctx->key = p11prov_object_get_key(obj, false);
     if (encctx->key == NULL) {
@@ -118,10 +118,9 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
     return p11prov_rsaenc_set_ctx_params(ctx, params);
 }
 
-static int p11prov_rsaenc_encrypt(void *ctx,
-                                  unsigned char *out, size_t *outlen,
-                                  size_t outsize,
-                                  const unsigned char *in, size_t inlen)
+static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
+                                  size_t outsize, const unsigned char *in,
+                                  size_t inlen)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     CK_FUNCTION_LIST *f;
@@ -172,20 +171,17 @@ static int p11prov_rsaenc_encrypt(void *ctx,
 
     ret = f->C_EncryptInit(session, &mechanism, handle);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Error returned by C_EncryptInit");
-        if (ret == CKR_MECHANISM_INVALID ||
-            ret == CKR_MECHANISM_PARAM_INVALID) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+        P11PROV_raise(encctx->provctx, ret, "Error returned by C_EncryptInit");
+        if (ret == CKR_MECHANISM_INVALID
+            || ret == CKR_MECHANISM_PARAM_INVALID) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
         }
         goto endsess;
     }
 
     ret = f->C_Encrypt(session, (void *)in, inlen, out, &out_size);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Error returned by C_Encrypt");
+        P11PROV_raise(encctx->provctx, ret, "Error returned by C_Encrypt");
         goto endsess;
     }
 
@@ -195,8 +191,8 @@ static int p11prov_rsaenc_encrypt(void *ctx,
 endsess:
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Failed to close session %lu", session);
+        P11PROV_raise(encctx->provctx, ret, "Failed to close session %lu",
+                      session);
     }
 
     return result;
@@ -208,8 +204,8 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
 
-    p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
+                  params);
 
     encctx->key = p11prov_object_get_key(obj, true);
     if (encctx->key == NULL) return RET_OSSL_ERR;
@@ -217,10 +213,9 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
     return p11prov_rsaenc_set_ctx_params(ctx, params);
 }
 
-static int p11prov_rsaenc_decrypt(void *ctx,
-                                  unsigned char *out, size_t *outlen,
-                                  size_t outsize,
-                                  const unsigned char *in, size_t inlen)
+static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
+                                  size_t outsize, const unsigned char *in,
+                                  size_t inlen)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     CK_FUNCTION_LIST *f;
@@ -271,20 +266,17 @@ static int p11prov_rsaenc_decrypt(void *ctx,
 
     ret = f->C_DecryptInit(session, &mechanism, handle);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Error returned by C_DecryptInit");
-        if (ret == CKR_MECHANISM_INVALID ||
-            ret == CKR_MECHANISM_PARAM_INVALID) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+        P11PROV_raise(encctx->provctx, ret, "Error returned by C_DecryptInit");
+        if (ret == CKR_MECHANISM_INVALID
+            || ret == CKR_MECHANISM_PARAM_INVALID) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
         }
         goto endsess;
     }
 
     ret = f->C_Decrypt(session, (void *)in, inlen, out, &out_size);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Error returned by C_Decrypt");
+        P11PROV_raise(encctx->provctx, ret, "Error returned by C_Decrypt");
         goto endsess;
     }
 
@@ -294,12 +286,11 @@ static int p11prov_rsaenc_decrypt(void *ctx,
 endsess:
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret,
-                      "Failed to close session %lu", session);
+        P11PROV_raise(encctx->provctx, ret, "Failed to close session %lu",
+                      session);
     }
 
     return result;
-
 }
 
 static struct {
@@ -352,7 +343,7 @@ static const char *p11prov_rsaenc_mgf_name(CK_RSA_PKCS_MGF_TYPE mgf)
     return "";
 }
 
-static CK_MECHANISM_TYPE p11prov_rsaenc_map_digest(const char*digest)
+static CK_MECHANISM_TYPE p11prov_rsaenc_map_digest(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
@@ -363,7 +354,7 @@ static CK_MECHANISM_TYPE p11prov_rsaenc_map_digest(const char*digest)
     return CK_UNAVAILABLE_INFORMATION;
 }
 
-static CK_RSA_PKCS_MGF_TYPE p11prov_rsaenc_map_mgf(const char*digest)
+static CK_RSA_PKCS_MGF_TYPE p11prov_rsaenc_map_mgf(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
@@ -380,8 +371,7 @@ static int p11prov_rsaenc_get_ctx_params(void *ctx, OSSL_PARAM *params)
     OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("rsaenc get ctx params (ctx=%p, params=%p)\n",
-                  ctx, params);
+    p11prov_debug("rsaenc get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -406,22 +396,22 @@ static int p11prov_rsaenc_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
     if (p) {
-        ret = OSSL_PARAM_set_utf8_string(p,
-                    p11prov_rsaenc_digest_name(encctx->oaep_params.hashAlg));
+        ret = OSSL_PARAM_set_utf8_string(
+            p, p11prov_rsaenc_digest_name(encctx->oaep_params.hashAlg));
         if (ret != RET_OSSL_OK) return ret;
     }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST);
     if (p) {
-        ret = OSSL_PARAM_set_utf8_string(p,
-                    p11prov_rsaenc_mgf_name(encctx->oaep_params.mgf));
+        ret = OSSL_PARAM_set_utf8_string(
+            p, p11prov_rsaenc_mgf_name(encctx->oaep_params.mgf));
         if (ret != RET_OSSL_OK) return ret;
     }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL);
     if (p) {
         ret = OSSL_PARAM_set_octet_ptr(p, encctx->oaep_params.pSourceData,
-                                          encctx->oaep_params.ulSourceDataLen);
+                                       encctx->oaep_params.ulSourceDataLen);
         if (ret != RET_OSSL_OK) return ret;
     }
 
@@ -434,8 +424,7 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("rsaenc set ctx params (ctx=%p, params=%p)\n",
-                  ctx, params);
+    p11prov_debug("rsaenc set ctx params (ctx=%p, params=%p)\n", ctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -466,15 +455,13 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             return RET_OSSL_ERR;
         }
         if (mechtype == CK_UNAVAILABLE_INFORMATION) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+            ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
             return RET_OSSL_ERR;
         }
         encctx->mechtype = mechtype;
 
-        p11prov_debug_mechanism(encctx->provctx,
-                                p11prov_key_slotid(encctx->key),
-                                encctx->mechtype);
+        p11prov_debug_mechanism(
+            encctx->provctx, p11prov_key_slotid(encctx->key), encctx->mechtype);
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
@@ -547,7 +534,8 @@ static const OSSL_PARAM *p11prov_rsaenc_settable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_PAD_MODE, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST, NULL, 0),
-        OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS, NULL,
+                               0),
         OSSL_PARAM_octet_string(OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL, NULL, 0),
         /*
         OSSL_PARAM_uint(OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION, NULL),

--- a/src/debug.c
+++ b/src/debug.c
@@ -60,20 +60,19 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 
     ret = f->C_GetMechanismInfo(slotid, type, &info);
     if (ret != CKR_OK) {
-        p11prov_debug("C_GetMechanismInfo for %s(%lu) failed %d\n",
-                      mechname, type, ret);
+        p11prov_debug("C_GetMechanismInfo for %s(%lu) failed %d\n", mechname,
+                      type, ret);
     } else {
-        p11prov_debug("Mechanism Info:\n"
-                      "  name: %s (%lu):\n"
-                      "  min key length: %lu\n"
-                      "  max key length: %lu\n"
-                      "  flags (%#08lx):\n",
-                      mechname, type,
-                      info.ulMinKeySize, info.ulMaxKeySize, info.flags);
+        p11prov_debug(
+            "Mechanism Info:\n"
+            "  name: %s (%lu):\n"
+            "  min key length: %lu\n"
+            "  max key length: %lu\n"
+            "  flags (%#08lx):\n",
+            mechname, type, info.ulMinKeySize, info.ulMaxKeySize, info.flags);
         for (int i = 0; mechanism_flags[i].name != NULL; i++) {
             if (info.flags & mechanism_flags[i].value) {
-                p11prov_debug("    %-25s (%#08lx)\n",
-                              mechanism_flags[i].name,
+                p11prov_debug("    %-25s (%#08lx)\n", mechanism_flags[i].name,
                               mechanism_flags[i].value);
             }
         }
@@ -84,41 +83,36 @@ extern struct ckmap token_flags[];
 
 void p11prov_debug_token_info(CK_TOKEN_INFO info)
 {
-    p11prov_debug("Token Info:\n"
-                  "  Label:            [%.32s]\n"
-                  "  Manufacturer ID:  [%.32s]\n"
-                  "  Model:            [%.16s]\n"
-                  "  Serial Number:    [%.16s]\n"
-                  "  Flags (%#08lx):\n",
-                  info.label, info.manufacturerID, info.model,
-                  info.serialNumber, info.flags);
+    p11prov_debug(
+        "Token Info:\n"
+        "  Label:            [%.32s]\n"
+        "  Manufacturer ID:  [%.32s]\n"
+        "  Model:            [%.16s]\n"
+        "  Serial Number:    [%.16s]\n"
+        "  Flags (%#08lx):\n",
+        info.label, info.manufacturerID, info.model, info.serialNumber,
+        info.flags);
     for (int i = 0; token_flags[i].name != NULL; i++) {
         if (info.flags & token_flags[i].value) {
-            p11prov_debug("    %-35s (%#08lx)\n",
-                          token_flags[i].name,
+            p11prov_debug("    %-35s (%#08lx)\n", token_flags[i].name,
                           token_flags[i].value);
         }
     }
-    p11prov_debug("  Session Count      Max: %3lu  Current: %3lu\n"
-                  "  R/W Session Count  Max: %3lu  Current: %3lu\n"
-                  "  Pin Len Range: %lu-%lu\n"
-                  "  Public  Memory  Total: %6lu  Free: %6lu\n"
-                  "  Private Memory  Total: %6lu  Free: %6lu\n"
-                  "  Hardware Version: %d.%d\n"
-                  "  Firmware Version: %d.%d\n"
-                  "  UTC Time: [%.16s]\n",
-                  info.ulMaxSessionCount, info.ulSessionCount,
-                  info.ulMaxRwSessionCount, info.ulRwSessionCount,
-                  info.ulMinPinLen, info.ulMaxPinLen,
-                  info.ulTotalPublicMemory,
-                  info.ulFreePublicMemory,
-                  info.ulTotalPrivateMemory,
-                  info.ulFreePrivateMemory,
-                  info.hardwareVersion.major,
-                  info.hardwareVersion.minor,
-                  info.firmwareVersion.major,
-                  info.firmwareVersion.minor,
-                  info.utcTime);
+    p11prov_debug(
+        "  Session Count      Max: %3lu  Current: %3lu\n"
+        "  R/W Session Count  Max: %3lu  Current: %3lu\n"
+        "  Pin Len Range: %lu-%lu\n"
+        "  Public  Memory  Total: %6lu  Free: %6lu\n"
+        "  Private Memory  Total: %6lu  Free: %6lu\n"
+        "  Hardware Version: %d.%d\n"
+        "  Firmware Version: %d.%d\n"
+        "  UTC Time: [%.16s]\n",
+        info.ulMaxSessionCount, info.ulSessionCount, info.ulMaxRwSessionCount,
+        info.ulRwSessionCount, info.ulMinPinLen, info.ulMaxPinLen,
+        info.ulTotalPublicMemory, info.ulFreePublicMemory,
+        info.ulTotalPrivateMemory, info.ulFreePrivateMemory,
+        info.hardwareVersion.major, info.hardwareVersion.minor,
+        info.firmwareVersion.major, info.firmwareVersion.minor, info.utcTime);
 }
 
 extern struct ckmap slot_flags[];
@@ -126,26 +120,25 @@ extern struct ckmap profile_ids[];
 
 void p11prov_debug_slot(struct p11prov_slot *slot)
 {
-    p11prov_debug("Slot Info:\n"
-                  "  ID: %lu\n"
-                  "  Description:      [%.64s]\n"
-                  "  Manufacturer ID:  [%.32s]\n"
-                  "  Flags (%#08lx):\n",
-                  slot->id, slot->slot.slotDescription,
-                  slot->slot.manufacturerID, slot->slot.flags);
+    p11prov_debug(
+        "Slot Info:\n"
+        "  ID: %lu\n"
+        "  Description:      [%.64s]\n"
+        "  Manufacturer ID:  [%.32s]\n"
+        "  Flags (%#08lx):\n",
+        slot->id, slot->slot.slotDescription, slot->slot.manufacturerID,
+        slot->slot.flags);
     for (int i = 0; slot_flags[i].name != NULL; i++) {
         if (slot->slot.flags & slot_flags[i].value) {
-            p11prov_debug("    %-25s (%#08lx)\n",
-                          slot_flags[i].name,
+            p11prov_debug("    %-25s (%#08lx)\n", slot_flags[i].name,
                           slot_flags[i].value);
         }
     }
-    p11prov_debug("  Hardware Version: %d.%d\n"
-                  "  Firmware Version: %d.%d\n",
-                  slot->slot.hardwareVersion.major,
-                  slot->slot.hardwareVersion.minor,
-                  slot->slot.firmwareVersion.major,
-                  slot->slot.firmwareVersion.minor);
+    p11prov_debug(
+        "  Hardware Version: %d.%d\n"
+        "  Firmware Version: %d.%d\n",
+        slot->slot.hardwareVersion.major, slot->slot.hardwareVersion.minor,
+        slot->slot.firmwareVersion.major, slot->slot.firmwareVersion.minor);
     if (slot->slot.flags & CKF_TOKEN_PRESENT) {
         p11prov_debug_token_info(slot->token);
     }
@@ -155,8 +148,7 @@ void p11prov_debug_slot(struct p11prov_slot *slot)
             CK_ULONG profile = slot->profiles[c];
             for (int i = 0; profile_ids[i].name != NULL; i++) {
                 if (profile == slot_flags[i].value) {
-                    p11prov_debug("    %-35s (%#08lx)\n",
-                                  profile_ids[i].name,
+                    p11prov_debug("    %-35s (%#08lx)\n", profile_ids[i].name,
                                   profile_ids[i].value);
                 }
             }
@@ -166,7 +158,10 @@ void p11prov_debug_slot(struct p11prov_slot *slot)
     }
 }
 
-#define MECH_ENTRY(_m) { _m, #_m }
+#define MECH_ENTRY(_m) \
+    { \
+        _m, #_m \
+    }
 struct ckmap mechanism_names[] = {
     MECH_ENTRY(CKM_RSA_PKCS_KEY_PAIR_GEN),
     MECH_ENTRY(CKM_RSA_PKCS),
@@ -594,7 +589,7 @@ struct ckmap mechanism_names[] = {
     MECH_ENTRY(CKM_SP800_108_COUNTER_KDF),
     MECH_ENTRY(CKM_SP800_108_FEEDBACK_KDF),
     MECH_ENTRY(CKM_SP800_108_DOUBLE_PIPELINE_KDF),
-    {0, NULL}
+    { 0, NULL },
 };
 
 struct ckmap mechanism_flags[] = {
@@ -624,7 +619,7 @@ struct ckmap mechanism_flags[] = {
     MECH_ENTRY(CKF_EC_UNCOMPRESS),
     MECH_ENTRY(CKF_EC_COMPRESS),
     MECH_ENTRY(CKF_EC_CURVENAME),
-    {0, NULL}
+    { 0, NULL },
 };
 
 struct ckmap token_flags[] = {
@@ -647,14 +642,14 @@ struct ckmap token_flags[] = {
     MECH_ENTRY(CKF_SO_PIN_LOCKED),
     MECH_ENTRY(CKF_SO_PIN_TO_BE_CHANGED),
     MECH_ENTRY(CKF_ERROR_STATE),
-    {0, NULL}
+    { 0, NULL },
 };
 
 struct ckmap slot_flags[] = {
     MECH_ENTRY(CKF_TOKEN_PRESENT),
     MECH_ENTRY(CKF_REMOVABLE_DEVICE),
     MECH_ENTRY(CKF_HW_SLOT),
-    {0, NULL}
+    { 0, NULL },
 };
 
 struct ckmap profile_ids[] = {
@@ -664,5 +659,5 @@ struct ckmap profile_ids[] = {
     MECH_ENTRY(CKP_AUTHENTICATION_TOKEN),
     MECH_ENTRY(CKP_PUBLIC_CERTIFICATES_TOKEN),
     MECH_ENTRY(CKP_VENDOR_DEFINED),
-    {0, NULL}
+    { 0, NULL },
 };

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -47,7 +47,7 @@ static struct {
     DM_ELEM_SHA(384),
     DM_ELEM_SHA(224),
     { "SHA1", CKM_SHA_1, CKD_SHA1_KDF, 20 },
-    { NULL, 0, 0, 0, }
+    { NULL, 0, 0, 0 },
 };
 
 static CK_ULONG p11prov_ecdh_digest_to_kdf(CK_MECHANISM_TYPE digest)
@@ -212,7 +212,7 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
         {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
         {CKA_SENSITIVE, &val_false, sizeof(val_false)},
         {CKA_EXTRACTABLE, &val_true, sizeof(val_true)},
-        {CKA_VALUE_LEN, &key_size, sizeof(key_size)}
+        {CKA_VALUE_LEN, &key_size, sizeof(key_size)},
     };
     CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
@@ -417,7 +417,7 @@ static const OSSL_PARAM *p11prov_ecdh_settable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_DIGEST, NULL, 0),
         OSSL_PARAM_size_t(OSSL_EXCHANGE_PARAM_KDF_OUTLEN, NULL),
         OSSL_PARAM_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -480,7 +480,7 @@ static const OSSL_PARAM *p11prov_ecdh_gettable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_EXCHANGE_PARAM_KDF_DIGEST, NULL, 0),
         OSSL_PARAM_size_t(OSSL_EXCHANGE_PARAM_KDF_OUTLEN, NULL),
         OSSL_PARAM_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -496,7 +496,7 @@ const OSSL_DISPATCH p11prov_ecdh_exchange_functions[] = {
     DISPATCH_ECDH_ELEM(ecdh, SETTABLE_CTX_PARAMS, settable_ctx_params),
     DISPATCH_ECDH_ELEM(ecdh, GET_CTX_PARAMS, get_ctx_params),
     DISPATCH_ECDH_ELEM(ecdh, GETTABLE_CTX_PARAMS, gettable_ctx_params),
-    { 0, NULL }
+    { 0, NULL },
 };
 
 /* unclear why OpenSSL makes KDFs go through a middle "exchange" layer
@@ -624,5 +624,5 @@ const OSSL_DISPATCH p11prov_hkdf_exchange_functions[] = {
     DISPATCH_EXCHHKDF_ELEM(exch_hkdf, DERIVE, derive),
     DISPATCH_EXCHHKDF_ELEM(exch_hkdf, SET_CTX_PARAMS, set_ctx_params),
     DISPATCH_EXCHHKDF_ELEM(exch_hkdf, SETTABLE_CTX_PARAMS, settable_ctx_params),
-    { 0, NULL }
+    { 0, NULL },
 };

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -22,15 +22,15 @@ struct p11prov_exch_ctx {
 typedef struct p11prov_exch_ctx P11PROV_EXCH_CTX;
 
 #define DM_ELEM_SHA(bits) \
-  { .name = "SHA"#bits, \
-    .digest = CKM_SHA##bits, \
-    .kdf = CKD_SHA##bits##_KDF, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA" #bits, .digest = CKM_SHA##bits, \
+        .kdf = CKD_SHA##bits##_KDF, .digest_size = bits / 8 \
+    }
 #define DM_ELEM_SHA3(bits) \
-  { .name = "SHA3-"#bits, \
-    .digest = CKM_SHA3_##bits, \
-    .kdf = CKD_SHA3_##bits##_KDF, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA3-" #bits, .digest = CKM_SHA3_##bits, \
+        .kdf = CKD_SHA3_##bits##_KDF, .digest_size = bits / 8 \
+    }
 /* only the ones we can support */
 static struct {
     const char *name;
@@ -169,7 +169,7 @@ static void p11prov_ecdh_freectx(void *ctx)
 }
 
 static int p11prov_ecdh_init(void *ctx, void *provkey,
-                            const OSSL_PARAM params[])
+                             const OSSL_PARAM params[])
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
@@ -208,11 +208,11 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     CK_BBOOL val_false = CK_FALSE;
     CK_ULONG key_size = 0;
     CK_ATTRIBUTE key_template[5] = {
-        {CKA_CLASS, &key_class, sizeof(key_class)},
-        {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
-        {CKA_SENSITIVE, &val_false, sizeof(val_false)},
-        {CKA_EXTRACTABLE, &val_true, sizeof(val_true)},
-        {CKA_VALUE_LEN, &key_size, sizeof(key_size)},
+        { CKA_CLASS, &key_class, sizeof(key_class) },
+        { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
+        { CKA_SENSITIVE, &val_false, sizeof(val_false) },
+        { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
+        { CKA_VALUE_LEN, &key_size, sizeof(key_size) },
     };
     CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
@@ -301,15 +301,14 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
         *psecretlen = secret_len;
         result = RET_OSSL_OK;
     } else {
-        P11PROV_raise(ecdhctx->provctx, ret,
-                      "Error returned by C_DeriveKey");
+        P11PROV_raise(ecdhctx->provctx, ret, "Error returned by C_DeriveKey");
         result = RET_OSSL_ERR;
     }
 
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        P11PROV_raise(ecdhctx->provctx, ret,
-                      "Failed to close session %lu", session);
+        P11PROV_raise(ecdhctx->provctx, ret, "Failed to close session %lu",
+                      session);
     }
 
     return result;
@@ -321,8 +320,7 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("ecdh set ctx params (ctx=%p, params=%p)\n",
-                  ecdhctx, params);
+    p11prov_debug("ecdh set ctx params (ctx=%p, params=%p)\n", ecdhctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -336,8 +334,10 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
         if (mode < -1 || mode > 1) return RET_OSSL_ERR;
 
-        if (mode == 0) ecdhctx->mechtype = CKM_ECDH1_DERIVE;
-        else ecdhctx->mechtype = CKM_ECDH1_COFACTOR_DERIVE;
+        if (mode == 0)
+            ecdhctx->mechtype = CKM_ECDH1_DERIVE;
+        else
+            ecdhctx->mechtype = CKM_ECDH1_COFACTOR_DERIVE;
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
@@ -408,8 +408,7 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     return RET_OSSL_OK;
 }
 
-static const OSSL_PARAM *p11prov_ecdh_settable_ctx_params(void *ctx,
-                                                          void *prov)
+static const OSSL_PARAM *p11prov_ecdh_settable_ctx_params(void *ctx, void *prov)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_EC_ECDH_COFACTOR_MODE, NULL),
@@ -428,12 +427,11 @@ static int p11prov_ecdh_get_ctx_params(void *ctx, OSSL_PARAM *params)
     OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("ecdh get ctx params (ctx=%p, params=%p)\n",
-                  ctx, params);
+    p11prov_debug("ecdh get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_EC_ECDH_COFACTOR_MODE);
     if (p) {
-        int mode = (ecdhctx->mechtype == CKM_ECDH1_DERIVE)?0:1;
+        int mode = (ecdhctx->mechtype == CKM_ECDH1_DERIVE) ? 0 : 1;
         ret = OSSL_PARAM_set_int(p, mode);
         if (ret != RET_OSSL_OK) return ret;
     }
@@ -471,8 +469,7 @@ static int p11prov_ecdh_get_ctx_params(void *ctx, OSSL_PARAM *params)
     return RET_OSSL_OK;
 }
 
-static const OSSL_PARAM *p11prov_ecdh_gettable_ctx_params(void *ctx,
-                                                          void *prov)
+static const OSSL_PARAM *p11prov_ecdh_gettable_ctx_params(void *ctx, void *prov)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_EC_ECDH_COFACTOR_MODE, NULL),
@@ -562,8 +559,8 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
     P11PROV_EXCH_CTX *hkdfctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provobj;
 
-    p11prov_debug("hkdf exchange init (ctx:%p obj:%p params:%p)\n",
-                  ctx, obj, params);
+    p11prov_debug("hkdf exchange init (ctx:%p obj:%p params:%p)\n", ctx, obj,
+                  params);
 
     if (ctx == NULL || provobj == NULL) return RET_OSSL_ERR;
 
@@ -596,8 +593,8 @@ static int p11prov_exch_hkdf_set_ctx_params(void *ctx,
 {
     P11PROV_EXCH_CTX *hkdfctx = (P11PROV_EXCH_CTX *)ctx;
 
-    p11prov_debug("hkdf exchange set ctx params (ctx:%p, params:%p)\n",
-                  ctx, params);
+    p11prov_debug("hkdf exchange set ctx params (ctx:%p, params:%p)\n", ctx,
+                  params);
 
     return EVP_KDF_CTX_set_params(hkdfctx->kdfctx, params);
 }

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -19,28 +19,23 @@ struct p11prov_kdf_ctx {
 typedef struct p11prov_kdf_ctx P11PROV_KDF_CTX;
 
 #define DM_ELEM_SHA(bits) \
-  { .name = "SHA"#bits, \
-    .digest = CKM_SHA##bits, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA" #bits, .digest = CKM_SHA##bits, .digest_size = bits / 8 \
+    }
 #define DM_ELEM_SHA3(bits) \
-  { .name = "SHA3-"#bits, \
-    .digest = CKM_SHA3_##bits, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA3-" #bits, .digest = CKM_SHA3_##bits, \
+        .digest_size = bits / 8 \
+    }
 /* only the ones we can support */
 static struct {
     const char *name;
     CK_MECHANISM_TYPE digest;
     int digest_size;
 } digest_map[] = {
-    DM_ELEM_SHA3(256),
-    DM_ELEM_SHA3(512),
-    DM_ELEM_SHA3(384),
-    DM_ELEM_SHA3(224),
-    DM_ELEM_SHA(256),
-    DM_ELEM_SHA(512),
-    DM_ELEM_SHA(384),
-    DM_ELEM_SHA(224),
-    { "SHA1", CKM_SHA_1, 20 },
+    DM_ELEM_SHA3(256), DM_ELEM_SHA3(512), DM_ELEM_SHA3(384),
+    DM_ELEM_SHA3(224), DM_ELEM_SHA(256),  DM_ELEM_SHA(512),
+    DM_ELEM_SHA(384),  DM_ELEM_SHA(224),  { "SHA1", CKM_SHA_1, 20 },
     { NULL, 0, 0 },
 };
 
@@ -135,11 +130,11 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     CK_BBOOL val_false = CK_FALSE;
     CK_ULONG key_size = keylen;
     CK_ATTRIBUTE key_template[5] = {
-        {CKA_CLASS, &key_class, sizeof(key_class)},
-        {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
-        {CKA_SENSITIVE, &val_false, sizeof(val_false)},
-        {CKA_EXTRACTABLE, &val_true, sizeof(val_true)},
-        {CKA_VALUE_LEN, &key_size, sizeof(key_size)},
+        { CKA_CLASS, &key_class, sizeof(key_class) },
+        { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
+        { CKA_SENSITIVE, &val_false, sizeof(val_false) },
+        { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
+        { CKA_VALUE_LEN, &key_size, sizeof(key_size) },
     };
     CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
@@ -147,8 +142,8 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     CK_OBJECT_HANDLE dkey_handle;
     int ret = RET_OSSL_ERR;
 
-    p11prov_debug("hkdf derive (ctx:%p, key:%p[%zu], params:%p)\n",
-                  ctx, key, keylen, params);
+    p11prov_debug("hkdf derive (ctx:%p, key:%p[%zu], params:%p)\n", ctx, key,
+                  keylen, params);
 
     if (hkdfctx->key == NULL || key == NULL) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
@@ -187,14 +182,13 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
         struct fetch_attrs attrs[1] = {
             { CKA_VALUE, &key, &dkey_len, false, true },
         };
-        ret = p11prov_fetch_attributes(f, hkdfctx->session, dkey_handle,
-                                       attrs, 1);
+        ret = p11prov_fetch_attributes(f, hkdfctx->session, dkey_handle, attrs,
+                                       1);
         if (ret != CKR_OK) {
             p11prov_debug("hkdf failed to retrieve secret %d\n", ret);
         }
     } else {
-        P11PROV_raise(hkdfctx->provctx, ret,
-                      "Error returned by C_DeriveKey");
+        P11PROV_raise(hkdfctx->provctx, ret, "Error returned by C_DeriveKey");
         return RET_OSSL_ERR;
     }
 
@@ -207,8 +201,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("hkdf set ctx params (ctx=%p, params=%p)\n",
-                  hkdfctx, params);
+    p11prov_debug("hkdf set ctx params (ctx=%p, params=%p)\n", hkdfctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -283,9 +276,8 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         }
         if (hkdfctx->session == CK_INVALID_HANDLE) return RET_OSSL_ERR;
 
-        hkdfctx->key = p11prov_create_secret_key(hkdfctx->provctx,
-                                                 hkdfctx->session, true,
-                                                 secret, secret_len);
+        hkdfctx->key = p11prov_create_secret_key(
+            hkdfctx->provctx, hkdfctx->session, true, secret, secret_len);
         if (hkdfctx->key == NULL) return RET_OSSL_ERR;
     }
 
@@ -304,8 +296,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     }
 
     /* can be multiple paramaters, which wil be all concatenated */
-    for (p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO);
-         p != NULL;
+    for (p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO); p != NULL;
          p = OSSL_PARAM_locate_const(p + 1, OSSL_KDF_PARAM_INFO)) {
         void *ptr;
         size_t len;
@@ -327,8 +318,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     return RET_OSSL_OK;
 }
 
-static const OSSL_PARAM *p11prov_hkdf_settable_ctx_params(void *ctx,
-                                                          void *prov)
+static const OSSL_PARAM *p11prov_hkdf_settable_ctx_params(void *ctx, void *prov)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
@@ -349,8 +339,7 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
     OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("hkdf get ctx params (ctx=%p, params=%p)\n",
-                  hkdfctx, params);
+    p11prov_debug("hkdf get ctx params (ctx=%p, params=%p)\n", hkdfctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -360,8 +349,8 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
         if (hkdfctx->params.bExpand != CK_FALSE) {
             ret_size = SIZE_MAX;
         } else {
-            ret_size = p11prov_hkdf_map_digest_size(
-                            hkdfctx->params.prfHashMechanism);
+            ret_size =
+                p11prov_hkdf_map_digest_size(hkdfctx->params.prfHashMechanism);
         }
         if (ret_size != 0) {
             return OSSL_PARAM_set_size_t(p, ret_size);
@@ -373,8 +362,7 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
     return RET_OSSL_OK;
 }
 
-static const OSSL_PARAM *p11prov_hkdf_gettable_ctx_params(void *ctx,
-                                                          void *prov)
+static const OSSL_PARAM *p11prov_hkdf_gettable_ctx_params(void *ctx, void *prov)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -41,7 +41,7 @@ static struct {
     DM_ELEM_SHA(384),
     DM_ELEM_SHA(224),
     { "SHA1", CKM_SHA_1, 20 },
-    { NULL, 0, 0 }
+    { NULL, 0, 0 },
 };
 
 static CK_MECHANISM_TYPE p11prov_hkdf_map_digest(const char *digest)
@@ -139,7 +139,7 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
         {CKA_KEY_TYPE, &key_type, sizeof(key_type)},
         {CKA_SENSITIVE, &val_false, sizeof(val_false)},
         {CKA_EXTRACTABLE, &val_true, sizeof(val_true)},
-        {CKA_VALUE_LEN, &key_size, sizeof(key_size)}
+        {CKA_VALUE_LEN, &key_size, sizeof(key_size)},
     };
     CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
@@ -338,7 +338,7 @@ static const OSSL_PARAM *p11prov_hkdf_settable_ctx_params(void *ctx,
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_KEY, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0),
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -378,7 +378,7 @@ static const OSSL_PARAM *p11prov_hkdf_gettable_ctx_params(void *ctx,
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -392,5 +392,5 @@ const OSSL_DISPATCH p11prov_hkdf_kdf_functions[] = {
     DISPATCH_HKDF_ELEM(hkdf, SETTABLE_CTX_PARAMS, settable_ctx_params),
     DISPATCH_HKDF_ELEM(hkdf, GET_CTX_PARAMS, get_ctx_params),
     DISPATCH_HKDF_ELEM(hkdf, GETTABLE_CTX_PARAMS, gettable_ctx_params),
-    { 0, NULL }
+    { 0, NULL },
 };

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -31,8 +31,7 @@ static void *p11prov_rsakm_gen_init(void *provctx, int selection,
     return NULL;
 }
 
-static void *p11prov_rsakm_gen(void *genctx,
-                               OSSL_CALLBACK *cb_fn, void *cb_arg)
+static void *p11prov_rsakm_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     p11prov_debug("rsa gen %p %p %p\n", genctx, cb_fn, cb_arg);
     return NULL;
@@ -54,8 +53,7 @@ static void *p11prov_rsakm_load(const void *reference, size_t reference_sz)
 
     p11prov_debug("rsa load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj))
-        return NULL;
+    if (!reference || reference_sz != sizeof(obj)) return NULL;
 
     /* the contents of the reference is the address to our object */
     obj = (P11PROV_OBJECT *)reference;
@@ -233,7 +231,6 @@ static const OSSL_PARAM *p11prov_rsakm_gettable_params(void *provctx)
     return params;
 }
 
-
 const OSSL_DISPATCH p11prov_rsa_keymgmt_functions[] = {
     DISPATCH_RSAKM_ELEM(NEW, new),
     DISPATCH_RSAKM_ELEM(GEN_INIT, gen_init),
@@ -274,14 +271,13 @@ static void *p11prov_eckm_new(void *provctx)
 }
 
 static void *p11prov_eckm_gen_init(void *provctx, int selection,
-                                    const OSSL_PARAM params[])
+                                   const OSSL_PARAM params[])
 {
     p11prov_debug("ec gen_init\n");
     return NULL;
 }
 
-static void *p11prov_eckm_gen(void *genctx,
-                               OSSL_CALLBACK *cb_fn, void *cb_arg)
+static void *p11prov_eckm_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     p11prov_debug("ec gen %p %p %p\n", genctx, cb_fn, cb_arg);
     return NULL;
@@ -303,8 +299,7 @@ static void *p11prov_eckm_load(const void *reference, size_t reference_sz)
 
     p11prov_debug("ec load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj))
-        return NULL;
+    if (!reference || reference_sz != sizeof(obj)) return NULL;
 
     /* the contents of the reference is the address to our object */
     obj = (P11PROV_OBJECT *)reference;
@@ -332,14 +327,14 @@ static int p11prov_eckm_has(const void *keydata, int selection)
 }
 
 static int p11prov_eckm_import(void *keydata, int selection,
-                                const OSSL_PARAM params[])
+                               const OSSL_PARAM params[])
 {
     p11prov_debug("ec import %p\n", keydata);
     return 0;
 }
 
 static int p11prov_eckm_export(void *keydata, int selection,
-                                OSSL_CALLBACK *cb_fn, void *cb_arg)
+                               OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
 
@@ -353,7 +348,7 @@ static int p11prov_eckm_export(void *keydata, int selection,
 }
 
 static const OSSL_PARAM p11prov_eckm_key_types[] = {
-/*
+    /*
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
  */
@@ -514,8 +509,8 @@ static void p11prov_hkdfkm_free(void *kdfdata)
     p11prov_debug("hkdf keymgmt free %p\n", kdfdata);
 
     if (kdfdata != &p11prov_hkdfkm_static_ctx) {
-        p11prov_debug("Invalid HKDF Keymgmt context: %p != %p\n",
-                      kdfdata, &p11prov_hkdfkm_static_ctx);
+        p11prov_debug("Invalid HKDF Keymgmt context: %p != %p\n", kdfdata,
+                      &p11prov_hkdfkm_static_ctx);
     }
 }
 
@@ -535,8 +530,8 @@ static int p11prov_hkdfkm_has(const void *kdfdata, int selection)
 {
     p11prov_debug("hkdf keymgmt has\n");
     if (kdfdata != &p11prov_hkdfkm_static_ctx) {
-        p11prov_debug("Invalid HKDF Keymgmt context: %p != %p\n",
-                      kdfdata, &p11prov_hkdfkm_static_ctx);
+        p11prov_debug("Invalid HKDF Keymgmt context: %p != %p\n", kdfdata,
+                      &p11prov_hkdfkm_static_ctx);
         return RET_OSSL_ERR;
     }
     return RET_OSSL_OK;

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -108,7 +108,7 @@ static int p11prov_rsakm_export(void *keydata, int selection,
 static const OSSL_PARAM p11prov_rsakm_key_types[] = {
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
-    OSSL_PARAM_END
+    OSSL_PARAM_END,
 };
 
 static const OSSL_PARAM *p11prov_rsakm_import_types(int selection)
@@ -228,7 +228,7 @@ static const OSSL_PARAM *p11prov_rsakm_gettable_params(void *provctx)
         /* OSSL_PKEY_PARAM_DEFAULT_DIGEST,
          * OSSL_PKEY_PARAM_RSA_N,
          * OSSL_PKEY_PARAM_RSA_E, */
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -249,7 +249,7 @@ const OSSL_DISPATCH p11prov_rsa_keymgmt_functions[] = {
     DISPATCH_RSAKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
     DISPATCH_RSAKM_ELEM(GET_PARAMS, get_params),
     DISPATCH_RSAKM_ELEM(GETTABLE_PARAMS, gettable_params),
-    { 0, NULL }
+    { 0, NULL },
 };
 
 DISPATCH_ECKM_FN(new);
@@ -357,7 +357,7 @@ static const OSSL_PARAM p11prov_eckm_key_types[] = {
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
  */
-    OSSL_PARAM_END
+    OSSL_PARAM_END,
 };
 
 static const OSSL_PARAM *p11prov_eckm_import_types(int selection)
@@ -473,7 +473,7 @@ static const OSSL_PARAM *p11prov_eckm_gettable_params(void *provctx)
          * OSSL_PKEY_PARAM_EC_PUB_X
          * OSSL_PKEY_PARAM_EC_PUB_Y
          */
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -493,7 +493,7 @@ const OSSL_DISPATCH p11prov_ecdsa_keymgmt_functions[] = {
     DISPATCH_ECKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
     DISPATCH_ECKM_ELEM(GET_PARAMS, get_params),
     DISPATCH_ECKM_ELEM(GETTABLE_PARAMS, gettable_params),
-    { 0, NULL }
+    { 0, NULL },
 };
 
 DISPATCH_HKDFKM_FN(new);
@@ -547,5 +547,5 @@ const OSSL_DISPATCH p11prov_hkdf_keymgmt_functions[] = {
     DISPATCH_HKDFKM_ELEM(FREE, free),
     DISPATCH_HKDFKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
     DISPATCH_HKDFKM_ELEM(HAS, has),
-    { 0, NULL }
+    { 0, NULL },
 };

--- a/src/pkcs11.h
+++ b/src/pkcs11.h
@@ -6,8 +6,8 @@
 
 #define CK_PTR *
 #define CK_DECLARE_FUNCTION(returnType, name) returnType name
-#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType (* name)
-#define CK_CALLBACK_FUNCTION(returnType, name) returnType (* name)
+#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType(*name)
+#define CK_CALLBACK_FUNCTION(returnType, name) returnType(*name)
 #define NULL_PTR NULL
 
 /*

--- a/src/provider.c
+++ b/src/provider.c
@@ -125,9 +125,8 @@ void p11prov_get_core_dispatch_funcs(const OSSL_DISPATCH *in)
     }
 }
 
-void p11prov_raise(P11PROV_CTX *ctx,
-                   const char *file, int line, const char *func,
-                   int errnum, const char *fmt, ...)
+void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
+                   const char *func, int errnum, const char *fmt, ...)
 {
     va_list args;
 
@@ -189,56 +188,103 @@ static int p11prov_get_params(void *provctx, OSSL_PARAM params[])
 /* TODO: this needs to be made dynamic,
  * based on what the pkcs11 module supports */
 static const OSSL_ALGORITHM p11prov_keymgmt[] = {
-    { P11PROV_NAMES_RSA, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_rsa_keymgmt_functions, P11PROV_DESCS_RSA, },
-    { P11PROV_NAMES_ECDSA, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_ecdsa_keymgmt_functions, P11PROV_DESCS_ECDSA, },
-    { P11PROV_NAMES_HKDF, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_hkdf_keymgmt_functions, P11PROV_DESCS_HKDF, },
-    { "HKDF", P11PROV_DEFAULT_PROPERTIES,
-      p11prov_hkdf_keymgmt_functions, P11PROV_DESCS_HKDF, },
+    {
+        P11PROV_NAMES_RSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_rsa_keymgmt_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        P11PROV_NAMES_ECDSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_ecdsa_keymgmt_functions,
+        P11PROV_DESCS_ECDSA,
+    },
+    {
+        P11PROV_NAMES_HKDF,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_hkdf_keymgmt_functions,
+        P11PROV_DESCS_HKDF,
+    },
+    {
+        "HKDF",
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_hkdf_keymgmt_functions,
+        P11PROV_DESCS_HKDF,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_store[] = {
-    { "pkcs11", P11PROV_DEFAULT_PROPERTIES,
-      p11prov_store_functions, P11PROV_DESCS_URI, },
+    {
+        "pkcs11",
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_store_functions,
+        P11PROV_DESCS_URI,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_signature[] = {
-    { P11PROV_NAMES_RSA, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_rsa_signature_functions, P11PROV_DESCS_RSA, },
-    { P11PROV_NAMES_ECDSA, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_ecdsa_signature_functions, P11PROV_DESCS_ECDSA, },
+    {
+        P11PROV_NAMES_RSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_rsa_signature_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        P11PROV_NAMES_ECDSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_ecdsa_signature_functions,
+        P11PROV_DESCS_ECDSA,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_asym_cipher[] = {
-    { P11PROV_NAMES_RSA, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_rsa_asym_cipher_functions, P11PROV_DESCS_RSA, },
+    {
+        P11PROV_NAMES_RSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_rsa_asym_cipher_functions,
+        P11PROV_DESCS_RSA,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_exchange[] = {
-    { P11PROV_NAMES_ECDH, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_ecdh_exchange_functions, P11PROV_DESCS_ECDH, },
-    { P11PROV_NAMES_HKDF, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_hkdf_exchange_functions, P11PROV_DESCS_HKDF, },
+    {
+        P11PROV_NAMES_ECDH,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_ecdh_exchange_functions,
+        P11PROV_DESCS_ECDH,
+    },
+    {
+        P11PROV_NAMES_HKDF,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_hkdf_exchange_functions,
+        P11PROV_DESCS_HKDF,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_kdf[] = {
-    { P11PROV_NAMES_HKDF, P11PROV_DEFAULT_PROPERTIES,
-      p11prov_hkdf_kdf_functions, P11PROV_DESCS_HKDF, },
-    { "HKDF", P11PROV_DEFAULT_PROPERTIES,
-      p11prov_hkdf_kdf_functions, P11PROV_DESCS_HKDF, },
+    {
+        P11PROV_NAMES_HKDF,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_hkdf_kdf_functions,
+        P11PROV_DESCS_HKDF,
+    },
+    {
+        "HKDF",
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_hkdf_kdf_functions,
+        P11PROV_DESCS_HKDF,
+    },
     { NULL, NULL, NULL, NULL },
 };
 
-static const OSSL_ALGORITHM *p11prov_query_operation(void *provctx,
-                                                     int operation_id,
-                                                     int *no_cache)
+static const OSSL_ALGORITHM *
+p11prov_query_operation(void *provctx, int operation_id, int *no_cache)
 {
     *no_cache = 0;
     switch (operation_id) {
@@ -273,52 +319,51 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_SLOT_ID_INVALID, "The specified slot ID is not valid" },
         { CKR_GENERAL_ERROR, "General Error" },
         { CKR_FUNCTION_FAILED,
-            "The requested function could not be performed" },
+          "The requested function could not be performed" },
         { CKR_ARGUMENTS_BAD,
-            "Invalid or improper arguments were provided to the "
-            "invoked function" },
+          "Invalid or improper arguments were provided to the "
+          "invoked function" },
         { CKR_ATTRIBUTE_READ_ONLY,
-            "Attempted to set or modify an attribute that is Read "
-            "Only for applications" },
+          "Attempted to set or modify an attribute that is Read "
+          "Only for applications" },
         { CKR_ATTRIBUTE_TYPE_INVALID,
-            "Invalid attribute type specified in a template" },
+          "Invalid attribute type specified in a template" },
         { CKR_ATTRIBUTE_VALUE_INVALID,
-            "Invalid value specified for attribute in a template" },
+          "Invalid value specified for attribute in a template" },
         { CKR_DATA_INVALID,
-            "The plaintext input data to a cryptographic "
-            "operation is invalid" },
+          "The plaintext input data to a cryptographic "
+          "operation is invalid" },
         { CKR_DATA_LEN_RANGE,
-            "The size of plaintext input data to a cryptographic "
-            "operation is invalid (Out of range)" },
+          "The size of plaintext input data to a cryptographic "
+          "operation is invalid (Out of range)" },
         { CKR_DEVICE_ERROR,
-            "Some problem has occurred with the token and/or slot" },
+          "Some problem has occurred with the token and/or slot" },
         { CKR_DEVICE_MEMORY,
-            "The token does not have sufficient memory to perform "
-            "the requested function" },
+          "The token does not have sufficient memory to perform "
+          "the requested function" },
         { CKR_DEVICE_REMOVED,
-            "The token was removed from its slot during the "
-            "execution of the function" },
-        { CKR_FUNCTION_CANCELED,
-            "The function was canceled in mid-execution" },
+          "The token was removed from its slot during the "
+          "execution of the function" },
+        { CKR_FUNCTION_CANCELED, "The function was canceled in mid-execution" },
         { CKR_KEY_HANDLE_INVALID, "The specified key handle is not valid" },
         { CKR_KEY_SIZE_RANGE,
-            "Unable to handle the specified key size (Out of range)" },
+          "Unable to handle the specified key size (Out of range)" },
         { CKR_KEY_TYPE_INCONSISTENT,
-            "The specified key is not the correct type of key to "
-            "use with the specified mechanism" },
+          "The specified key is not the correct type of key to "
+          "use with the specified mechanism" },
         { CKR_KEY_FUNCTION_NOT_PERMITTED,
-            "The key attributes do not allow this operation to be executed" },
+          "The key attributes do not allow this operation to be executed" },
         { CKR_MECHANISM_INVALID,
-            "An invalid mechanism was specified to the "
-            "cryptographic operation" },
+          "An invalid mechanism was specified to the "
+          "cryptographic operation" },
         { CKR_MECHANISM_PARAM_INVALID,
-            "Invalid mechanism parameters were supplied" },
+          "Invalid mechanism parameters were supplied" },
         { CKR_OPERATION_ACTIVE,
-            "There is already an active operation that prevents "
-            "executing the requested function" },
+          "There is already an active operation that prevents "
+          "executing the requested function" },
         { CKR_OPERATION_NOT_INITIALIZED,
-            "There is no active operation of appropriate type "
-            "in the specified session" },
+          "There is no active operation of appropriate type "
+          "in the specified session" },
         { CKR_PIN_INCORRECT, "The specified PIN is incorrect" },
         { CKR_PIN_EXPIRED, "The specified PIN has expired" },
         { CKR_PIN_LOCKED, "The specified PIN is locked, and cannot be used" },
@@ -326,51 +371,49 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_SESSION_COUNT, "Too many sessions open" },
         { CKR_SESSION_HANDLE_INVALID, "Invalid Session Handle" },
         { CKR_SESSION_PARALLEL_NOT_SUPPORTED,
-            "Parallel sessions not supported" },
+          "Parallel sessions not supported" },
         { CKR_SESSION_READ_ONLY, "Session is Read Only" },
         { CKR_SESSION_EXISTS, "Session already exists" },
-        { CKR_SESSION_READ_ONLY_EXISTS,
-            "A read-only session already exists" },
+        { CKR_SESSION_READ_ONLY_EXISTS, "A read-only session already exists" },
         { CKR_SESSION_READ_WRITE_SO_EXISTS,
-            "A read/write SO session already exists" },
+          "A read/write SO session already exists" },
         { CKR_TEMPLATE_INCOMPLETE,
-            "The template to create an object is incomplete" },
+          "The template to create an object is incomplete" },
         { CKR_TEMPLATE_INCONSISTENT,
-            "The template to create an object has conflicting attributes" },
+          "The template to create an object has conflicting attributes" },
         { CKR_TOKEN_NOT_PRESENT,
-            "The token was not present in its slot when the "
-            "function was invoked" },
-        { CKR_TOKEN_NOT_RECOGNIZED,
-            "The token in the slot is not recognized" },
+          "The token was not present in its slot when the "
+          "function was invoked" },
+        { CKR_TOKEN_NOT_RECOGNIZED, "The token in the slot is not recognized" },
         { CKR_TOKEN_WRITE_PROTECTED,
-            "Action denied because the token is write-protected" },
+          "Action denied because the token is write-protected" },
         { CKR_TOKEN_WRITE_PROTECTED,
-            "Can't perform action because the token is write-protected" },
+          "Can't perform action because the token is write-protected" },
         { CKR_USER_NOT_LOGGED_IN,
-            "The desired action cannot be performed because an "
-            "appropriate user is not logged in" },
+          "The desired action cannot be performed because an "
+          "appropriate user is not logged in" },
         { CKR_USER_PIN_NOT_INITIALIZED, "The user PIN is not initialized" },
         { CKR_USER_TYPE_INVALID, "An invalid user type was specified" },
         { CKR_USER_ANOTHER_ALREADY_LOGGED_IN,
-            "Another user is already logged in" },
+          "Another user is already logged in" },
         { CKR_USER_TOO_MANY_TYPES,
-            "Attempted to log in more users than the token can support" },
+          "Attempted to log in more users than the token can support" },
         { CKR_OPERATION_CANCEL_FAILED, "The operation cannot be cancelled" },
         { CKR_DOMAIN_PARAMS_INVALID,
-            "Invalid or unsupported domain parameters were "
-            "supplied to the function" },
+          "Invalid or unsupported domain parameters were "
+          "supplied to the function" },
         { CKR_CURVE_NOT_SUPPORTED,
-            "The specified curve is not supported by this token" },
+          "The specified curve is not supported by this token" },
         { CKR_BUFFER_TOO_SMALL,
-            "The output of the function is too large to fit in "
-            "the supplied buffer" },
+          "The output of the function is too large to fit in "
+          "the supplied buffer" },
         { CKR_SAVED_STATE_INVALID,
-            "The supplied saved cryptographic operations state is invalid" },
+          "The supplied saved cryptographic operations state is invalid" },
         { CKR_STATE_UNSAVEABLE,
-            "The cryptographic operations state of the specified "
-            "session cannot be saved" },
+          "The cryptographic operations state of the specified "
+          "session cannot be saved" },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
-            "PKCS11 Module has not been intialized yet" },
+          "PKCS11 Module has not been intialized yet" },
         { 0, NULL },
     };
 
@@ -379,12 +422,10 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH p11prov_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_TEARDOWN,
-      (void (*)(void))p11prov_teardown },
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p11prov_teardown },
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS,
       (void (*)(void))p11prov_gettable_params },
-    { OSSL_FUNC_PROVIDER_GET_PARAMS,
-      (void (*)(void))p11prov_get_params },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p11prov_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION,
       (void (*)(void))p11prov_query_operation },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
@@ -439,8 +480,7 @@ static int refresh_slot_profiles(P11PROV_CTX *ctx, struct p11prov_slot *slot)
         CK_ULONG value = CK_UNAVAILABLE_INFORMATION;
         CK_ATTRIBUTE profileid = { CKA_PROFILE_ID, &value, sizeof(value) };
 
-        ret = ctx->fns->C_GetAttributeValue(session, object[i],
-                                            &profileid, 1);
+        ret = ctx->fns->C_GetAttributeValue(session, object[i], &profileid, 1);
         if (ret != CKR_OK || value == CK_UNAVAILABLE_INFORMATION) {
             p11prov_debug("C_GetAttributeValue failed %d\n", ret);
             continue;
@@ -483,7 +523,6 @@ static int refresh_slots(P11PROV_CTX *ctx)
         ret = -ENOMEM;
         goto done;
     }
-
 
     ret = ctx->fns->C_GetSlotList(CK_FALSE, slotid, &nslots);
     if (ret) {
@@ -548,8 +587,7 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     p11prov_debug("PKCS#11: Initializing the module: %s\n", ctx->module);
 
     dlerror();
-    ctx->dlhandle = dlopen(ctx->module,
-                           RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
+    ctx->dlhandle = dlopen(ctx->module, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
     if (ctx->dlhandle == NULL) {
         char *err = dlerror();
         p11prov_debug("dlopen() failed: %s\n", err);
@@ -559,7 +597,8 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     c_get_function_list = dlsym(ctx->dlhandle, "C_GetFunctionList");
     if (c_get_function_list) {
         ret = c_get_function_list(&ctx->fns);
-    } else ret = CKR_GENERAL_ERROR;
+    } else
+        ret = CKR_GENERAL_ERROR;
     if (ret != CKR_OK) {
         char *err = dlerror();
         p11prov_debug("dlsym() failed: %s\n", err);
@@ -580,10 +619,8 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     }
     p11prov_debug("Module Info: ck_ver:%d.%d lib: '%s' '%s' ver:%d.%d\n",
                   (int)ck_info.cryptokiVersion.major,
-                  (int)ck_info.cryptokiVersion.minor,
-                  ck_info.manufacturerID,
-                  ck_info.libraryDescription,
-                  (int)ck_info.libraryVersion.major,
+                  (int)ck_info.cryptokiVersion.minor, ck_info.manufacturerID,
+                  ck_info.libraryDescription, (int)ck_info.libraryVersion.major,
                   (int)ck_info.libraryVersion.minor);
 
     ret = refresh_slots(ctx);
@@ -595,10 +632,8 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     return 0;
 }
 
-int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
-                       const OSSL_DISPATCH *in,
-                       const OSSL_DISPATCH **out,
-                       void **provctx)
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
+                       const OSSL_DISPATCH **out, void **provctx)
 {
     OSSL_PARAM core_params[3] = { 0 };
     P11PROV_CTX *ctx;
@@ -622,13 +657,10 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     /* get module path */
     core_params[0] = OSSL_PARAM_construct_utf8_ptr(
-                        P11PROV_PKCS11_MODULE_PATH,
-                        (char **)&ctx->module,
-                        sizeof(ctx->module));
+        P11PROV_PKCS11_MODULE_PATH, (char **)&ctx->module, sizeof(ctx->module));
     core_params[1] = OSSL_PARAM_construct_utf8_ptr(
-                        P11PROV_PKCS11_MODULE_INIT_ARGS,
-                        (char **)&ctx->init_args,
-                        sizeof(ctx->init_args));
+        P11PROV_PKCS11_MODULE_INIT_ARGS, (char **)&ctx->init_args,
+        sizeof(ctx->init_args));
     core_params[2] = OSSL_PARAM_construct_end();
     ret = core_get_params(handle, core_params);
     if (ret != RET_OSSL_OK) {

--- a/src/provider.c
+++ b/src/provider.c
@@ -146,7 +146,7 @@ static const OSSL_PARAM p11prov_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_STATUS, OSSL_PARAM_INTEGER, NULL, 0),
-    OSSL_PARAM_END
+    OSSL_PARAM_END,
 };
 
 static const OSSL_PARAM *p11prov_gettable_params(void *provctx)
@@ -197,13 +197,13 @@ static const OSSL_ALGORITHM p11prov_keymgmt[] = {
       p11prov_hkdf_keymgmt_functions, P11PROV_DESCS_HKDF, },
     { "HKDF", P11PROV_DEFAULT_PROPERTIES,
       p11prov_hkdf_keymgmt_functions, P11PROV_DESCS_HKDF, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_store[] = {
     { "pkcs11", P11PROV_DEFAULT_PROPERTIES,
       p11prov_store_functions, P11PROV_DESCS_URI, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_signature[] = {
@@ -211,13 +211,13 @@ static const OSSL_ALGORITHM p11prov_signature[] = {
       p11prov_rsa_signature_functions, P11PROV_DESCS_RSA, },
     { P11PROV_NAMES_ECDSA, P11PROV_DEFAULT_PROPERTIES,
       p11prov_ecdsa_signature_functions, P11PROV_DESCS_ECDSA, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_asym_cipher[] = {
     { P11PROV_NAMES_RSA, P11PROV_DEFAULT_PROPERTIES,
       p11prov_rsa_asym_cipher_functions, P11PROV_DESCS_RSA, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_exchange[] = {
@@ -225,7 +225,7 @@ static const OSSL_ALGORITHM p11prov_exchange[] = {
       p11prov_ecdh_exchange_functions, P11PROV_DESCS_ECDH, },
     { P11PROV_NAMES_HKDF, P11PROV_DEFAULT_PROPERTIES,
       p11prov_hkdf_exchange_functions, P11PROV_DESCS_HKDF, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM p11prov_kdf[] = {
@@ -233,7 +233,7 @@ static const OSSL_ALGORITHM p11prov_kdf[] = {
       p11prov_hkdf_kdf_functions, P11PROV_DESCS_HKDF, },
     { "HKDF", P11PROV_DEFAULT_PROPERTIES,
       p11prov_hkdf_kdf_functions, P11PROV_DESCS_HKDF, },
-    { NULL, NULL, NULL, NULL }
+    { NULL, NULL, NULL, NULL },
 };
 
 static const OSSL_ALGORITHM *p11prov_query_operation(void *provctx,
@@ -371,7 +371,7 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
             "session cannot be saved" },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
             "PKCS11 Module has not been intialized yet" },
-        { 0, NULL }
+        { 0, NULL },
     };
 
     return reason_strings;
@@ -391,7 +391,7 @@ static const OSSL_DISPATCH p11prov_dispatch_table[] = {
       (void (*)(void))p11prov_get_capabilities },
     { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
       (void (*)(void))p11prov_get_reason_strings },
-    { 0, NULL }
+    { 0, NULL },
 };
 
 static int refresh_slot_profiles(P11PROV_CTX *ctx, struct p11prov_slot *slot)

--- a/src/provider.h
+++ b/src/provider.h
@@ -18,7 +18,7 @@
 #include <openssl/proverr.h>
 #include <openssl/core_names.h>
 
-#define UNUSED  __attribute__((unused))
+#define UNUSED __attribute__((unused))
 #define RET_OSSL_OK 1
 #define RET_OSSL_ERR 0
 #define RET_OSSL_BAD -1
@@ -53,18 +53,16 @@ int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 
 /* Errors */
-void p11prov_raise(P11PROV_CTX *ctx,
-                   const char *file, int line, const char *func,
-                   int errnum, const char *fmt, ...);
+void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
+                   const char *func, int errnum, const char *fmt, ...);
 
 #define P11PROV_raise(ctx, errnum, ...) \
-do { \
-    p11prov_raise((ctx), OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC, \
-                  (errnum), __VA_ARGS__); \
-    if (errnum) \
-        p11prov_debug("Error: %lu", (unsigned long)(errnum)); \
-    p11prov_debug(__VA_ARGS__); \
-} while(0)
+    do { \
+        p11prov_raise((ctx), OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC, \
+                      (errnum), __VA_ARGS__); \
+        if (errnum) p11prov_debug("Error: %lu", (unsigned long)(errnum)); \
+        p11prov_debug(__VA_ARGS__); \
+    } while (0)
 
 /* Debugging */
 void p11prov_debug(const char *fmt, ...);
@@ -84,15 +82,12 @@ CK_SLOT_ID p11prov_key_slotid(P11PROV_KEY *key);
 CK_OBJECT_HANDLE p11prov_key_handle(P11PROV_KEY *key);
 CK_ULONG p11prov_key_size(P11PROV_KEY *key);
 
-int find_keys(P11PROV_CTX *provctx,
-              P11PROV_KEY **priv, P11PROV_KEY **pub,
-              CK_SLOT_ID slotid, CK_OBJECT_CLASS class,
-              const unsigned char *id, size_t id_len,
-              const char *label);
+int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
+              CK_SLOT_ID slotid, CK_OBJECT_CLASS class, const unsigned char *id,
+              size_t id_len, const char *label);
 P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        CK_SESSION_HANDLE session,
-                                       bool session_key,
-                                       unsigned char *secret,
+                                       bool session_key, unsigned char *secret,
                                        size_t secretlen);
 
 /* Object Store */
@@ -104,43 +99,48 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
                                          OSSL_CALLBACK *cb_fn, void *cb_arg);
 P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJECT *obj, bool priv);
 
-
 /* dispatching */
 #define DECL_DISPATCH_FUNC(type, prefix, name) \
     static OSSL_FUNC_##type##_##name##_fn prefix##_##name
 
 /* rsa keymgmt */
-#define DISPATCH_RSAKM_FN(name) \
-    DECL_DISPATCH_FUNC(keymgmt, p11prov_rsakm, name)
+#define DISPATCH_RSAKM_FN(name) DECL_DISPATCH_FUNC(keymgmt, p11prov_rsakm, name)
 #define DISPATCH_RSAKM_ELEM(NAME, name) \
-    { OSSL_FUNC_KEYMGMT_##NAME, (void(*)(void))p11prov_rsakm_##name }
+    { \
+        OSSL_FUNC_KEYMGMT_##NAME, (void (*)(void))p11prov_rsakm_##name \
+    }
 extern const OSSL_DISPATCH p11prov_rsa_keymgmt_functions[];
 
 /* ecdsa keymgmt */
-#define DISPATCH_ECKM_FN(name) \
-    DECL_DISPATCH_FUNC(keymgmt, p11prov_eckm, name)
+#define DISPATCH_ECKM_FN(name) DECL_DISPATCH_FUNC(keymgmt, p11prov_eckm, name)
 #define DISPATCH_ECKM_ELEM(NAME, name) \
-    { OSSL_FUNC_KEYMGMT_##NAME, (void(*)(void))p11prov_eckm_##name }
+    { \
+        OSSL_FUNC_KEYMGMT_##NAME, (void (*)(void))p11prov_eckm_##name \
+    }
 extern const OSSL_DISPATCH p11prov_ecdsa_keymgmt_functions[];
 
 /* hkdf keymgmt */
 #define DISPATCH_HKDFKM_FN(name) \
     DECL_DISPATCH_FUNC(keymgmt, p11prov_hkdfkm, name)
 #define DISPATCH_HKDFKM_ELEM(NAME, name) \
-    { OSSL_FUNC_KEYMGMT_##NAME, (void(*)(void))p11prov_hkdfkm_##name }
+    { \
+        OSSL_FUNC_KEYMGMT_##NAME, (void (*)(void))p11prov_hkdfkm_##name \
+    }
 extern const OSSL_DISPATCH p11prov_hkdf_keymgmt_functions[];
 
-#define DISPATCH_STORE_FN(name) \
-    DECL_DISPATCH_FUNC(store, p11prov_store, name)
+#define DISPATCH_STORE_FN(name) DECL_DISPATCH_FUNC(store, p11prov_store, name)
 #define DISPATCH_STORE_ELEM(NAME, name) \
-    { OSSL_FUNC_STORE_##NAME, (void(*)(void))p11prov_store_##name }
+    { \
+        OSSL_FUNC_STORE_##NAME, (void (*)(void))p11prov_store_##name \
+    }
 extern const OSSL_DISPATCH p11prov_store_functions[];
 
 /* common sig functions */
-#define DISPATCH_SIG_FN(name) \
-    DECL_DISPATCH_FUNC(signature, p11prov_sig, name)
+#define DISPATCH_SIG_FN(name) DECL_DISPATCH_FUNC(signature, p11prov_sig, name)
 #define DISPATCH_SIG_ELEM(prefix, NAME, name) \
-    { OSSL_FUNC_SIGNATURE_##NAME, (void(*)(void))p11prov_##prefix##_##name }
+    { \
+        OSSL_FUNC_SIGNATURE_##NAME, (void (*)(void))p11prov_##prefix##_##name \
+    }
 
 /* rsa sig functions */
 #define DISPATCH_RSASIG_FN(name) \
@@ -156,29 +156,34 @@ extern const OSSL_DISPATCH p11prov_ecdsa_signature_functions[];
 #define DISPATCH_RSAENC_FN(name) \
     DECL_DISPATCH_FUNC(asym_cipher, p11prov_rsaenc, name)
 #define DISPATCH_RSAENC_ELEM(NAME, name) \
-    { OSSL_FUNC_ASYM_CIPHER_##NAME, (void(*)(void))p11prov_rsaenc_##name }
+    { \
+        OSSL_FUNC_ASYM_CIPHER_##NAME, (void (*)(void))p11prov_rsaenc_##name \
+    }
 extern const OSSL_DISPATCH p11prov_rsa_asym_cipher_functions[];
 
 /* ecdh derivation */
-#define DISPATCH_ECDH_FN(name) \
-    DECL_DISPATCH_FUNC(keyexch, p11prov_ecdh, name)
+#define DISPATCH_ECDH_FN(name) DECL_DISPATCH_FUNC(keyexch, p11prov_ecdh, name)
 #define DISPATCH_ECDH_ELEM(prefix, NAME, name) \
-    { OSSL_FUNC_KEYEXCH_##NAME, (void(*)(void))p11prov_##prefix##_##name }
+    { \
+        OSSL_FUNC_KEYEXCH_##NAME, (void (*)(void))p11prov_##prefix##_##name \
+    }
 extern const OSSL_DISPATCH p11prov_ecdh_exchange_functions[];
 
 /* HKDF exchange and kdf fns */
 #define DISPATCH_EXCHHKDF_FN(name) \
     DECL_DISPATCH_FUNC(keyexch, p11prov_exch_hkdf, name)
 #define DISPATCH_EXCHHKDF_ELEM(prefix, NAME, name) \
-    { OSSL_FUNC_KEYEXCH_##NAME, (void(*)(void))p11prov_##prefix##_##name }
+    { \
+        OSSL_FUNC_KEYEXCH_##NAME, (void (*)(void))p11prov_##prefix##_##name \
+    }
 extern const OSSL_DISPATCH p11prov_hkdf_exchange_functions[];
-#define DISPATCH_HKDF_FN(name) \
-    DECL_DISPATCH_FUNC(kdf, p11prov_hkdf, name)
+#define DISPATCH_HKDF_FN(name) DECL_DISPATCH_FUNC(kdf, p11prov_hkdf, name)
 #define DISPATCH_HKDF_ELEM(prefix, NAME, name) \
-    { OSSL_FUNC_KDF_##NAME, (void(*)(void))p11prov_##prefix##_##name }
+    { \
+        OSSL_FUNC_KDF_##NAME, (void (*)(void))p11prov_##prefix##_##name \
+    }
 extern const void *p11prov_hkdfkm_static_ctx;
 extern const OSSL_DISPATCH p11prov_hkdf_kdf_functions[];
-
 
 /* Utilities to fetch objects from tokens */
 
@@ -196,13 +201,13 @@ struct fetch_attrs {
         x.value_len = _c; \
         x.allocate = _d; \
         x.required = _e; \
-    } while(0)
+    } while (0)
 
 #define FA_RETURN_VAL(x, _a, _b) \
     do { \
         *x.value = _a; \
         *x.value_len = _b; \
-    } while(0)
+    } while (0)
 
 #define FA_RETURN_LEN(x, _a) *x.value_len = _a
 
@@ -211,15 +216,12 @@ struct fetch_attrs {
         x.type = _a; \
         x.pValue = (void *)_b; \
         x.ulValueLen = _c; \
-    } while(0)
+    } while (0)
 
-int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
-                             CK_SESSION_HANDLE session,
-                             CK_OBJECT_HANDLE object,
-                             struct fetch_attrs *attrs,
+int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
+                             CK_OBJECT_HANDLE object, struct fetch_attrs *attrs,
                              unsigned long attrnums);
 
-CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx,
-                                      CK_SLOT_ID slotid);
+CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid);
 void p11prov_put_session(P11PROV_CTX *provctx, CK_SESSION_HANDLE session);
 #endif /* _PROVIDER_H */

--- a/src/signature.c
+++ b/src/signature.c
@@ -205,7 +205,7 @@ static struct {
     { "SHA1", CKM_SHA_1, CKM_SHA1_RSA_PKCS,
        CKM_SHA1_RSA_PKCS_PSS, CKM_ECDSA_SHA1,
        CKG_MGF1_SHA1, 20 },
-    { NULL, 0, 0, 0, 0, 0, 0 }
+    { NULL, 0, 0, 0, 0, 0, 0 },
 };
 
 static const char *p11prov_sig_digest_name(CK_MECHANISM_TYPE digest)
@@ -795,7 +795,7 @@ static struct {
     { CKM_RSA_PKCS, RSA_PKCS1_PADDING, OSSL_PKEY_RSA_PAD_MODE_PKCSV15 },
     { CKM_RSA_X9_31, RSA_X931_PADDING, OSSL_PKEY_RSA_PAD_MODE_X931 },
     { CKM_RSA_PKCS_PSS, RSA_PKCS1_PSS_PADDING, OSSL_PKEY_RSA_PAD_MODE_PSS },
-    { CK_UNAVAILABLE_INFORMATION, 0, NULL }
+    { CK_UNAVAILABLE_INFORMATION, 0, NULL },
 };
 
 static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
@@ -973,7 +973,7 @@ static const OSSL_PARAM *p11prov_rsasig_gettable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -987,7 +987,7 @@ static const OSSL_PARAM *p11prov_rsasig_settable_ctx_params(void *ctx,
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -1010,7 +1010,7 @@ const OSSL_DISPATCH p11prov_rsa_signature_functions[] = {
     DISPATCH_SIG_ELEM(rsasig, GETTABLE_CTX_PARAMS, gettable_ctx_params),
     DISPATCH_SIG_ELEM(rsasig, SET_CTX_PARAMS, set_ctx_params),
     DISPATCH_SIG_ELEM(rsasig, SETTABLE_CTX_PARAMS, settable_ctx_params),
-    { 0, NULL }
+    { 0, NULL },
 };
 
 DISPATCH_ECDSA_FN(newctx);
@@ -1239,7 +1239,7 @@ static const OSSL_PARAM *p11prov_ecdsa_gettable_ctx_params(void *ctx,
         OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
          */
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -1249,7 +1249,7 @@ static const OSSL_PARAM *p11prov_ecdsa_settable_ctx_params(void *ctx,
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return params;
 }
@@ -1273,5 +1273,5 @@ const OSSL_DISPATCH p11prov_ecdsa_signature_functions[] = {
     DISPATCH_SIG_ELEM(ecdsa, GETTABLE_CTX_PARAMS, gettable_ctx_params),
     DISPATCH_SIG_ELEM(ecdsa, SET_CTX_PARAMS, set_ctx_params),
     DISPATCH_SIG_ELEM(ecdsa, SETTABLE_CTX_PARAMS, settable_ctx_params),
-    { 0, NULL }
+    { 0, NULL },
 };

--- a/src/signature.c
+++ b/src/signature.c
@@ -77,8 +77,7 @@ static void *p11prov_sig_dupctx(void *ctx)
     newctx->digest = sigctx->digest;
     newctx->pss_params = sigctx->pss_params;
 
-    if (sigctx->session == CK_INVALID_HANDLE)
-        goto done;
+    if (sigctx->session == CK_INVALID_HANDLE) goto done;
 
     /* This is not really funny. OpenSSL by dfault asume contexts with
      * operations in flight can be easily duplicated, with all the
@@ -103,8 +102,7 @@ static void *p11prov_sig_dupctx(void *ctx)
         return NULL;
     }
 
-    if (slotid != CK_UNAVAILABLE_INFORMATION &&
-        handle != CK_INVALID_HANDLE) {
+    if (slotid != CK_UNAVAILABLE_INFORMATION && handle != CK_INVALID_HANDLE) {
 
         ret = f->C_GetOperationState(newctx->session, NULL_PTR, &state_len);
         if (ret != CKR_OK) {
@@ -127,8 +125,8 @@ static void *p11prov_sig_dupctx(void *ctx)
         ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL,
                                &sigctx->session);
         if (ret != CKR_OK) {
-        P11PROV_raise(sigctx->provctx, ret,
-                      "Failed to open session on slot %lu", slotid);
+            P11PROV_raise(sigctx->provctx, ret,
+                          "Failed to open session on slot %lu", slotid);
             goto done;
         }
         ret = f->C_SetOperationState(sigctx->session, state, state_len,
@@ -169,21 +167,21 @@ static void p11prov_sig_freectx(void *ctx)
 }
 
 #define DM_ELEM_SHA(bits) \
-  { .name = "SHA"#bits, \
-    .digest = CKM_SHA##bits, \
-    .pkcs_mech = CKM_SHA##bits##_RSA_PKCS, \
-    .pkcs_pss = CKM_SHA##bits##_RSA_PKCS_PSS, \
-    .ecdsa_mech = CKM_ECDSA_SHA##bits, \
-    .mgf = CKG_MGF1_SHA##bits, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA" #bits, .digest = CKM_SHA##bits, \
+        .pkcs_mech = CKM_SHA##bits##_RSA_PKCS, \
+        .pkcs_pss = CKM_SHA##bits##_RSA_PKCS_PSS, \
+        .ecdsa_mech = CKM_ECDSA_SHA##bits, .mgf = CKG_MGF1_SHA##bits, \
+        .digest_size = bits / 8 \
+    }
 #define DM_ELEM_SHA3(bits) \
-  { .name = "SHA3-"#bits, \
-    .digest = CKM_SHA3_##bits, \
-    .pkcs_mech = CKM_SHA3_##bits##_RSA_PKCS, \
-    .pkcs_pss = CKM_SHA3_##bits##_RSA_PKCS_PSS, \
-    .ecdsa_mech = CKM_ECDSA_SHA3_##bits, \
-    .mgf = CKG_MGF1_SHA3_##bits, \
-    .digest_size = bits / 8 }
+    { \
+        .name = "SHA3-" #bits, .digest = CKM_SHA3_##bits, \
+        .pkcs_mech = CKM_SHA3_##bits##_RSA_PKCS, \
+        .pkcs_pss = CKM_SHA3_##bits##_RSA_PKCS_PSS, \
+        .ecdsa_mech = CKM_ECDSA_SHA3_##bits, .mgf = CKG_MGF1_SHA3_##bits, \
+        .digest_size = bits / 8 \
+    }
 /* only the ones we can support */
 static struct {
     const char *name;
@@ -202,9 +200,8 @@ static struct {
     DM_ELEM_SHA(512),
     DM_ELEM_SHA(384),
     DM_ELEM_SHA(224),
-    { "SHA1", CKM_SHA_1, CKM_SHA1_RSA_PKCS,
-       CKM_SHA1_RSA_PKCS_PSS, CKM_ECDSA_SHA1,
-       CKG_MGF1_SHA1, 20 },
+    { "SHA1", CKM_SHA_1, CKM_SHA1_RSA_PKCS, CKM_SHA1_RSA_PKCS_PSS,
+      CKM_ECDSA_SHA1, CKG_MGF1_SHA1, 20 },
     { NULL, 0, 0, 0, 0, 0, 0 },
 };
 
@@ -228,7 +225,7 @@ static const char *p11prov_sig_mgf_name(CK_RSA_PKCS_MGF_TYPE mgf)
     return "";
 }
 
-static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char*digest)
+static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
@@ -239,7 +236,7 @@ static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char*digest)
     return CK_UNAVAILABLE_INFORMATION;
 }
 
-static CK_MECHANISM_TYPE p11prov_sig_map_digest(const char*digest)
+static CK_MECHANISM_TYPE p11prov_sig_map_digest(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
@@ -258,7 +255,7 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
 
     mechanism->mechanism = sigctx->mechtype;
     mechanism->pParameter = NULL;
-    mechanism->ulParameterLen  = 0;
+    mechanism->ulParameterLen = 0;
 
     if (sigctx->mechtype == CKM_RSA_PKCS_PSS) {
         mechanism->pParameter = &sigctx->pss_params;
@@ -312,7 +309,7 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
     return result;
 }
 
-#define ANYKEY(ctx) (ctx->pub_key?ctx->pub_key:ctx->priv_key)
+#define ANYKEY(ctx) (ctx->pub_key ? ctx->pub_key : ctx->priv_key)
 
 static int p11prov_sig_get_sig_size(void *ctx, size_t *siglen)
 {
@@ -342,7 +339,7 @@ static int p11prov_rsasig_set_pss_saltlen_from_digest(void *ctx)
 
     if (sigctx->digest == 0) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED,
-               "Can only be set if Digest was set first.");
+                       "Can only be set if Digest was set first.");
         return RET_OSSL_ERR;
     }
     for (int i = 0; digest_map[i].name != NULL; i++) {
@@ -354,10 +351,8 @@ static int p11prov_rsasig_set_pss_saltlen_from_digest(void *ctx)
     return RET_OSSL_ERR;
 }
 
-static int p11prov_sig_op_init(void *ctx, void *provkey,
-                               CK_FLAGS operation,
-                               const char *digest,
-                               const OSSL_PARAM params[])
+static int p11prov_sig_op_init(void *ctx, void *provkey, CK_FLAGS operation,
+                               const char *digest, const OSSL_PARAM params[])
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
@@ -379,8 +374,7 @@ static int p11prov_sig_op_init(void *ctx, void *provkey,
     return RET_OSSL_OK;
 }
 
-static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx,
-                                    bool digest_op,
+static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx, bool digest_op,
                                     CK_SESSION_HANDLE *_session)
 {
     CK_FUNCTION_LIST *f;
@@ -431,8 +425,7 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx,
     if (sigctx->operation == CKF_SIGN) {
         ret = f->C_SignInit(session, &mechanism, handle);
         if (ret != CKR_OK) {
-            P11PROV_raise(sigctx->provctx, ret,
-                          "Error returned by C_SignInit");
+            P11PROV_raise(sigctx->provctx, ret, "Error returned by C_SignInit");
         }
     } else {
         ret = f->C_VerifyInit(session, &mechanism, handle);
@@ -443,15 +436,14 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx,
     }
     if (ret != CKR_OK) {
         int result = ret;
-        if (ret == CKR_MECHANISM_INVALID ||
-            ret == CKR_MECHANISM_PARAM_INVALID) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+        if (ret == CKR_MECHANISM_INVALID
+            || ret == CKR_MECHANISM_PARAM_INVALID) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
         }
         ret = f->C_CloseSession(session);
         if (ret != CKR_OK) {
-            P11PROV_raise(sigctx->provctx, ret,
-                          "Failed to close session %lu", session);
+            P11PROV_raise(sigctx->provctx, ret, "Failed to close session %lu",
+                          session);
         }
         return result;
     }
@@ -460,9 +452,8 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx,
     return CKR_OK;
 }
 
-static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx,
-                               unsigned char *sig, size_t *siglen,
-                               size_t sigsize,
+static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
+                               size_t *siglen, size_t sigsize,
                                unsigned char *tbs, size_t tbslen)
 {
     CK_FUNCTION_LIST *f;
@@ -476,8 +467,7 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx,
         return p11prov_sig_get_sig_size(sigctx, siglen);
     }
 
-    if (sigctx->operation == CKF_SIGN &&
-        sigctx->mechtype == CKM_RSA_X_509) {
+    if (sigctx->operation == CKF_SIGN && sigctx->mechtype == CKM_RSA_X_509) {
         /* some tokens allow raw signatures on any data size.
          * Enforce data size is the same as modulus as that is
          * what OpenSSL expects and does internally in rsa_sign
@@ -497,14 +487,12 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx,
     if (sigctx->operation == CKF_SIGN) {
         ret = f->C_Sign(session, tbs, tbslen, sig, &sig_size);
         if (ret != CKR_OK) {
-            P11PROV_raise(sigctx->provctx, ret,
-                          "Error returned by C_Sign");
+            P11PROV_raise(sigctx->provctx, ret, "Error returned by C_Sign");
         }
     } else {
         ret = f->C_Verify(session, tbs, tbslen, sig, sigsize);
         if (ret != CKR_OK) {
-            P11PROV_raise(sigctx->provctx, ret,
-                          "Error returned by C_Verify");
+            P11PROV_raise(sigctx->provctx, ret, "Error returned by C_Verify");
         }
     }
     if (ret != CKR_OK) {
@@ -517,16 +505,15 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx,
 endsess:
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        P11PROV_raise(sigctx->provctx, ret,
-                      "Failed to close session %lu", session);
+        P11PROV_raise(sigctx->provctx, ret, "Failed to close session %lu",
+                      session);
     }
 
     return result;
 }
 
 static int p11prov_sig_digest_update(P11PROV_SIG_CTX *sigctx,
-                                     unsigned char *data,
-                                     size_t datalen)
+                                     unsigned char *data, size_t datalen)
 {
     CK_FUNCTION_LIST *f;
     int ret;
@@ -556,8 +543,8 @@ static int p11prov_sig_digest_update(P11PROV_SIG_CTX *sigctx,
     if (ret != CKR_OK) {
         ret = f->C_CloseSession(sigctx->session);
         if (ret != CKR_OK) {
-            P11PROV_raise(sigctx->provctx, ret,
-                          "Failed to close session %lu", sigctx->session);
+            P11PROV_raise(sigctx->provctx, ret, "Failed to close session %lu",
+                          sigctx->session);
         }
         sigctx->session = CK_INVALID_HANDLE;
         return RET_OSSL_ERR;
@@ -566,9 +553,8 @@ static int p11prov_sig_digest_update(P11PROV_SIG_CTX *sigctx,
     return RET_OSSL_OK;
 }
 
-static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx,
-                                    unsigned char *sig, size_t *siglen,
-                                    size_t sigsize)
+static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
+                                    size_t *siglen, size_t sigsize)
 {
     CK_ULONG sig_size = sigsize;
     CK_FUNCTION_LIST *f;
@@ -606,8 +592,8 @@ static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx,
 
     ret = f->C_CloseSession(sigctx->session);
     if (ret != CKR_OK) {
-        P11PROV_raise(sigctx->provctx, ret,
-                      "Failed to close session %lu", sigctx->session);
+        P11PROV_raise(sigctx->provctx, ret, "Failed to close session %lu",
+                      sigctx->session);
     }
     sigctx->session = CK_INVALID_HANDLE;
 
@@ -652,8 +638,8 @@ static int p11prov_rsasig_sign_init(void *ctx, void *provkey,
 {
     int ret;
 
-    p11prov_debug("rsa sign init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("rsa sign init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
+                  params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, NULL, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -661,16 +647,16 @@ static int p11prov_rsasig_sign_init(void *ctx, void *provkey,
     return p11prov_rsasig_set_ctx_params(ctx, params);
 }
 
-static int p11prov_rsasig_sign(void *ctx, unsigned char *sig,
-                               size_t *siglen, size_t sigsize,
-                               const unsigned char *tbs, size_t tbslen)
+static int p11prov_rsasig_sign(void *ctx, unsigned char *sig, size_t *siglen,
+                               size_t sigsize, const unsigned char *tbs,
+                               size_t tbslen)
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
     p11prov_debug("rsa sign (ctx=%p)\n", ctx);
 
-    return p11prov_sig_operate(sigctx, sig, siglen, sigsize,
-                               (void *)tbs, tbslen);
+    return p11prov_sig_operate(sigctx, sig, siglen, sigsize, (void *)tbs,
+                               tbslen);
 }
 
 static int p11prov_rsasig_verify_init(void *ctx, void *provkey,
@@ -678,8 +664,8 @@ static int p11prov_rsasig_verify_init(void *ctx, void *provkey,
 {
     int ret;
 
-    p11prov_debug("rsa verify init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("rsa verify init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
+                  params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, NULL, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -695,19 +681,18 @@ static int p11prov_rsasig_verify(void *ctx, const unsigned char *sig,
 
     p11prov_debug("rsa verify (ctx=%p)\n", ctx);
 
-    return p11prov_sig_operate(sigctx, (void *)sig, NULL, siglen,
-                               (void *)tbs, tbslen);
+    return p11prov_sig_operate(sigctx, (void *)sig, NULL, siglen, (void *)tbs,
+                               tbslen);
 }
 
-static int p11prov_rsasig_digest_sign_init(void *ctx,
-                                           const char *digest,
+static int p11prov_rsasig_digest_sign_init(void *ctx, const char *digest,
                                            void *provkey,
                                            const OSSL_PARAM params[])
 {
     int ret;
 
-    p11prov_debug("rsa digest sign init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("rsa digest sign init (ctx=%p, key=%p, params=%p)\n", ctx,
+                  provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, digest, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -734,23 +719,24 @@ static int p11prov_rsasig_digest_sign_final(void *ctx, unsigned char *sig,
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
-    p11prov_debug("rsa digest sign final (ctx=%p, sig=%p, siglen=%zu, "
-                  "sigsize=%zu)\n", ctx, sig, *siglen, sigsize);
+    p11prov_debug(
+        "rsa digest sign final (ctx=%p, sig=%p, siglen=%zu, "
+        "sigsize=%zu)\n",
+        ctx, sig, *siglen, sigsize);
 
     if (sigctx == NULL) return RET_OSSL_ERR;
 
     return p11prov_sig_digest_final(sigctx, sig, siglen, sigsize);
 }
 
-static int p11prov_rsasig_digest_verify_init(void *ctx,
-                                             const char *digest,
+static int p11prov_rsasig_digest_verify_init(void *ctx, const char *digest,
                                              void *provkey,
                                              const OSSL_PARAM params[])
 {
     int ret;
 
-    p11prov_debug("rsa digest verify init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("rsa digest verify init (ctx=%p, key=%p, params=%p)\n", ctx,
+                  provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, digest, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -778,8 +764,8 @@ static int p11prov_rsasig_digest_verify_final(void *ctx,
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
-    p11prov_debug("rsa digest verify final (ctx=%p, sig=%p, siglen=%zu)\n",
-                  ctx, sig, siglen);
+    p11prov_debug("rsa digest verify final (ctx=%p, sig=%p, siglen=%zu)\n", ctx,
+                  sig, siglen);
 
     if (sigctx == NULL) return RET_OSSL_ERR;
 
@@ -808,8 +794,7 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
         OSSL_SIGNATURE_PARAM_ALGORITHM_ID
      */
 
-    p11prov_debug("rsasig get ctx params (ctx=%p, params=%p)\n",
-                  ctx, params);
+    p11prov_debug("rsasig get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -855,8 +840,8 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("rsasig set ctx params (ctx=%p, params=%p)\n",
-                  sigctx, params);
+    p11prov_debug("rsasig set ctx params (ctx=%p, params=%p)\n", sigctx,
+                  params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -901,8 +886,7 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             return RET_OSSL_ERR;
         }
         if (mechtype == CK_UNAVAILABLE_INFORMATION) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
+            ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
             return RET_OSSL_ERR;
         }
         sigctx->mechtype = mechtype;
@@ -1045,8 +1029,8 @@ static int p11prov_ecdsa_sign_init(void *ctx, void *provkey,
 {
     int ret;
 
-    p11prov_debug("rsa sign init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("rsa sign init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
+                  params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, NULL, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -1054,16 +1038,16 @@ static int p11prov_ecdsa_sign_init(void *ctx, void *provkey,
     return p11prov_ecdsa_set_ctx_params(ctx, params);
 }
 
-static int p11prov_ecdsa_sign(void *ctx, unsigned char *sig,
-                              size_t *siglen, size_t sigsize,
-                              const unsigned char *tbs, size_t tbslen)
+static int p11prov_ecdsa_sign(void *ctx, unsigned char *sig, size_t *siglen,
+                              size_t sigsize, const unsigned char *tbs,
+                              size_t tbslen)
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
     p11prov_debug("ecdsa sign (ctx=%p)\n", ctx);
 
-    return p11prov_sig_operate(sigctx, sig, siglen, sigsize,
-                               (void *)tbs, tbslen);
+    return p11prov_sig_operate(sigctx, sig, siglen, sigsize, (void *)tbs,
+                               tbslen);
 }
 
 static int p11prov_ecdsa_verify_init(void *ctx, void *provkey,
@@ -1071,8 +1055,8 @@ static int p11prov_ecdsa_verify_init(void *ctx, void *provkey,
 {
     int ret;
 
-    p11prov_debug("ecdsa verify init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("ecdsa verify init (ctx=%p, key=%p, params=%p)\n", ctx,
+                  provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, NULL, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -1088,19 +1072,18 @@ static int p11prov_ecdsa_verify(void *ctx, const unsigned char *sig,
 
     p11prov_debug("rsa verify (ctx=%p)\n", ctx);
 
-    return p11prov_sig_operate(sigctx, (void *)sig, NULL, siglen,
-                               (void *)tbs, tbslen);
+    return p11prov_sig_operate(sigctx, (void *)sig, NULL, siglen, (void *)tbs,
+                               tbslen);
 }
 
-static int p11prov_ecdsa_digest_sign_init(void *ctx,
-                                           const char *digest,
-                                           void *provkey,
-                                           const OSSL_PARAM params[])
+static int p11prov_ecdsa_digest_sign_init(void *ctx, const char *digest,
+                                          void *provkey,
+                                          const OSSL_PARAM params[])
 {
     int ret;
 
-    p11prov_debug("ecdsa digest sign init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("ecdsa digest sign init (ctx=%p, key=%p, params=%p)\n", ctx,
+                  provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, digest, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -1109,8 +1092,8 @@ static int p11prov_ecdsa_digest_sign_init(void *ctx,
 }
 
 static int p11prov_ecdsa_digest_sign_update(void *ctx,
-                                             const unsigned char *data,
-                                             size_t datalen)
+                                            const unsigned char *data,
+                                            size_t datalen)
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
@@ -1127,23 +1110,24 @@ static int p11prov_ecdsa_digest_sign_final(void *ctx, unsigned char *sig,
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
-    p11prov_debug("ecdsa digest sign final (ctx=%p, sig=%p, siglen=%zu, "
-                  "sigsize=%zu)\n", ctx, sig, *siglen, sigsize);
+    p11prov_debug(
+        "ecdsa digest sign final (ctx=%p, sig=%p, siglen=%zu, "
+        "sigsize=%zu)\n",
+        ctx, sig, *siglen, sigsize);
 
     if (sigctx == NULL) return RET_OSSL_ERR;
 
     return p11prov_sig_digest_final(sigctx, sig, siglen, sigsize);
 }
 
-static int p11prov_ecdsa_digest_verify_init(void *ctx,
-                                            const char *digest,
+static int p11prov_ecdsa_digest_verify_init(void *ctx, const char *digest,
                                             void *provkey,
                                             const OSSL_PARAM params[])
 {
     int ret;
 
-    p11prov_debug("ecdsa digest verify init (ctx=%p, key=%p, params=%p)\n",
-                  ctx, provkey, params);
+    p11prov_debug("ecdsa digest verify init (ctx=%p, key=%p, params=%p)\n", ctx,
+                  provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, digest, params);
     if (ret != RET_OSSL_OK) return ret;
@@ -1157,8 +1141,10 @@ static int p11prov_ecdsa_digest_verify_update(void *ctx,
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
-    p11prov_debug("ecdsa digest verify update (ctx=%p, data=%p, "
-                  "datalen=%zu)\n", ctx, data, datalen);
+    p11prov_debug(
+        "ecdsa digest verify update (ctx=%p, data=%p, "
+        "datalen=%zu)\n",
+        ctx, data, datalen);
 
     if (sigctx == NULL) return RET_OSSL_ERR;
 
@@ -1189,8 +1175,7 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
         OSSL_SIGNATURE_PARAM_ALGORITHM_ID
      */
 
-    p11prov_debug("ecdsa get ctx params (ctx=%p, params=%p)\n",
-                  ctx, params);
+    p11prov_debug("ecdsa get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
@@ -1202,15 +1187,13 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
     return RET_OSSL_ERR;
 }
 
-
 static int p11prov_ecdsa_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
     const OSSL_PARAM *p;
     int ret;
 
-    p11prov_debug("ecdsa set ctx params (ctx=%p, params=%p)\n",
-                  sigctx, params);
+    p11prov_debug("ecdsa set ctx params (ctx=%p, params=%p)\n", sigctx, params);
 
     if (params == NULL) return RET_OSSL_OK;
 
@@ -1253,7 +1236,6 @@ static const OSSL_PARAM *p11prov_ecdsa_settable_ctx_params(void *ctx,
     };
     return params;
 }
-
 
 const OSSL_DISPATCH p11prov_ecdsa_signature_functions[] = {
     DISPATCH_SIG_ELEM(ecdsa, NEWCTX, newctx),

--- a/src/store.c
+++ b/src/store.c
@@ -52,8 +52,7 @@ static void p11prov_uri_free(struct p11prov_uri *parsed_uri)
 
 static P11PROV_OBJECT *p11prov_object_ref(P11PROV_OBJECT *obj)
 {
-    if (obj &&
-        __atomic_fetch_add(&obj->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
+    if (obj && __atomic_fetch_add(&obj->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
         return obj;
     }
 
@@ -128,8 +127,7 @@ static void endianfix(unsigned char *src, unsigned char *dest, size_t len)
     endianfix(src->pValue, fix_##src, src->ulValueLen); \
     ptr = fix_##src;
 #else
-#define WITH_FIXED_BUFFER(src, ptr) \
-    ptr = src->pValue;
+#define WITH_FIXED_BUFFER(src, ptr) ptr = src->pValue;
 #endif
 int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
                                          OSSL_CALLBACK *cb_fn, void *cb_arg)
@@ -146,15 +144,15 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
     if (n == NULL) return RET_OSSL_ERR;
 
     WITH_FIXED_BUFFER(n, val);
-    params[0] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N,
-                                        val, n->ulValueLen);
+    params[0] =
+        OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, val, n->ulValueLen);
 
     e = p11prov_key_attr(obj->pub_key, CKA_PUBLIC_EXPONENT);
     if (e == NULL) return RET_OSSL_ERR;
 
     WITH_FIXED_BUFFER(e, val);
-    params[1] = OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_E,
-                                        val, e->ulValueLen);
+    params[1] =
+        OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_E, val, e->ulValueLen);
 
     params[2] = OSSL_PARAM_construct_end();
 
@@ -182,8 +180,8 @@ static int hex_to_byte(const char *in, unsigned char *byte)
     return 0;
 }
 
-static int parse_attr(const char *str, size_t len,
-                      unsigned char **output, size_t *outlen)
+static int parse_attr(const char *str, size_t len, unsigned char **output,
+                      size_t *outlen)
 {
     unsigned char *out;
     size_t index = 0;
@@ -231,10 +229,9 @@ done:
 }
 
 #define MAX_PIN_LENGTH 32
-static int get_pin(const char *str, size_t len,
-                   char **output, size_t *outlen)
+static int get_pin(const char *str, size_t len, char **output, size_t *outlen)
 {
-    char pin[MAX_PIN_LENGTH+1];
+    char pin[MAX_PIN_LENGTH + 1];
     char *pinfile;
     char *filename;
     BIO *fp;
@@ -336,8 +333,8 @@ static int parse_uri(struct p11prov_uri *u, const char *uri)
             len -= 11;
             ret = get_pin(p, len, &u->pin, ptrlen);
             if (ret != 0) goto done;
-        } else if (strncmp(p, "type=", 5) == 0 ||
-                   strncmp(p, "object-type=", 12) == 0) {
+        } else if (strncmp(p, "type=", 5) == 0
+                   || strncmp(p, "object-type=", 12) == 0) {
             p += 4;
             if (*p == '=') {
                 p++;
@@ -427,8 +424,8 @@ static void *p11prov_store_attach(void *provctx, OSSL_CORE_BIO *in)
     return NULL;
 }
 
-static int p11prov_store_load(void *ctx,
-                              OSSL_CALLBACK *object_cb, void *object_cbarg,
+static int p11prov_store_load(void *ctx, OSSL_CALLBACK *object_cb,
+                              void *object_cbarg,
                               OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)ctx;
@@ -442,7 +439,7 @@ static int p11prov_store_load(void *ctx,
     nslots = p11prov_ctx_lock_slots(obj->provctx, &slots);
 
     for (int i = 0; i < nslots; i++) {
-	CK_TOKEN_INFO token;
+        CK_TOKEN_INFO token;
 
         /* ignore slots that are not initialized */
         if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) continue;
@@ -451,21 +448,23 @@ static int p11prov_store_load(void *ctx,
         token = slots[i].token;
 
         /* skip slots that do not match */
-        if (obj->parsed_uri->model &&
-            strncmp(obj->parsed_uri->model,
-                    (const char *)token.model, 16) != 0)
+        if (obj->parsed_uri->model
+            && strncmp(obj->parsed_uri->model, (const char *)token.model, 16)
+                   != 0)
             continue;
-        if (obj->parsed_uri->manufacturer &&
-            strncmp(obj->parsed_uri->manufacturer,
-                    (const char *)token.manufacturerID, 32) != 0)
+        if (obj->parsed_uri->manufacturer
+            && strncmp(obj->parsed_uri->manufacturer,
+                       (const char *)token.manufacturerID, 32)
+                   != 0)
             continue;
-        if (obj->parsed_uri->token &&
-            strncmp(obj->parsed_uri->token,
-                    (const char *)token.label, 32) != 0)
+        if (obj->parsed_uri->token
+            && strncmp(obj->parsed_uri->token, (const char *)token.label, 32)
+                   != 0)
             continue;
-        if (obj->parsed_uri->serial &&
-            strncmp(obj->parsed_uri->serial,
-                    (const char *)token.serialNumber, 16) != 0)
+        if (obj->parsed_uri->serial
+            && strncmp(obj->parsed_uri->serial,
+                       (const char *)token.serialNumber, 16)
+                   != 0)
             continue;
 
         if (token.flags & CKF_LOGIN_REQUIRED) {
@@ -491,8 +490,7 @@ static int p11prov_store_load(void *ctx,
             /* Supports only USER login sessions for now */
             ret = f->C_Login(obj->login_session, CKU_USER, pin, pinlen);
             if (ret && ret != CKR_USER_ALREADY_LOGGED_IN) {
-                P11PROV_raise(obj->provctx, ret,
-                              "Error returned by C_Login");
+                P11PROV_raise(obj->provctx, ret, "Error returned by C_Login");
                 continue;
             }
         }
@@ -526,14 +524,10 @@ static int p11prov_store_load(void *ctx,
             }
         }
         if (class == CKO_PUBLIC_KEY || class == CKO_PRIVATE_KEY) {
-             int ret = find_keys(obj->provctx,
-                                 &obj->priv_key,
-                                 &obj->pub_key,
-                                 slots[i].id,
-                                 class,
-                                 obj->parsed_uri->id,
-                                 obj->parsed_uri->id_len,
-                                 obj->parsed_uri->object);
+            int ret =
+                find_keys(obj->provctx, &obj->priv_key, &obj->pub_key,
+                          slots[i].id, class, obj->parsed_uri->id,
+                          obj->parsed_uri->id_len, obj->parsed_uri->object);
             /* for keys return on first match */
             if (ret == CKR_OK) break;
         }
@@ -549,8 +543,8 @@ static int p11prov_store_load(void *ctx,
         CK_KEY_TYPE type;
         char *data_type;
 
-        params[0] = OSSL_PARAM_construct_int(
-                        OSSL_OBJECT_PARAM_TYPE, &object_type);
+        params[0] =
+            OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
 
         if (obj->pub_key) {
             type = p11prov_key_type(obj->pub_key);
@@ -571,8 +565,10 @@ static int p11prov_store_load(void *ctx,
                 data_type = "RSA";
                 break;
             default:
-                if (obj->priv_key) data_type = P11PROV_NAMES_RSA;
-                else data_type = "RSA";
+                if (obj->priv_key)
+                    data_type = P11PROV_NAMES_RSA;
+                else
+                    data_type = "RSA";
                 break;
             }
             break;
@@ -583,12 +579,11 @@ static int p11prov_store_load(void *ctx,
             return RET_OSSL_ERR;
         }
         params[1] = OSSL_PARAM_construct_utf8_string(
-                        OSSL_OBJECT_PARAM_DATA_TYPE, data_type, 0);
+            OSSL_OBJECT_PARAM_DATA_TYPE, data_type, 0);
 
         /* giving away the object by reference */
         params[2] = OSSL_PARAM_construct_octet_string(
-                        OSSL_OBJECT_PARAM_REFERENCE,
-                        p11prov_object_ref(obj), sizeof(obj));
+            OSSL_OBJECT_PARAM_REFERENCE, p11prov_object_ref(obj), sizeof(obj));
         params[3] = OSSL_PARAM_construct_end();
 
         return object_cb(params, object_cbarg);
@@ -603,7 +598,7 @@ static int p11prov_store_eof(void *ctx)
 
     p11prov_debug("object eof (%p)\n", obj);
 
-    return obj->loaded?1:0;
+    return obj->loaded ? 1 : 0;
 }
 
 static int p11prov_store_close(void *ctx)
@@ -618,18 +613,15 @@ static int p11prov_store_close(void *ctx)
     return 1;
 }
 
-static int p11prov_store_export_object(void *loaderctx,
-                                       const void *reference,
+static int p11prov_store_export_object(void *loaderctx, const void *reference,
                                        size_t reference_sz,
-                                       OSSL_CALLBACK *cb_fn,
-                                       void *cb_arg)
+                                       OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     P11PROV_OBJECT *obj = NULL;
 
     p11prov_debug("object export %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj))
-        return RET_OSSL_ERR;
+    if (!reference || reference_sz != sizeof(obj)) return RET_OSSL_ERR;
 
     /* the contents of the reference is the address to our object */
     obj = (P11PROV_OBJECT *)reference;

--- a/src/store.c
+++ b/src/store.c
@@ -653,7 +653,7 @@ static const OSSL_PARAM *p11prov_store_settable_ctx_params(void *provctx)
         OSSL_PARAM_octet_string(OSSL_STORE_PARAM_SUBJECT, NULL, 0),
          */
         OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_INPUT_TYPE, NULL, 0),
-        OSSL_PARAM_END
+        OSSL_PARAM_END,
     };
     return known_settable_ctx_params;
 }
@@ -700,5 +700,5 @@ const OSSL_DISPATCH p11prov_store_functions[] = {
     DISPATCH_STORE_ELEM(SET_CTX_PARAMS, set_ctx_params),
     DISPATCH_STORE_ELEM(SETTABLE_CTX_PARAMS, settable_ctx_params),
     DISPATCH_STORE_ELEM(EXPORT_OBJECT, export_object),
-    { 0, NULL }
+    { 0, NULL },
 };

--- a/src/util.c
+++ b/src/util.c
@@ -3,10 +3,8 @@
 
 #include "provider.h"
 
-int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
-                             CK_SESSION_HANDLE session,
-                             CK_OBJECT_HANDLE object,
-                             struct fetch_attrs *attrs,
+int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
+                             CK_OBJECT_HANDLE object, struct fetch_attrs *attrs,
                              unsigned long attrnums)
 {
     CK_ATTRIBUTE q[attrnums];
@@ -17,8 +15,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
         if (attrs[i].allocate) {
             CKATTR_ASSIGN_ALL(q[i], attrs[i].type, NULL, 0);
         } else {
-            CKATTR_ASSIGN_ALL(q[i], attrs[i].type,
-                              *attrs[i].value,
+            CKATTR_ASSIGN_ALL(q[i], attrs[i].type, *attrs[i].value,
                               *attrs[i].value_len);
         }
     }
@@ -42,8 +39,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
                 if (a == NULL) return -ENOMEM;
                 FA_RETURN_VAL(attrs[i], a, q[i].ulValueLen);
 
-                CKATTR_ASSIGN_ALL(r[retrnums], attrs[i].type,
-                                  *attrs[i].value,
+                CKATTR_ASSIGN_ALL(r[retrnums], attrs[i].type, *attrs[i].value,
                                   *attrs[i].value_len);
                 retrnums++;
             } else {
@@ -53,8 +49,8 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
         if (retrnums > 0) {
             ret = f->C_GetAttributeValue(session, object, r, retrnums);
         }
-    } else if (ret == CKR_ATTRIBUTE_SENSITIVE ||
-               ret == CKR_ATTRIBUTE_TYPE_INVALID) {
+    } else if (ret == CKR_ATTRIBUTE_SENSITIVE
+               || ret == CKR_ATTRIBUTE_TYPE_INVALID) {
         p11prov_debug("Quering attributes one by one\n");
         /* go one by one as this PKCS11 does not have some attributes
          * and does not handle it gracefully */
@@ -70,8 +66,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
                     FA_RETURN_VAL(attrs[i], a, q[0].ulValueLen);
                 }
             }
-            CKATTR_ASSIGN_ALL(r[0], attrs[i].type,
-                              *attrs[i].value,
+            CKATTR_ASSIGN_ALL(r[0], attrs[i].type, *attrs[i].value,
                               *attrs[i].value_len);
             ret = f->C_GetAttributeValue(session, object, r, 1);
             if (ret != CKR_OK) {
@@ -88,8 +83,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f,
     return ret;
 }
 
-CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx,
-                                      CK_SLOT_ID slotid)
+CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid)
 {
     CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
     CK_FUNCTION_LIST *f;
@@ -119,8 +113,8 @@ CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx,
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
-        P11PROV_raise(provctx, ret,
-                      "Failed to open session on slot %lu", slotid);
+        P11PROV_raise(provctx, ret, "Failed to open session on slot %lu",
+                      slotid);
     }
 
 done:
@@ -137,7 +131,6 @@ void p11prov_put_session(P11PROV_CTX *provctx, CK_SESSION_HANDLE session)
 
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {
-        P11PROV_raise(provctx, ret,
-                      "Failed to close session %lu", session);
+        P11PROV_raise(provctx, ret, "Failed to close session %lu", session);
     }
 }


### PR DESCRIPTION
This is an initial example of how .clang-format can be configured. It doesn't precisely match the current style, but no tool can do that.