### PR TITLE
Add missing single-line braces using clang-tidy

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,11 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf-archive clang-format
+        sudo apt-get install -y autoconf-archive clang-format clang-tidy
+    - name: Install compiledb
+      run: |
+        sudo apt install python3-pip
+        pip install compiledb
     - name: Setup
       if: ${{ github.event.pull_request.base.sha }}
       run: |
@@ -23,6 +27,14 @@ jobs:
       run: |
         autoreconf -fiv
         ./configure
+        compiledb make
+    - name: Run Clang Tidy
+      run: |
+        /usr/bin/run-clang-tidy-14 \
+         -checks=-*,readability-braces-around-statements \
+         -config "{WarningsAsErrors: '*'}" \
+         -header-filter "src/oasis" \
+         -quiet
     - name: Check the Style
       run: make check-style
     - name: Show Style diff in case of failure

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ aclocal.m4
 ar-lib
 autom4te.cache/
 compile
+compile_commands.json
 config.guess
 config.log
 config.status

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -32,7 +32,9 @@ static void *p11prov_rsaenc_newctx(void *provctx)
     struct p11prov_rsaenc_ctx *encctx;
 
     encctx = OPENSSL_zalloc(sizeof(struct p11prov_rsaenc_ctx));
-    if (encctx == NULL) return NULL;
+    if (encctx == NULL) {
+        return NULL;
+    }
 
     encctx->provctx = ctx;
 
@@ -46,7 +48,9 @@ static void p11prov_rsaenc_freectx(void *ctx)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
 
-    if (encctx == NULL) return;
+    if (encctx == NULL) {
+        return;
+    }
 
     p11prov_key_free(encctx->key);
     OPENSSL_free(encctx->oaep_params.pSourceData);
@@ -59,10 +63,14 @@ static void *p11prov_rsaenc_dupctx(void *ctx)
     struct p11prov_rsaenc_ctx *newctx;
     int ret;
 
-    if (encctx == NULL) return NULL;
+    if (encctx == NULL) {
+        return NULL;
+    }
 
     newctx = p11prov_rsaenc_newctx(encctx->provctx);
-    if (newctx == NULL) return NULL;
+    if (newctx == NULL) {
+        return NULL;
+    }
 
     newctx->key = p11prov_key_ref(encctx->key);
     newctx->mechtype = encctx->mechtype;
@@ -113,7 +121,9 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
     if (encctx->key == NULL) {
         encctx->key = p11prov_object_get_key(obj, true);
     }
-    if (encctx->key == NULL) return RET_OSSL_ERR;
+    if (encctx->key == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_rsaenc_set_ctx_params(ctx, params);
 }
