### PR TITLE
Add checks to enforce at least c11 semantics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libnss3 libnss3-tools libnss3-dev
+        sudo apt-get install -y autoconf-archive libnss3 libnss3-tools libnss3-dev
     - name: Setup
       run: |
         autoreconf -fiv

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang-format
+        sudo apt-get install -y autoconf-archive clang-format
     - name: Setup
       if: ${{ github.event.pull_request.base.sha }}
       run: |

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -11,6 +11,7 @@ Files: **/Makefile.am
        .gitignore
        Makefile.am
        README.md
+       BUILD.md
        configure.ac
        configure.ac
        src/Makefile.am

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,13 @@
+## Build Prerequisites
+
+This package requires the following:
+- OpenSSL 3.0+ libraries and developement headers
+- autoconf-archives packages for some m4 macros
+- NSS softoken and development headers (for testing)
+- a C compiler that supports at least C11 semantics
+
+The usual command to build are:
+- autorecofn -fi (if needed)
+- ./configure
+- make
+- make check

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,11 @@ AM_PROG_AR
 LT_INIT
 PKG_PROG_PKG_CONFIG
 
+AX_CHECK_COMPILE_FLAG([-std=c11],
+                      [CFLAGS="$CFLAGS -std=c11"],
+                      AC_MSG_ERROR([C compiler must support at least C11 standard])
+)
+
 # Checks for libraries.
 PKG_CHECK_MODULES(
 	[OPENSSL],


### PR DESCRIPTION
Add a BUILD.md file to start documenting build process and requirements

Fixes #18 