### PR TITLE
Enable all (most) of the warnings as errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,26 @@ AX_CHECK_COMPILE_FLAG([-std=c11],
                       AC_MSG_ERROR([C compiler must support at least C11 standard])
 )
 
+STD_CFLAGS="-Wall -Wextra -Wwrite-strings -Wpointer-arith -Wno-missing-field-initializers -Wformat -Wshadow"
+
+# Temporarily disable unused parameter until the implementation is complete
+STD_CFLAGS="$STD_CFLAGS -Wno-unused-parameter"
+
+# These should be always errors
+STD_CFLAGS="$STD_CFLAGS -Werror=implicit-function-declaration -Werror=missing-prototypes -Werror=format-security -Werror=parentheses -Werror=implicit -Werror=strict-prototypes"
+
+# Don't enable warnings on VLA yet, but I would avoid using VLAs
+# STD_CFLAGS"$STD_CFLAGS -Werror=vla"
+
+AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing],
+		      [STD_CFLAGS="$STD_CFLAGS -fno-strict-aliasing"])
+AX_CHECK_COMPILE_FLAG([-Werror -fno-delete-null-pointer-checks],
+		      [STD_CFLAGS="$STD_CFLAGS -fno-delete-null-pointer-checks"])
+AX_CHECK_COMPILE_FLAG([-fdiagnostics-show-option],
+		      [STD_CFLAGS="$STD_CFLAGS -fdiagnostics-show-option"])
+
+AC_SUBST([STD_CFLAGS])
+
 # Checks for libraries.
 PKG_CHECK_MODULES(
 	[OPENSSL],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,6 @@
 
+AM_CFLAGS = $(STD_CFLAGS)
+
 noinst_HEADERS = pkcs11.h provider.h
 lib_LTLIBRARIES = pkcs11_provider.la
 
@@ -24,7 +26,7 @@ pkcs11_provider_la_SOURCES = \
 	provider.exports \
 	$(NULL)
 
-pkcs11_provider_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
+pkcs11_provider_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS) -Wall -Werror
 pkcs11_provider_la_LIBADD = $(OPENSSL_LIBS)
 
 pkcs11_provider_la_LDFLAGS = \

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -61,7 +61,6 @@ static void *p11prov_rsaenc_dupctx(void *ctx)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     struct p11prov_rsaenc_ctx *newctx;
-    int ret;
 
     if (encctx == NULL) {
         return NULL;
@@ -93,7 +92,6 @@ static void *p11prov_rsaenc_dupctx(void *ctx)
 static int p11prov_rsaenc_set_mechanism(void *ctx, CK_MECHANISM *mechanism)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
-    int result;
 
     mechanism->mechanism = encctx->mechtype;
     mechanism->pParameter = NULL;
@@ -315,7 +313,7 @@ endsess:
 
 static struct {
     CK_MECHANISM_TYPE type;
-    unsigned int ossl_id;
+    int ossl_id;
     const char *string;
 } padding_map[] = {
     { CKM_RSA_X_509, RSA_NO_PADDING, OSSL_PKEY_RSA_PAD_MODE_NONE },

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -117,7 +117,6 @@ static void *p11prov_ecdh_dupctx(void *ctx)
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_EXCH_CTX *newctx;
-    int ret;
 
     if (ecdhctx == NULL) {
         return NULL;

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -316,7 +316,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
     /* can be multiple paramaters, which wil be all concatenated */
     for (p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO); p != NULL;
          p = OSSL_PARAM_locate_const(p + 1, OSSL_KDF_PARAM_INFO)) {
-        void *ptr;
+        uint8_t *ptr;
         size_t len;
 
         if (p->data_size == 0 || p->data == NULL) {
@@ -357,7 +357,6 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
 {
     P11PROV_KDF_CTX *hkdfctx = (P11PROV_KDF_CTX *)ctx;
     OSSL_PARAM *p;
-    int ret;
 
     p11prov_debug("hkdf get ctx params (ctx=%p, params=%p)\n", hkdfctx, params);
 

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -172,13 +172,13 @@ static int p11prov_rsakm_secbits(int bits)
      * see ossl_ifc_ffc_compute_security_bits() */
 
     /* NOLINTBEGIN(readability-braces-around-statements) */
-    if (bits > 15360) return 256;
-    if (bits > 8192) return 200;
-    if (bits > 7680) return 192;
-    if (bits > 6144) return 176;
-    if (bits > 4096) return 152;
-    if (bits > 3072) return 128;
-    if (bits > 2048) return 112;
+    if (bits >= 15360) return 256;
+    if (bits >= 8192) return 200;
+    if (bits >= 7680) return 192;
+    if (bits >= 6144) return 176;
+    if (bits >= 4096) return 152;
+    if (bits >= 3072) return 128;
+    if (bits >= 2048) return 112;
     /* NOLINTEND(readability-braces-around-statements) */
 
     return 0;
@@ -440,7 +440,6 @@ static int p11prov_eckm_secbits(int bits)
 static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
 {
     P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
-    CK_ATTRIBUTE *modulus;
     P11PROV_KEY *key;
     OSSL_PARAM *p;
     CK_ULONG group_size;

--- a/src/keys.c
+++ b/src/keys.c
@@ -62,7 +62,7 @@ void p11prov_key_free(P11PROV_KEY *key)
     OPENSSL_free(key->id);
     OPENSSL_free(key->label);
 
-    for (int i = 0; i < key->numattrs; i++) {
+    for (size_t i = 0; i < key->numattrs; i++) {
         OPENSSL_free(key->attrs[i].pValue);
     }
     OPENSSL_free(key->attrs);
@@ -76,7 +76,7 @@ CK_ATTRIBUTE *p11prov_key_attr(P11PROV_KEY *key, CK_ATTRIBUTE_TYPE type)
         return NULL;
     }
 
-    for (int i = 0; i < key->numattrs; i++) {
+    for (size_t i = 0; i < key->numattrs; i++) {
         if (key->attrs[i].type == type) {
             return &key->attrs[i];
         }
@@ -161,7 +161,7 @@ static int fetch_ec_public_key(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
     struct fetch_attrs attrs[2];
     unsigned long params_len = 0, point_len = 0;
     CK_BYTE *params = NULL, *point = NULL;
-    size_t n_bytes;
+    size_t n_bytes = 0;
     int ret;
 
     FA_ASSIGN_ALL(attrs[0], CKA_EC_PARAMS, &params, &params_len, true, true);
@@ -222,7 +222,6 @@ static P11PROV_KEY *object_handle_to_key(CK_FUNCTION_LIST *f, CK_SLOT_ID slotid,
     unsigned long key_type_len = sizeof(CKA_KEY_TYPE);
     unsigned long label_len;
     struct fetch_attrs attrs[3];
-    unsigned long aa_len = 0;
     int ret;
 
     key = p11prov_key_new();
@@ -440,7 +439,6 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
         p11prov_debug("Failed to query object attributes (%d)\n", ret);
     }
 
-done:
     if (ret != CKR_OK) {
         p11prov_key_free(key);
         key = NULL;

--- a/src/provider.c
+++ b/src/provider.c
@@ -106,7 +106,7 @@ static OSSL_FUNC_core_new_error_fn *core_new_error = NULL;
 static OSSL_FUNC_core_set_error_debug_fn *core_set_error_debug = NULL;
 static OSSL_FUNC_core_vset_error_fn *core_vset_error = NULL;
 
-void p11prov_get_core_dispatch_funcs(const OSSL_DISPATCH *in)
+static void p11prov_get_core_dispatch_funcs(const OSSL_DISPATCH *in)
 {
     const OSSL_DISPATCH *iter_in;
 
@@ -330,110 +330,115 @@ static int p11prov_get_capabilities(void *provctx, const char *capability,
 
 static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
 {
+#define C(str) (void *)(str)
     static const OSSL_ITEM reason_strings[] = {
-        { CKR_HOST_MEMORY, "Host out of memory error" },
-        { CKR_SLOT_ID_INVALID, "The specified slot ID is not valid" },
-        { CKR_GENERAL_ERROR, "General Error" },
+        { CKR_HOST_MEMORY, C("Host out of memory error") },
+        { CKR_SLOT_ID_INVALID, C("The specified slot ID is not valid") },
+        { CKR_GENERAL_ERROR, C("General Error") },
         { CKR_FUNCTION_FAILED,
-          "The requested function could not be performed" },
+          C("The requested function could not be performed") },
         { CKR_ARGUMENTS_BAD,
-          "Invalid or improper arguments were provided to the "
-          "invoked function" },
+          C("Invalid or improper arguments were provided to the "
+            "invoked function") },
         { CKR_ATTRIBUTE_READ_ONLY,
-          "Attempted to set or modify an attribute that is Read "
-          "Only for applications" },
+          C("Attempted to set or modify an attribute that is Read "
+            "Only for applications") },
         { CKR_ATTRIBUTE_TYPE_INVALID,
-          "Invalid attribute type specified in a template" },
+          C("Invalid attribute type specified in a template") },
         { CKR_ATTRIBUTE_VALUE_INVALID,
-          "Invalid value specified for attribute in a template" },
-        { CKR_DATA_INVALID,
-          "The plaintext input data to a cryptographic "
-          "operation is invalid" },
+          C("Invalid value specified for attribute in a template") },
+        { CKR_DATA_INVALID, C("The plaintext input data to a cryptographic "
+                              "operation is invalid") },
         { CKR_DATA_LEN_RANGE,
-          "The size of plaintext input data to a cryptographic "
-          "operation is invalid (Out of range)" },
+          C("The size of plaintext input data to a cryptographic "
+            "operation is invalid (Out of range)") },
         { CKR_DEVICE_ERROR,
-          "Some problem has occurred with the token and/or slot" },
+          C("Some problem has occurred with the token and/or slot") },
         { CKR_DEVICE_MEMORY,
-          "The token does not have sufficient memory to perform "
-          "the requested function" },
+          C("The token does not have sufficient memory to perform "
+            "the requested function") },
         { CKR_DEVICE_REMOVED,
-          "The token was removed from its slot during the "
-          "execution of the function" },
-        { CKR_FUNCTION_CANCELED, "The function was canceled in mid-execution" },
-        { CKR_KEY_HANDLE_INVALID, "The specified key handle is not valid" },
+          C("The token was removed from its slot during the "
+            "execution of the function") },
+        { CKR_FUNCTION_CANCELED,
+          C("The function was canceled in mid-execution") },
+        { CKR_KEY_HANDLE_INVALID, C("The specified key handle is not valid") },
         { CKR_KEY_SIZE_RANGE,
-          "Unable to handle the specified key size (Out of range)" },
+          C("Unable to handle the specified key size (Out of range)") },
         { CKR_KEY_TYPE_INCONSISTENT,
-          "The specified key is not the correct type of key to "
-          "use with the specified mechanism" },
+          C("The specified key is not the correct type of key to "
+            "use with the specified mechanism") },
         { CKR_KEY_FUNCTION_NOT_PERMITTED,
-          "The key attributes do not allow this operation to be executed" },
-        { CKR_MECHANISM_INVALID,
-          "An invalid mechanism was specified to the "
-          "cryptographic operation" },
+          C("The key attributes do not allow this operation to "
+            "be executed") },
+        { CKR_MECHANISM_INVALID, C("An invalid mechanism was specified to the "
+                                   "cryptographic operation") },
         { CKR_MECHANISM_PARAM_INVALID,
-          "Invalid mechanism parameters were supplied" },
+          C("Invalid mechanism parameters were supplied") },
         { CKR_OPERATION_ACTIVE,
-          "There is already an active operation that prevents "
-          "executing the requested function" },
+          C("There is already an active operation that prevents "
+            "executing the requested function") },
         { CKR_OPERATION_NOT_INITIALIZED,
-          "There is no active operation of appropriate type "
-          "in the specified session" },
-        { CKR_PIN_INCORRECT, "The specified PIN is incorrect" },
-        { CKR_PIN_EXPIRED, "The specified PIN has expired" },
-        { CKR_PIN_LOCKED, "The specified PIN is locked, and cannot be used" },
-        { CKR_SESSION_CLOSED, "Session is already closed" },
-        { CKR_SESSION_COUNT, "Too many sessions open" },
-        { CKR_SESSION_HANDLE_INVALID, "Invalid Session Handle" },
+          C("There is no active operation of appropriate type "
+            "in the specified session") },
+        { CKR_PIN_INCORRECT, C("The specified PIN is incorrect") },
+        { CKR_PIN_EXPIRED, C("The specified PIN has expired") },
+        { CKR_PIN_LOCKED,
+          C("The specified PIN is locked, and cannot be used") },
+        { CKR_SESSION_CLOSED, C("Session is already closed") },
+        { CKR_SESSION_COUNT, C("Too many sessions open") },
+        { CKR_SESSION_HANDLE_INVALID, C("Invalid Session Handle") },
         { CKR_SESSION_PARALLEL_NOT_SUPPORTED,
-          "Parallel sessions not supported" },
-        { CKR_SESSION_READ_ONLY, "Session is Read Only" },
-        { CKR_SESSION_EXISTS, "Session already exists" },
-        { CKR_SESSION_READ_ONLY_EXISTS, "A read-only session already exists" },
+          C("Parallel sessions not supported") },
+        { CKR_SESSION_READ_ONLY, C("Session is Read Only") },
+        { CKR_SESSION_EXISTS, C("Session already exists") },
+        { CKR_SESSION_READ_ONLY_EXISTS,
+          C("A read-only session already exists") },
         { CKR_SESSION_READ_WRITE_SO_EXISTS,
-          "A read/write SO session already exists" },
+          C("A read/write SO session already exists") },
         { CKR_TEMPLATE_INCOMPLETE,
-          "The template to create an object is incomplete" },
+          C("The template to create an object is incomplete") },
         { CKR_TEMPLATE_INCONSISTENT,
-          "The template to create an object has conflicting attributes" },
+          C("The template to create an object has conflicting attributes") },
         { CKR_TOKEN_NOT_PRESENT,
-          "The token was not present in its slot when the "
-          "function was invoked" },
-        { CKR_TOKEN_NOT_RECOGNIZED, "The token in the slot is not recognized" },
+          C("The token was not present in its slot when the "
+            "function was invoked") },
+        { CKR_TOKEN_NOT_RECOGNIZED,
+          C("The token in the slot is not recognized") },
         { CKR_TOKEN_WRITE_PROTECTED,
-          "Action denied because the token is write-protected" },
+          C("Action denied because the token is write-protected") },
         { CKR_TOKEN_WRITE_PROTECTED,
-          "Can't perform action because the token is write-protected" },
+          C("Can't perform action because the token is write-protected") },
         { CKR_USER_NOT_LOGGED_IN,
-          "The desired action cannot be performed because an "
-          "appropriate user is not logged in" },
-        { CKR_USER_PIN_NOT_INITIALIZED, "The user PIN is not initialized" },
-        { CKR_USER_TYPE_INVALID, "An invalid user type was specified" },
+          C("The desired action cannot be performed because an "
+            "appropriate user is not logged in") },
+        { CKR_USER_PIN_NOT_INITIALIZED, C("The user PIN is not initialized") },
+        { CKR_USER_TYPE_INVALID, C("An invalid user type was specified") },
         { CKR_USER_ANOTHER_ALREADY_LOGGED_IN,
-          "Another user is already logged in" },
+          C("Another user is already logged in") },
         { CKR_USER_TOO_MANY_TYPES,
-          "Attempted to log in more users than the token can support" },
-        { CKR_OPERATION_CANCEL_FAILED, "The operation cannot be cancelled" },
+          C("Attempted to log in more users than the token can support") },
+        { CKR_OPERATION_CANCEL_FAILED, C("The operation cannot be cancelled") },
         { CKR_DOMAIN_PARAMS_INVALID,
-          "Invalid or unsupported domain parameters were "
-          "supplied to the function" },
+          C("Invalid or unsupported domain parameters were "
+            "supplied to the function") },
         { CKR_CURVE_NOT_SUPPORTED,
-          "The specified curve is not supported by this token" },
+          C("The specified curve is not supported by this token") },
         { CKR_BUFFER_TOO_SMALL,
-          "The output of the function is too large to fit in "
-          "the supplied buffer" },
+          C("The output of the function is too large to fit in "
+            "the supplied buffer") },
         { CKR_SAVED_STATE_INVALID,
-          "The supplied saved cryptographic operations state is invalid" },
+          C("The supplied saved cryptographic operations state is invalid") },
         { CKR_STATE_UNSAVEABLE,
-          "The cryptographic operations state of the specified "
-          "session cannot be saved" },
+          C("The cryptographic operations state of the specified "
+            "session cannot be saved") },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
-          "PKCS11 Module has not been intialized yet" },
+          C("PKCS11 Module has not been intialized yet") },
         { 0, NULL },
     };
 
     return reason_strings;