@@ -145,7 +155,9 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     f = p11prov_ctx_fns(encctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
     slotid = p11prov_key_slotid(encctx->key);
     if (slotid == CK_UNAVAILABLE_INFORMATION) {
         P11PROV_raise(encctx->provctx, CKR_SLOT_ID_INVALID,
@@ -160,7 +172,9 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     ret = p11prov_rsaenc_set_mechanism(encctx, &mechanism);
-    if (ret != CKR_OK) return RET_OSSL_ERR;
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -208,7 +222,9 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
                   params);
 
     encctx->key = p11prov_object_get_key(obj, true);
-    if (encctx->key == NULL) return RET_OSSL_ERR;
+    if (encctx->key == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_rsaenc_set_ctx_params(ctx, params);
 }
@@ -240,7 +256,9 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     f = p11prov_ctx_fns(encctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
     slotid = p11prov_key_slotid(encctx->key);
     if (slotid == CK_UNAVAILABLE_INFORMATION) {
         P11PROV_raise(encctx->provctx, CKR_SLOT_ID_INVALID,
@@ -255,7 +273,9 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     ret = p11prov_rsaenc_set_mechanism(encctx, &mechanism);
-    if (ret != CKR_OK) return RET_OSSL_ERR;
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -373,7 +393,9 @@ static int p11prov_rsaenc_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p11prov_debug("rsaenc get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_PAD_MODE);
     if (p) {
@@ -391,28 +413,36 @@ static int p11prov_rsaenc_get_ctx_params(void *ctx, OSSL_PARAM *params)
                 break;
             }
         }
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
     if (p) {
         ret = OSSL_PARAM_set_utf8_string(
             p, p11prov_rsaenc_digest_name(encctx->oaep_params.hashAlg));
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST);
     if (p) {
         ret = OSSL_PARAM_set_utf8_string(
             p, p11prov_rsaenc_mgf_name(encctx->oaep_params.mgf));
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL);
     if (p) {
         ret = OSSL_PARAM_set_octet_ptr(p, encctx->oaep_params.pSourceData,
                                        encctx->oaep_params.ulSourceDataLen);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     return RET_OSSL_OK;
@@ -426,7 +456,9 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p11prov_debug("rsaenc set ctx params (ctx=%p, params=%p)\n", ctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_PAD_MODE);
     if (p) {
@@ -435,7 +467,9 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             int pad_mode;
             /* legacy pad mode number */
             ret = OSSL_PARAM_get_int(p, &pad_mode);
-            if (ret != RET_OSSL_OK) return ret;
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
             for (int i = 0; padding_map[i].string != NULL; i++) {
                 if (padding_map[i].ossl_id == pad_mode) {
                     mechtype = padding_map[i].type;
@@ -469,7 +503,9 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         encctx->oaep_params.hashAlg = p11prov_rsaenc_map_digest(digest);
         if (encctx->oaep_params.hashAlg == CK_UNAVAILABLE_INFORMATION) {
@@ -483,7 +519,9 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         encctx->oaep_params.mgf = p11prov_rsaenc_map_mgf(digest);
         if (encctx->oaep_params.mgf == CK_UNAVAILABLE_INFORMATION) {
@@ -498,7 +536,9 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         size_t len;
 
         ret = OSSL_PARAM_get_octet_string(p, &label, 0, &len);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         /* just in case it was previously set */
         OPENSSL_free(encctx->oaep_params.pSourceData);

--- a/src/debug.c
+++ b/src/debug.c
@@ -16,7 +16,9 @@ void p11prov_debug(const char *fmt, ...)
             debug_lazy_init = 1;
             if (strncmp(env, "file:", 5) == 0) {
                 stddebug = fopen(&env[5], "a");
-                if (stddebug == NULL) debug_lazy_init = -1;
+                if (stddebug == NULL) {
+                    debug_lazy_init = -1;
+                }
             } else {
                 stddebug = stderr;
             }
@@ -47,10 +49,14 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
     const char *mechname = "UNKNOWN";
     int ret;
 
-    if (debug_lazy_init < 0) return;
+    if (debug_lazy_init < 0) {
+        return;
+    }
 
     f = p11prov_ctx_fns(ctx);
-    if (f == NULL) return;
+    if (f == NULL) {
+        return;
+    }
 
     for (int i = 0; mechanism_names[i].name != NULL; i++) {
         if (type == mechanism_names[i].value) {

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -98,7 +98,9 @@ static void *p11prov_ecdh_newctx(void *provctx)
     P11PROV_EXCH_CTX *ecdhctx;
 
     ecdhctx = OPENSSL_zalloc(sizeof(P11PROV_EXCH_CTX));
-    if (ecdhctx == NULL) return NULL;
+    if (ecdhctx == NULL) {
+        return NULL;
+    }
 
     ecdhctx->provctx = ctx;
 
@@ -117,10 +119,14 @@ static void *p11prov_ecdh_dupctx(void *ctx)
     P11PROV_EXCH_CTX *newctx;
     int ret;
 
-    if (ecdhctx == NULL) return NULL;
+    if (ecdhctx == NULL) {
+        return NULL;
+    }
 
     newctx = p11prov_ecdh_newctx(ecdhctx->provctx);
-    if (newctx == NULL) return NULL;
+    if (newctx == NULL) {
+        return NULL;
+    }
 
     newctx->key = p11prov_key_ref(ecdhctx->key);
     newctx->peer_key = p11prov_key_ref(ecdhctx->peer_key);
@@ -159,7 +165,9 @@ static void p11prov_ecdh_freectx(void *ctx)
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
 
-    if (ecdhctx == NULL) return;
+    if (ecdhctx == NULL) {
+        return;
+    }
 
     p11prov_key_free(ecdhctx->key);
     p11prov_key_free(ecdhctx->peer_key);
@@ -174,11 +182,15 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
 
-    if (ctx == NULL || provkey == NULL) return RET_OSSL_ERR;
+    if (ctx == NULL || provkey == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     p11prov_key_free(ecdhctx->key);
     ecdhctx->key = p11prov_object_get_key(obj, true);
-    if (ecdhctx->key == NULL) return RET_OSSL_ERR;
+    if (ecdhctx->key == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_ecdh_set_ctx_params(ctx, params);
 }
@@ -188,11 +200,15 @@ static int p11prov_ecdh_set_peer(void *ctx, void *provkey)
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
 
-    if (ctx == NULL || provkey == NULL) return RET_OSSL_ERR;
+    if (ctx == NULL || provkey == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     p11prov_key_free(ecdhctx->peer_key);
     ecdhctx->peer_key = p11prov_object_get_key(obj, false);
-    if (ecdhctx->peer_key == NULL) return RET_OSSL_ERR;
+    if (ecdhctx->peer_key == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return RET_OSSL_OK;
 }
@@ -247,7 +263,9 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     }
 
     ec_point = p11prov_key_attr(ecdhctx->peer_key, CKA_EC_POINT);
-    if (ec_point == NULL) return RET_OSSL_ERR;
+    if (ec_point == NULL) {
+        return RET_OSSL_ERR;
+    }
     ecdhctx->ecdh_params.pPublicData = ec_point->pValue;
     ecdhctx->ecdh_params.ulPublicDataLen = ec_point->ulValueLen;
 
@@ -277,7 +295,9 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     }
 
     f = p11prov_ctx_fns(ecdhctx->provctx);
-    if (f == NULL) return CKR_GENERAL_ERROR;
+    if (f == NULL) {
+        return CKR_GENERAL_ERROR;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -322,7 +342,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p11prov_debug("ecdh set ctx params (ctx=%p, params=%p)\n", ecdhctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate_const(params,
                                 OSSL_EXCHANGE_PARAM_EC_ECDH_COFACTOR_MODE);
@@ -330,14 +352,19 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         int mode;
 
         ret = OSSL_PARAM_get_int(p, &mode);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
-        if (mode < -1 || mode > 1) return RET_OSSL_ERR;
+        if (mode < -1 || mode > 1) {
+            return RET_OSSL_ERR;
+        }
 
-        if (mode == 0)
+        if (mode == 0) {
             ecdhctx->mechtype = CKM_ECDH1_DERIVE;
-        else
+        } else {
             ecdhctx->mechtype = CKM_ECDH1_COFACTOR_DERIVE;
+        }
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
@@ -346,7 +373,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         char *str = name;
 
         ret = OSSL_PARAM_get_utf8_string(p, &str, sizeof(name));
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         if (name[0] == '\0') {
             ecdhctx->ecdh_params.kdf = CKD_NULL;
@@ -373,7 +402,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         ecdhctx->digest = p11prov_ecdh_map_digest(digest);
         if (ecdhctx->digest == CK_UNAVAILABLE_INFORMATION) {
@@ -387,7 +418,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         size_t outlen;
 
         ret = OSSL_PARAM_get_size_t(p, &outlen);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         ecdhctx->kdf_outlen = outlen;
     }
@@ -398,7 +431,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         size_t ukm_len;
 
         ret = OSSL_PARAM_get_octet_string(p, &ukm, 0, &ukm_len);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         OPENSSL_free(ecdhctx->ecdh_params.pSharedData);
         ecdhctx->ecdh_params.pSharedData = ukm;
@@ -433,7 +468,9 @@ static int p11prov_ecdh_get_ctx_params(void *ctx, OSSL_PARAM *params)
     if (p) {
         int mode = (ecdhctx->mechtype == CKM_ECDH1_DERIVE) ? 0 : 1;
         ret = OSSL_PARAM_set_int(p, mode);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
@@ -443,27 +480,35 @@ static int p11prov_ecdh_get_ctx_params(void *ctx, OSSL_PARAM *params)
         } else {
             ret = OSSL_PARAM_set_utf8_string(p, OSSL_KDF_NAME_X963KDF);
         }
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
     if (p) {
         const char *digest = p11prov_ecdh_digest_name(ecdhctx->digest);
         ret = OSSL_PARAM_set_utf8_string(p, digest);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN);
     if (p) {
         ret = OSSL_PARAM_set_size_t(p, ecdhctx->kdf_outlen);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_UKM);
     if (p) {
         ret = OSSL_PARAM_set_octet_ptr(p, ecdhctx->ecdh_params.pSharedData,
                                        ecdhctx->ecdh_params.ulSharedDataLen);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     return RET_OSSL_OK;
@@ -517,7 +562,9 @@ static void *p11prov_exch_hkdf_newctx(void *provctx)
     p11prov_debug("hkdf exchange newctx\n");
 
     hkdfctx = OPENSSL_zalloc(sizeof(P11PROV_EXCH_CTX));
-    if (hkdfctx == NULL) return NULL;
+    if (hkdfctx == NULL) {
+        return NULL;
+    }
 
     hkdfctx->provctx = ctx;
 
@@ -546,7 +593,9 @@ static void p11prov_exch_hkdf_freectx(void *ctx)
 
     p11prov_debug("hkdf exchange freectx\n");
 
-    if (hkdfctx == NULL) return;
+    if (hkdfctx == NULL) {
+        return;
+    }
 
     EVP_KDF_CTX_free(hkdfctx->kdfctx);
     p11prov_key_free(hkdfctx->key);
@@ -562,12 +611,16 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
     p11prov_debug("hkdf exchange init (ctx:%p obj:%p params:%p)\n", ctx, obj,
                   params);
 
-    if (ctx == NULL || provobj == NULL) return RET_OSSL_ERR;
+    if (ctx == NULL || provobj == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     if (provobj != &p11prov_hkdfkm_static_ctx) {
         p11prov_key_free(hkdfctx->key);
         hkdfctx->key = p11prov_object_get_key(obj, true);
-        if (hkdfctx->key == NULL) return RET_OSSL_ERR;
+        if (hkdfctx->key == NULL) {
+            return RET_OSSL_ERR;
+        }
     }
 
     return p11prov_exch_hkdf_set_ctx_params(ctx, params);
@@ -606,7 +659,9 @@ static const OSSL_PARAM *p11prov_exch_hkdf_settable_ctx_params(void *ctx,
     EVP_KDF *kdf;
 
     kdf = EVP_KDF_fetch(NULL, "HKDF", P11PROV_DEFAULT_PROPERTIES);
-    if (kdf == NULL) return NULL;
+    if (kdf == NULL) {
+        return NULL;
+    }
 
     params = EVP_KDF_settable_ctx_params(kdf);
     EVP_KDF_free(kdf);

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -77,7 +77,9 @@ static void *p11prov_hkdf_newctx(void *provctx)
     p11prov_debug("hkdf newctx\n");
 
     hkdfctx = OPENSSL_zalloc(sizeof(P11PROV_KDF_CTX));
-    if (hkdfctx == NULL) return NULL;
+    if (hkdfctx == NULL) {
+        return NULL;
+    }
 
     hkdfctx->provctx = ctx;
 
@@ -172,7 +174,9 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     }
 
     f = p11prov_ctx_fns(hkdfctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     ret = f->C_DeriveKey(hkdfctx->session, &mechanism, pkey_handle,
                          key_template, 5, &dkey_handle);
@@ -203,14 +207,18 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p11prov_debug("hkdf set ctx params (ctx=%p, params=%p)\n", hkdfctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST);
     if (p) {
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         hkdfctx->params.prfHashMechanism = p11prov_hkdf_map_digest(digest);
         if (hkdfctx->params.prfHashMechanism == CK_UNAVAILABLE_INFORMATION) {
@@ -235,7 +243,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             }
         } else {
             ret = OSSL_PARAM_get_int(p, &mode);
-            if (ret != RET_OSSL_OK) return ret;
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
         }
 
         switch (mode) {
@@ -266,7 +276,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         size_t secret_len;
         /* TODO: import into a pkcs11 key? */
         ret = OSSL_PARAM_get_octet_string(p, &secret, 0, &secret_len);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         /* Create Session  and key from key material */
 
@@ -274,11 +286,15 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             hkdfctx->session = p11prov_get_session(hkdfctx->provctx,
                                                    CK_UNAVAILABLE_INFORMATION);
         }
-        if (hkdfctx->session == CK_INVALID_HANDLE) return RET_OSSL_ERR;
+        if (hkdfctx->session == CK_INVALID_HANDLE) {
+            return RET_OSSL_ERR;
+        }
 
         hkdfctx->key = p11prov_create_secret_key(
             hkdfctx->provctx, hkdfctx->session, true, secret, secret_len);
-        if (hkdfctx->key == NULL) return RET_OSSL_ERR;
+        if (hkdfctx->key == NULL) {
+            return RET_OSSL_ERR;
+        }
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SALT);
@@ -288,7 +304,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         OPENSSL_cleanse(hkdfctx->params.pSalt, hkdfctx->params.ulSaltLen);
         hkdfctx->params.pSalt = NULL;
         ret = OSSL_PARAM_get_octet_string(p, &ptr, 0, &len);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
         hkdfctx->params.ulSaltType = CKF_HKDF_SALT_DATA;
         hkdfctx->params.pSalt = ptr;
         hkdfctx->params.ulSaltLen = len;
@@ -301,7 +319,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         void *ptr;
         size_t len;
 
-        if (p->data_size == 0 || p->data == NULL) return RET_OSSL_ERR;
+        if (p->data_size == 0 || p->data == NULL) {
+            return RET_OSSL_ERR;
+        }
 
         len = hkdfctx->params.ulInfoLen + p->data_size;
         ptr = OPENSSL_realloc(hkdfctx->params.pInfo, len);
@@ -341,7 +361,9 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p11prov_debug("hkdf get ctx params (ctx=%p, params=%p)\n", hkdfctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
     if (p) {

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -53,7 +53,9 @@ static void *p11prov_rsakm_load(const void *reference, size_t reference_sz)
 
     p11prov_debug("rsa load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj)) return NULL;
+    if (!reference || reference_sz != sizeof(obj)) {
+        return NULL;
+    }
 
     /* the contents of the reference is the address to our object */
     obj = (P11PROV_OBJECT *)reference;
@@ -67,14 +69,20 @@ static int p11prov_rsakm_has(const void *keydata, int selection)
 
     p11prov_debug("rsa has %p %d\n", obj, selection);
 
-    if (obj == NULL) return 0;
+    if (obj == NULL) {
+        return 0;
+    }
 
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
-        if (!p11prov_object_check_key(obj, true)) return 0;
+        if (!p11prov_object_check_key(obj, true)) {
+            return 0;
+        }
     }
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        if (!p11prov_object_check_key(obj, false)) return 0;
+        if (!p11prov_object_check_key(obj, false)) {
+            return 0;
+        }
     }
 
     return 1;
@@ -94,7 +102,9 @@ static int p11prov_rsakm_export(void *keydata, int selection,
 
     p11prov_debug("rsa export %p\n", keydata);
 
-    if (obj == NULL) return 0;
+    if (obj == NULL) {
+        return 0;
+    }
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return p11prov_object_export_public_rsa_key(obj, cb_fn, cb_arg);
@@ -112,16 +122,18 @@ static const OSSL_PARAM p11prov_rsakm_key_types[] = {
 static const OSSL_PARAM *p11prov_rsakm_import_types(int selection)
 {
     p11prov_debug("rsa import types\n");
-    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return p11prov_rsakm_key_types;
+    }
     return NULL;
 }
 
 static const OSSL_PARAM *p11prov_rsakm_export_types(int selection)
 {
     p11prov_debug("rsa export types\n");
-    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return p11prov_rsakm_key_types;
+    }
     return NULL;
 }
 
@@ -158,6 +170,8 @@ static int p11prov_rsakm_secbits(int bits)
 
     /* TODO: do better calculations,
      * see ossl_ifc_ffc_compute_security_bits() */
+
+    /* NOLINTBEGIN(readability-braces-around-statements) */
     if (bits > 15360) return 256;
     if (bits > 8192) return 200;
     if (bits > 7680) return 192;
@@ -165,7 +179,9 @@ static int p11prov_rsakm_secbits(int bits)
     if (bits > 4096) return 152;
     if (bits > 3072) return 128;
     if (bits > 2048) return 112;
-    if (bits <= 2048) return 0;
+    /* NOLINTEND(readability-braces-around-statements) */
+
+    return 0;
 }
 
 static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
@@ -178,7 +194,9 @@ static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
 
     p11prov_debug("rsa get params %p\n", keydata);
 
-    if (obj == NULL) return 0;
+    if (obj == NULL) {
+        return 0;
+    }
 
     key = p11prov_object_get_key(obj, false);
     if (key == NULL) {
@@ -196,19 +214,25 @@ static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
         /* TODO: may want to try to get CKA_MODULUS_BITS,
          * and fallback only if unavailable */
         ret = OSSL_PARAM_set_int(p, modulus->ulValueLen * 8);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS);
     if (p) {
         /* TODO: as above, plus use log() for intermediate values */
         int secbits = p11prov_rsakm_secbits(modulus->ulValueLen * 8);
         ret = OSSL_PARAM_set_int(p, secbits);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
     if (p) {
         ret = OSSL_PARAM_set_int(p, modulus->ulValueLen);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
 
     ret = RET_OSSL_OK;
@@ -299,7 +323,9 @@ static void *p11prov_eckm_load(const void *reference, size_t reference_sz)
 
     p11prov_debug("ec load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj)) return NULL;
+    if (!reference || reference_sz != sizeof(obj)) {
+        return NULL;
+    }
 
     /* the contents of the reference is the address to our object */
     obj = (P11PROV_OBJECT *)reference;
@@ -313,14 +339,20 @@ static int p11prov_eckm_has(const void *keydata, int selection)
 
     p11prov_debug("ec has %p %d\n", obj, selection);
 
-    if (obj == NULL) return 0;
+    if (obj == NULL) {
+        return 0;
+    }
 
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
-        if (!p11prov_object_check_key(obj, true)) return 0;
+        if (!p11prov_object_check_key(obj, true)) {
+            return 0;
+        }
     }
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        if (!p11prov_object_check_key(obj, false)) return 0;
+        if (!p11prov_object_check_key(obj, false)) {
+            return 0;
+        }
     }
 
     return 1;
@@ -340,7 +372,9 @@ static int p11prov_eckm_export(void *keydata, int selection,
 
     p11prov_debug("ec export %p\n", keydata);
 
-    if (obj == NULL) return RET_OSSL_ERR;
+    if (obj == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     /* TODO */
 
@@ -358,16 +392,18 @@ static const OSSL_PARAM p11prov_eckm_key_types[] = {
 static const OSSL_PARAM *p11prov_eckm_import_types(int selection)
 {
     p11prov_debug("ec import types\n");
-    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return p11prov_eckm_key_types;
+    }
     return NULL;
 }
 
 static const OSSL_PARAM *p11prov_eckm_export_types(int selection)
 {
     p11prov_debug("ec export types\n");
-    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return p11prov_eckm_key_types;
+    }
     return NULL;
 }
 
@@ -386,10 +422,18 @@ static const char *p11prov_eckm_query_operation_name(int operation_id)
 static int p11prov_eckm_secbits(int bits)
 {
     /* common values from various NIST documents */
-    if (bits < 224) return 0;
-    if (bits < 256) return 112;
-    if (bits < 384) return 128;
-    if (bits < 512) return 192;
+    if (bits < 224) {
+        return 0;
+    }
+    if (bits < 256) {
+        return 112;
+    }
+    if (bits < 384) {
+        return 128;
+    }
+    if (bits < 512) {
+        return 192;
+    }
     return 256;
 }
 
@@ -404,7 +448,9 @@ static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
 
     p11prov_debug("ec get params %p\n", keydata);
 
-    if (obj == NULL) return 0;
+    if (obj == NULL) {
+        return 0;
+    }
 
     key = p11prov_object_get_key(obj, false);
     if (key == NULL) {
@@ -413,26 +459,34 @@ static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
     }
 
     group_size = p11prov_key_size(key);
-    if (group_size == CK_UNAVAILABLE_INFORMATION) return RET_OSSL_ERR;
+    if (group_size == CK_UNAVAILABLE_INFORMATION) {
+        return RET_OSSL_ERR;
+    }
 
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS);
     if (p) {
         /* TODO: may want to try to get CKA_MODULUS_BITS,
          * and fallback only if unavailable */
         ret = OSSL_PARAM_set_int(p, group_size * 8);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS);
     if (p) {
         /* TODO: as above, plus use log() for intermediate values */
         int secbits = p11prov_eckm_secbits(group_size * 8);
         ret = OSSL_PARAM_set_int(p, secbits);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MAX_SIZE);
     if (p) {
         ret = OSSL_PARAM_set_int(p, group_size * 2);
-        if (ret != RET_OSSL_OK) goto done;
+        if (ret != RET_OSSL_OK) {
+            goto done;
+        }
     }
 
     ret = RET_OSSL_OK;

--- a/src/keys.c
+++ b/src/keys.c
@@ -29,7 +29,9 @@ static P11PROV_KEY *p11prov_key_new(void)
     P11PROV_KEY *key;
 
     key = OPENSSL_zalloc(sizeof(P11PROV_KEY));
-    if (!key) return NULL;
+    if (!key) {
+        return NULL;
+    }
 
     key->refcnt = 1;
 
@@ -49,7 +51,9 @@ void p11prov_key_free(P11PROV_KEY *key)
 {
     p11prov_debug("key free (%p)\n", key);
 
-    if (key == NULL) return;
+    if (key == NULL) {
+        return;
+    }
     if (__atomic_sub_fetch(&key->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
         p11prov_debug("key free: reference held\n");
         return;
@@ -68,7 +72,9 @@ void p11prov_key_free(P11PROV_KEY *key)
 
 CK_ATTRIBUTE *p11prov_key_attr(P11PROV_KEY *key, CK_ATTRIBUTE_TYPE type)
 {
-    if (!key) return NULL;
+    if (!key) {
+        return NULL;
+    }
 
     for (int i = 0; i < key->numattrs; i++) {
         if (key->attrs[i].type == type) {
@@ -81,25 +87,33 @@ CK_ATTRIBUTE *p11prov_key_attr(P11PROV_KEY *key, CK_ATTRIBUTE_TYPE type)
 
 CK_KEY_TYPE p11prov_key_type(P11PROV_KEY *key)
 {
-    if (key) return key->type;
+    if (key) {
+        return key->type;
+    }
     return CK_UNAVAILABLE_INFORMATION;
 }
 
 CK_SLOT_ID p11prov_key_slotid(P11PROV_KEY *key)
 {
-    if (key) return key->slotid;
+    if (key) {
+        return key->slotid;
+    }
     return CK_UNAVAILABLE_INFORMATION;
 }
 
 CK_OBJECT_HANDLE p11prov_key_handle(P11PROV_KEY *key)
 {
-    if (key) return key->handle;
+    if (key) {
+        return key->handle;
+    }
     return CK_INVALID_HANDLE;
 }
 
 CK_ULONG p11prov_key_size(P11PROV_KEY *key)
 {
-    if (key == NULL) return CK_UNAVAILABLE_INFORMATION;
+    if (key == NULL) {
+        return CK_UNAVAILABLE_INFORMATION;
+    }
     return key->key_size;
 }
 
@@ -212,7 +226,9 @@ static P11PROV_KEY *object_handle_to_key(CK_FUNCTION_LIST *f, CK_SLOT_ID slotid,
     int ret;
 
     key = p11prov_key_new();
-    if (key == NULL) return NULL;
+    if (key == NULL) {
+        return NULL;
+    }
 
     key_type = &key->type;
     FA_ASSIGN_ALL(attrs[0], CKA_KEY_TYPE, &key_type, &key_type_len, false,
@@ -280,7 +296,9 @@ int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
 
     p11prov_debug("Find keys\n");
 
-    if (f == NULL) return result;
+    if (f == NULL) {
+        return result;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -305,7 +323,9 @@ again:
             CK_OBJECT_HANDLE object;
             /* TODO: pull multiple objects at once to reduce roundtrips */
             ret = f->C_FindObjects(session, &object, 1, &objcount);
-            if (ret != CKR_OK || objcount == 0) break;
+            if (ret != CKR_OK || objcount == 0) {
+                break;
+            }
 
             key = object_handle_to_key(f, slotid, class, session, object);
 
@@ -380,7 +400,9 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                   session, secret, secretlen);
 
     f = p11prov_ctx_fns(provctx);
-    if (f == NULL) return NULL;
+    if (f == NULL) {
+        return NULL;
+    }
 
     ret = f->C_GetSessionInfo(session, &session_info);
     if (ret != CKR_OK) {
@@ -400,7 +422,9 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
     }
 
     key = p11prov_key_new();
-    if (key == NULL) return NULL;
+    if (key == NULL) {
+        return NULL;
+    }
 
     key->type = key_type;
     key->slotid = session_info.slotID;

--- a/src/provider.c
+++ b/src/provider.c
@@ -30,7 +30,9 @@ struct p11prov_ctx {
 
 int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots)
 {
-    if (!ctx->initialized) return RET_OSSL_ERR;
+    if (!ctx->initialized) {
+        return RET_OSSL_ERR;
+    }
 
     pthread_mutex_lock(&ctx->lock);
 
@@ -40,7 +42,9 @@ int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots)
 
 void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots)
 {
-    if (!ctx->initialized) return;
+    if (!ctx->initialized) {
+        return;
+    }
 
     *slots = NULL;
 
@@ -49,7 +53,9 @@ void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots)
 
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx)
 {
-    if (!ctx->initialized) return NULL;
+    if (!ctx->initialized) {
+        return NULL;
+    }
     return ctx->libctx;
 }
 
@@ -130,7 +136,9 @@ void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
 {
     va_list args;
 
-    if (!core_new_error || !core_vset_error) return;
+    if (!core_new_error || !core_vset_error) {
+        return;
+    }
 
     va_start(args, fmt);
     core_new_error(ctx->handle);
@@ -161,26 +169,34 @@ static int p11prov_get_params(void *provctx, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
     if (p != NULL) {
         ret = OSSL_PARAM_set_utf8_ptr(p, "PKCS#11 Provider");
-        if (ret == 0) return RET_OSSL_ERR;
+        if (ret == 0) {
+            return RET_OSSL_ERR;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
     if (p != NULL) {
         /* temporarily return the OpenSSL build version */
         ret = OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR);
-        if (ret == 0) return RET_OSSL_ERR;
+        if (ret == 0) {
+            return RET_OSSL_ERR;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
     if (p != NULL) {
         /* temporarily return the OpenSSL build version */
         ret = OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR);
-        if (ret == 0) return RET_OSSL_ERR;
+        if (ret == 0) {
+            return RET_OSSL_ERR;
+        }
     }
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
     if (p != NULL) {
         /* return 1 for now,
          * return 0 in future if there are module issues? */
         ret = OSSL_PARAM_set_int(p, 1);
-        if (ret == 0) return RET_OSSL_ERR;
+        if (ret == 0) {
+            return RET_OSSL_ERR;
+        }
     }
     return RET_OSSL_OK;
 }
@@ -580,7 +596,9 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     CK_INFO ck_info = { 0 };
     int ret;
 
-    if (ctx->initialized) return 0;
+    if (ctx->initialized) {
+        return 0;
+    }
 
     pthread_mutex_init(&ctx->lock, 0);
 
@@ -597,8 +615,9 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
     c_get_function_list = dlsym(ctx->dlhandle, "C_GetFunctionList");
     if (c_get_function_list) {
         ret = c_get_function_list(&ctx->fns);
-    } else
+    } else {
         ret = CKR_GENERAL_ERROR;
+    }
     if (ret != CKR_OK) {
         char *err = dlerror();
         p11prov_debug("dlsym() failed: %s\n", err);

--- a/src/signature.c
+++ b/src/signature.c
@@ -33,7 +33,9 @@ static P11PROV_SIG_CTX *p11prov_sig_newctx(P11PROV_CTX *ctx,
     P11PROV_SIG_CTX *sigctx;
 
     sigctx = OPENSSL_zalloc(sizeof(P11PROV_SIG_CTX));
-    if (sigctx == NULL) return NULL;
+    if (sigctx == NULL) {
+        return NULL;
+    }
 
     sigctx->provctx = ctx;
 
@@ -62,14 +64,20 @@ static void *p11prov_sig_dupctx(void *ctx)
     CK_ULONG state_len;
     int ret;
 
-    if (sigctx == NULL) return NULL;
+    if (sigctx == NULL) {
+        return NULL;
+    }
 
     f = p11prov_ctx_fns(sigctx->provctx);
-    if (f == NULL) return NULL;
+    if (f == NULL) {
+        return NULL;
+    }
 
     newctx = p11prov_sig_newctx(sigctx->provctx, sigctx->mechtype,
                                 sigctx->properties);
-    if (newctx == NULL) return NULL;
+    if (newctx == NULL) {
+        return NULL;
+    }
 
     newctx->priv_key = p11prov_key_ref(sigctx->priv_key);
     newctx->pub_key = p11prov_key_ref(sigctx->pub_key);
@@ -77,7 +85,9 @@ static void *p11prov_sig_dupctx(void *ctx)
     newctx->digest = sigctx->digest;
     newctx->pss_params = sigctx->pss_params;
 
-    if (sigctx->session == CK_INVALID_HANDLE) goto done;
+    if (sigctx->session == CK_INVALID_HANDLE) {
+        goto done;
+    }
 
     /* This is not really funny. OpenSSL by dfault asume contexts with
      * operations in flight can be easily duplicated, with all the
@@ -153,11 +163,15 @@ static void p11prov_sig_freectx(void *ctx)
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
 
-    if (sigctx == NULL) return;
+    if (sigctx == NULL) {
+        return;
+    }
 
     if (sigctx->session != CK_INVALID_HANDLE) {
         CK_FUNCTION_LIST *f = p11prov_ctx_fns(sigctx->provctx);
-        if (f) f->C_CloseSession(sigctx->session);
+        if (f) {
+            f->C_CloseSession(sigctx->session);
+        }
     }
 
     p11prov_key_free(sigctx->priv_key);
@@ -265,7 +279,9 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
         }
     }
 
-    if (!digest_sign) return CKR_OK;
+    if (!digest_sign) {
+        return CKR_OK;
+    }
 
     switch (sigctx->mechtype) {
     case CKM_RSA_PKCS:
@@ -317,8 +333,12 @@ static int p11prov_sig_get_sig_size(void *ctx, size_t *siglen)
     CK_KEY_TYPE type = p11prov_key_type(ANYKEY(sigctx));
     CK_ULONG size = p11prov_key_size(ANYKEY(sigctx));
 
-    if (type == CK_UNAVAILABLE_INFORMATION) return RET_OSSL_ERR;
-    if (size == CK_UNAVAILABLE_INFORMATION) return RET_OSSL_ERR;
+    if (type == CK_UNAVAILABLE_INFORMATION) {
+        return RET_OSSL_ERR;
+    }
+    if (size == CK_UNAVAILABLE_INFORMATION) {
+        return RET_OSSL_ERR;
+    }
 
     switch (type) {
     case CKK_RSA:
@@ -358,7 +378,9 @@ static int p11prov_sig_op_init(void *ctx, void *provkey, CK_FLAGS operation,
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
 
     sigctx->priv_key = p11prov_object_get_key(obj, true);
-    if (sigctx->priv_key == NULL) return RET_OSSL_ERR;
+    if (sigctx->priv_key == NULL) {
+        return RET_OSSL_ERR;
+    }
     sigctx->pub_key = p11prov_object_get_key(obj, false);
 
     sigctx->operation = operation;
@@ -386,7 +408,9 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx, bool digest_op,
     int ret;
 
     f = p11prov_ctx_fns(sigctx->provctx);
-    if (f == NULL) return CKR_GENERAL_ERROR;
+    if (f == NULL) {
+        return CKR_GENERAL_ERROR;
+    }
 
     switch (sigctx->operation) {
     case CKF_SIGN:
@@ -413,7 +437,9 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx, bool digest_op,
     }
 
     ret = p11prov_sig_set_mechanism(sigctx, digest_op, &mechanism);
-    if (ret != CKR_OK) return ret;
+    if (ret != CKR_OK) {
+        return ret;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -463,7 +489,9 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     int ret;
 
     if (sig == NULL) {
-        if (sigctx->operation == CKF_VERIFY) return RET_OSSL_ERR;
+        if (sigctx->operation == CKF_VERIFY) {
+            return RET_OSSL_ERR;
+        }
         return p11prov_sig_get_sig_size(sigctx, siglen);
     }
 
@@ -479,10 +507,14 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     }
 
     ret = p11prov_sig_operate_init(sigctx, false, &session);
-    if (ret != CKR_OK) return RET_OSSL_ERR;
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     f = p11prov_ctx_fns(sigctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     if (sigctx->operation == CKF_SIGN) {
         ret = f->C_Sign(session, tbs, tbslen, sig, &sig_size);
@@ -499,7 +531,9 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
         goto endsess;
     }
 
-    if (siglen) *siglen = sig_size;
+    if (siglen) {
+        *siglen = sig_size;
+    }
     result = RET_OSSL_OK;
 
 endsess:
@@ -519,11 +553,15 @@ static int p11prov_sig_digest_update(P11PROV_SIG_CTX *sigctx,
     int ret;
 
     f = p11prov_ctx_fns(sigctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     if (sigctx->session == CK_INVALID_HANDLE) {
         ret = p11prov_sig_operate_init(sigctx, true, &sigctx->session);
-        if (ret != CKR_OK) return RET_OSSL_ERR;
+        if (ret != CKR_OK) {
+            return RET_OSSL_ERR;
+        }
     }
 
     /* we have an initialized session */
@@ -561,15 +599,21 @@ static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     int result = RET_OSSL_ERR;
     int ret;
 
-    if (sigctx->session == CK_INVALID_HANDLE) return RET_OSSL_ERR;
+    if (sigctx->session == CK_INVALID_HANDLE) {
+        return RET_OSSL_ERR;
+    }
 
     if (sig == NULL) {
-        if (sigctx->operation == CKF_VERIFY) return RET_OSSL_ERR;
+        if (sigctx->operation == CKF_VERIFY) {
+            return RET_OSSL_ERR;
+        }
         return p11prov_sig_get_sig_size(sigctx, siglen);
     }
 
     f = p11prov_ctx_fns(sigctx->provctx);
-    if (f == NULL) return RET_OSSL_ERR;
+    if (f == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     if (sigctx->operation == CKF_SIGN) {
         ret = f->C_SignFinal(sigctx->session, sig, &sig_size);
@@ -586,7 +630,9 @@ static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     }
 
     if (ret == CKR_OK) {
-        if (siglen) *siglen = sig_size;
+        if (siglen) {
+            *siglen = sig_size;
+        }
         result = RET_OSSL_OK;
     }
 
@@ -623,7 +669,9 @@ static void *p11prov_rsasig_newctx(void *provctx, const char *properties)
 
     /* PKCS1.5 is the default, PSS set via padding params */
     sigctx = p11prov_sig_newctx(ctx, CKM_RSA_PKCS, properties);
-    if (sigctx == NULL) return NULL;
+    if (sigctx == NULL) {
+        return NULL;
+    }
 
     /* default PSS Params */
     sigctx->pss_params.hashAlg = CKM_SHA_1;
@@ -642,7 +690,9 @@ static int p11prov_rsasig_sign_init(void *ctx, void *provkey,
                   params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, NULL, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_rsasig_set_ctx_params(ctx, params);
 }
@@ -668,7 +718,9 @@ static int p11prov_rsasig_verify_init(void *ctx, void *provkey,
                   params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, NULL, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_rsasig_set_ctx_params(ctx, params);
 }
@@ -695,7 +747,9 @@ static int p11prov_rsasig_digest_sign_init(void *ctx, const char *digest,
                   provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, digest, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_rsasig_set_ctx_params(ctx, params);
 }
@@ -709,7 +763,9 @@ static int p11prov_rsasig_digest_sign_update(void *ctx,
     p11prov_debug("rsa digest sign update (ctx=%p, data=%p, datalen=%zu)\n",
                   ctx, data, datalen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_update(sigctx, (void *)data, datalen);
 }
@@ -724,7 +780,9 @@ static int p11prov_rsasig_digest_sign_final(void *ctx, unsigned char *sig,
         "sigsize=%zu)\n",
         ctx, sig, *siglen, sigsize);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_final(sigctx, sig, siglen, sigsize);
 }
@@ -739,7 +797,9 @@ static int p11prov_rsasig_digest_verify_init(void *ctx, const char *digest,
                   provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, digest, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_rsasig_set_ctx_params(ctx, params);
 }
@@ -753,7 +813,9 @@ static int p11prov_rsasig_digest_verify_update(void *ctx,
     p11prov_debug("rsa digest verify update (ctx=%p, data=%p, datalen=%zu)\n",
                   ctx, data, datalen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_update(sigctx, (void *)data, datalen);
 }
@@ -767,7 +829,9 @@ static int p11prov_rsasig_digest_verify_final(void *ctx,
     p11prov_debug("rsa digest verify final (ctx=%p, sig=%p, siglen=%zu)\n", ctx,
                   sig, siglen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_final(sigctx, (void *)sig, NULL, siglen);
 }
@@ -796,13 +860,17 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p11prov_debug("rsasig get ctx params (ctx=%p, params=%p)\n", ctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
         const char *digest = p11prov_sig_digest_name(sigctx->digest);
         ret = OSSL_PARAM_set_utf8_string(p, digest);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_PAD_MODE);
@@ -821,14 +889,18 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
                 break;
             }
         }
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_MGF1_DIGEST);
     if (p) {
         const char *digest = p11prov_sig_mgf_name(sigctx->pss_params.mgf);
         ret = OSSL_PARAM_set_utf8_string(p, digest);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     return RET_OSSL_OK;
@@ -843,14 +915,18 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     p11prov_debug("rsasig set ctx params (ctx=%p, params=%p)\n", sigctx,
                   params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         sigctx->digest = p11prov_sig_map_digest(digest);
         if (sigctx->digest == CK_UNAVAILABLE_INFORMATION) {
@@ -866,7 +942,9 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
             int pad_mode;
             /* legacy pad mode number */
             ret = OSSL_PARAM_get_int(p, &pad_mode);
-            if (ret != RET_OSSL_OK) return ret;
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
             for (int i = 0; padding_map[i].string != NULL; i++) {
                 if (padding_map[i].ossl_id == pad_mode) {
                     mechtype = padding_map[i].type;
@@ -908,12 +986,16 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         if (p->data_type == OSSL_PARAM_INTEGER) {
             /* legacy saltlen number */
             ret = OSSL_PARAM_get_int(p, &saltlen);
-            if (ret != RET_OSSL_OK) return ret;
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
             sigctx->pss_params.sLen = saltlen;
         } else if (p->data_type == OSSL_PARAM_UTF8_STRING) {
             if (strcmp(p->data, OSSL_PKEY_RSA_PSS_SALT_LEN_DIGEST) == 0) {
                 ret = p11prov_rsasig_set_pss_saltlen_from_digest(sigctx);
-                if (ret != RET_OSSL_OK) return ret;
+                if (ret != RET_OSSL_OK) {
+                    return ret;
+                }
             } else if (strcmp(p->data, OSSL_PKEY_RSA_PSS_SALT_LEN_MAX) == 0) {
                 ERR_raise_data(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED,
                                "saltlen=max is unsupported.");
@@ -924,7 +1006,9 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
                 return RET_OSSL_ERR;
             } else {
                 saltlen = atoi(p->data);
-                if (saltlen == 0) return RET_OSSL_ERR;
+                if (saltlen == 0) {
+                    return RET_OSSL_ERR;
+                }
                 sigctx->pss_params.sLen = saltlen;
             }
         } else {
@@ -937,7 +1021,9 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         sigctx->pss_params.mgf = p11prov_sig_map_mgf(digest);
         if (sigctx->pss_params.mgf == CK_UNAVAILABLE_INFORMATION) {
@@ -1019,7 +1105,9 @@ static void *p11prov_ecdsa_newctx(void *provctx, const char *properties)
     P11PROV_SIG_CTX *sigctx;
 
     sigctx = p11prov_sig_newctx(ctx, CKM_ECDSA, properties);
-    if (sigctx == NULL) return NULL;
+    if (sigctx == NULL) {
+        return NULL;
+    }
 
     return sigctx;
 }
@@ -1033,7 +1121,9 @@ static int p11prov_ecdsa_sign_init(void *ctx, void *provkey,
                   params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, NULL, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_ecdsa_set_ctx_params(ctx, params);
 }
@@ -1059,7 +1149,9 @@ static int p11prov_ecdsa_verify_init(void *ctx, void *provkey,
                   provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, NULL, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_ecdsa_set_ctx_params(ctx, params);
 }
@@ -1086,7 +1178,9 @@ static int p11prov_ecdsa_digest_sign_init(void *ctx, const char *digest,
                   provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_SIGN, digest, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_ecdsa_set_ctx_params(ctx, params);
 }
@@ -1100,7 +1194,9 @@ static int p11prov_ecdsa_digest_sign_update(void *ctx,
     p11prov_debug("ecdsa digest sign update (ctx=%p, data=%p, datalen=%zu)\n",
                   ctx, data, datalen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_update(sigctx, (void *)data, datalen);
 }
@@ -1115,7 +1211,9 @@ static int p11prov_ecdsa_digest_sign_final(void *ctx, unsigned char *sig,
         "sigsize=%zu)\n",
         ctx, sig, *siglen, sigsize);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_final(sigctx, sig, siglen, sigsize);
 }
@@ -1130,7 +1228,9 @@ static int p11prov_ecdsa_digest_verify_init(void *ctx, const char *digest,
                   provkey, params);
 
     ret = p11prov_sig_op_init(ctx, provkey, CKF_VERIFY, digest, params);
-    if (ret != RET_OSSL_OK) return ret;
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
 
     return p11prov_ecdsa_set_ctx_params(ctx, params);
 }
@@ -1146,7 +1246,9 @@ static int p11prov_ecdsa_digest_verify_update(void *ctx,
         "datalen=%zu)\n",
         ctx, data, datalen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_update(sigctx, (void *)data, datalen);
 }
@@ -1160,7 +1262,9 @@ static int p11prov_ecdsa_digest_verify_final(void *ctx,
     p11prov_debug("ecdsa digest verify final (ctx=%p, sig=%p, siglen=%zu)\n",
                   ctx, sig, siglen);
 
-    if (sigctx == NULL) return RET_OSSL_ERR;
+    if (sigctx == NULL) {
+        return RET_OSSL_ERR;
+    }
 
     return p11prov_sig_digest_final(sigctx, (void *)sig, NULL, siglen);
 }
@@ -1181,7 +1285,9 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
     if (p) {
         const char *digest = p11prov_sig_digest_name(sigctx->digest);
         ret = OSSL_PARAM_set_utf8_string(p, digest);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
     }
 
     return RET_OSSL_ERR;
@@ -1195,14 +1301,18 @@ static int p11prov_ecdsa_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p11prov_debug("ecdsa set ctx params (ctx=%p, params=%p)\n", sigctx, params);
 
-    if (params == NULL) return RET_OSSL_OK;
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
         char digest[256];
         char *ptr = digest;
         ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
-        if (ret != RET_OSSL_OK) return ret;
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
 
         sigctx->digest = p11prov_sig_map_digest(digest);
         if (sigctx->digest == CK_UNAVAILABLE_INFORMATION) {

--- a/src/util.c
+++ b/src/util.c
@@ -36,7 +36,9 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
                 /* always allocate and zero one more, so that
                  * zero terminated strings work automatically */
                 char *a = OPENSSL_zalloc(q[i].ulValueLen + 1);
-                if (a == NULL) return -ENOMEM;
+                if (a == NULL) {
+                    return -ENOMEM;
+                }
                 FA_RETURN_VAL(attrs[i], a, q[i].ulValueLen);
 
                 CKATTR_ASSIGN_ALL(r[retrnums], attrs[i].type, *attrs[i].value,
@@ -59,10 +61,14 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
                 CKATTR_ASSIGN_ALL(q[0], attrs[i].type, NULL, 0);
                 ret = f->C_GetAttributeValue(session, object, q, 1);
                 if (ret != CKR_OK) {
-                    if (attrs[i].required) return ret;
+                    if (attrs[i].required) {
+                        return ret;
+                    }
                 } else {
                     char *a = OPENSSL_zalloc(q[0].ulValueLen + 1);
-                    if (a == NULL) return -ENOMEM;
+                    if (a == NULL) {
+                        return -ENOMEM;
+                    }
                     FA_RETURN_VAL(attrs[i], a, q[0].ulValueLen);
                 }
             }
@@ -73,7 +79,9 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
                 if (r[i].ulValueLen == CK_UNAVAILABLE_INFORMATION) {
                     FA_RETURN_LEN(attrs[i], 0);
                 }
-                if (attrs[i].required) return ret;
+                if (attrs[i].required) {
+                    return ret;
+                }
             }
             p11prov_debug("Attribute| type:%lu value:%p, len:%lu\n",
                           attrs[i].type, *attrs[i].value, *attrs[i].value_len);
@@ -97,8 +105,12 @@ CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid)
 
         for (int i = 0; i < nslots; i++) {
             /* ignore slots that are not initialized */
-            if (slots[i].slot.flags & CKF_TOKEN_PRESENT == 0) continue;
-            if (slots[i].token.flags & CKF_TOKEN_INITIALIZED == 0) continue;
+            if (slots[i].slot.flags & CKF_TOKEN_PRESENT == 0) {
+                continue;
+            }
+            if (slots[i].token.flags & CKF_TOKEN_INITIALIZED == 0) {
+                continue;
+            }
 
             slotid = slots[i].id;
         }
@@ -106,10 +118,14 @@ CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid)
         p11prov_ctx_unlock_slots(provctx, &slots);
     }
 
-    if (slotid == CK_UNAVAILABLE_INFORMATION) goto done;
+    if (slotid == CK_UNAVAILABLE_INFORMATION) {
+        goto done;
+    }
 
     f = p11prov_ctx_fns(provctx);
-    if (f == NULL) goto done;
+    if (f == NULL) {
+        goto done;
+    }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
     if (ret != CKR_OK) {
@@ -127,7 +143,9 @@ void p11prov_put_session(P11PROV_CTX *provctx, CK_SESSION_HANDLE session)
     CK_RV ret;
 
     f = p11prov_ctx_fns(provctx);
-    if (f == NULL) return;
+    if (f == NULL) {
+        return;
+    }
 
     ret = f->C_CloseSession(session);
     if (ret != CKR_OK) {


### PR DESCRIPTION
As the clang-format doesn't have (yet) the capability to add braces around single read statements, clang-tidy needs to be used for this.