### PR TITLE
Add GitHub Action that runs Clang's scan-build

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,0 +1,34 @@
+name: Scan Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: CI with softoken
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout Repository
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y autoconf-archive clang-tools
+    - name: Setup
+      run: |
+        autoreconf -fiv
+        ./configure
+    - name: Scan Build
+      run: |
+        scan-build --html-title="PKCS#11 Provider ($GITHUB_SHA)" \
+                  --keep-cc \
+                  --status-bugs \
+                  --keep-going \
+                  -o scan-build.reports make
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: Scan Build logs
+        path: |
+          scan-build.reports/


### PR DESCRIPTION
Run scan-build on any new pull request. Save the report in case of bugs
found.