+#undef C
 }
 
 /* Functions we provide to the core */
@@ -492,7 +497,7 @@ static int refresh_slot_profiles(P11PROV_CTX *ctx, struct p11prov_slot *slot)
         goto done;
     }
 
-    for (int i = 0; i < objcount; i++) {
+    for (size_t i = 0; i < objcount; i++) {
         CK_ULONG value = CK_UNAVAILABLE_INFORMATION;
         CK_ATTRIBUTE profileid = { CKA_PROFILE_ID, &value, sizeof(value) };
 
@@ -553,7 +558,7 @@ static int refresh_slots(P11PROV_CTX *ctx)
         goto done;
     }
 
-    for (int i = 0; i < nslots; i++) {
+    for (size_t i = 0; i < nslots; i++) {
         slots[i].id = slotid[i];
         ret = ctx->fns->C_GetSlotInfo(slotid[i], &slots[i].slot);
         if (ret == CKR_OK && slots[i].slot.flags & CKF_TOKEN_PRESENT) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -838,7 +838,7 @@ static int p11prov_rsasig_digest_verify_final(void *ctx,
 
 static struct {
     CK_MECHANISM_TYPE type;
-    unsigned int ossl_id;
+    int ossl_id;
     const char *string;
 } padding_map[] = {
     { CKM_RSA_X_509, RSA_NO_PADDING, OSSL_PKEY_RSA_PAD_MODE_NONE },

--- a/src/store.c
+++ b/src/store.c
@@ -139,8 +139,6 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
     OSSL_PARAM params[3];
     CK_ATTRIBUTE *n, *e;
     unsigned char *val;
-    int pidx = 0;
-    int ret = 0;
 
     if (p11prov_key_type(obj->pub_key) != CKK_RSA) {
         return RET_OSSL_ERR;
@@ -593,22 +591,22 @@ static int p11prov_store_load(void *ctx, OSSL_CALLBACK *object_cb,
              * deal with them in the default provider */
             switch (obj->expected_type) {
             case OSSL_STORE_INFO_PKEY:
-                data_type = P11PROV_NAMES_RSA;
+                data_type = (char *)P11PROV_NAMES_RSA;
                 break;
             case OSSL_STORE_INFO_PUBKEY:
-                data_type = "RSA";
+                data_type = (char *)"RSA";
                 break;
             default:
                 if (obj->priv_key) {
-                    data_type = P11PROV_NAMES_RSA;
+                    data_type = (char *)P11PROV_NAMES_RSA;
                 } else {
-                    data_type = "RSA";
+                    data_type = (char *)"RSA";
                 }
                 break;
             }
             break;
         case CKK_EC:
-            data_type = P11PROV_NAMES_ECDSA;
+            data_type = (char *)P11PROV_NAMES_ECDSA;
             break;
         default:
             return RET_OSSL_ERR;

--- a/src/util.c
+++ b/src/util.c
@@ -11,7 +11,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
     CK_ATTRIBUTE r[attrnums];
     int ret;
 
-    for (int i = 0; i < attrnums; i++) {
+    for (size_t i = 0; i < attrnums; i++) {
         if (attrs[i].allocate) {
             CKATTR_ASSIGN_ALL(q[i], attrs[i].type, NULL, 0);
         } else {
@@ -24,7 +24,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
     ret = f->C_GetAttributeValue(session, object, q, attrnums);
     if (ret == CKR_OK) {
         unsigned long retrnums = 0;
-        for (int i = 0; i < attrnums; i++) {
+        for (size_t i = 0; i < attrnums; i++) {
             if (q[i].ulValueLen == CK_UNAVAILABLE_INFORMATION) {
                 if (attrs[i].required) {
                     return -ENOENT;
@@ -35,7 +35,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
             if (attrs[i].allocate) {
                 /* always allocate and zero one more, so that
                  * zero terminated strings work automatically */
-                char *a = OPENSSL_zalloc(q[i].ulValueLen + 1);
+                uint8_t *a = OPENSSL_zalloc(q[i].ulValueLen + 1);
                 if (a == NULL) {
                     return -ENOMEM;
                 }
@@ -56,7 +56,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
         p11prov_debug("Quering attributes one by one\n");
         /* go one by one as this PKCS11 does not have some attributes
          * and does not handle it gracefully */
-        for (int i = 0; i < attrnums; i++) {
+        for (size_t i = 0; i < attrnums; i++) {
             if (attrs[i].allocate) {
                 CKATTR_ASSIGN_ALL(q[0], attrs[i].type, NULL, 0);
                 ret = f->C_GetAttributeValue(session, object, q, 1);
@@ -65,7 +65,7 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
                         return ret;
                     }
                 } else {
-                    char *a = OPENSSL_zalloc(q[0].ulValueLen + 1);
+                    uint8_t *a = OPENSSL_zalloc(q[0].ulValueLen + 1);
                     if (a == NULL) {
                         return -ENOMEM;
                     }
@@ -105,10 +105,10 @@ CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid)
 
         for (int i = 0; i < nslots; i++) {
             /* ignore slots that are not initialized */
-            if (slots[i].slot.flags & CKF_TOKEN_PRESENT == 0) {
+            if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
                 continue;
             }
-            if (slots[i].token.flags & CKF_TOKEN_INITIALIZED == 0) {
+            if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
                 continue;
             }
 


### PR DESCRIPTION
Enable -Wall -Wextra and couple of additional warnings and treat
them as errors.

Because the implementation is not complete, disable unused parameter
warning.

And fix all issues found.