### PR TITLE
Use OPENSSL_strcasecmp() instead of strcasecmp()

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -347,7 +347,7 @@ static CK_MECHANISM_TYPE p11prov_rsaenc_map_digest(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
-        if (strcasecmp(digest, digest_map[i].name) == 0) {
+        if (OPENSSL_strcasecmp(digest, digest_map[i].name) == 0) {
             return digest_map[i].digest;
         }
     }
@@ -358,7 +358,7 @@ static CK_RSA_PKCS_MGF_TYPE p11prov_rsaenc_map_mgf(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
-        if (strcasecmp(digest, digest_map[i].name) == 0) {
+        if (OPENSSL_strcasecmp(digest, digest_map[i].name) == 0) {
             return digest_map[i].mgf;
         }
     }

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -64,7 +64,7 @@ static CK_MECHANISM_TYPE p11prov_ecdh_map_digest(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
-        if (strcasecmp(digest, digest_map[i].name) == 0) {
+        if (OPENSSL_strcasecmp(digest, digest_map[i].name) == 0) {
             return digest_map[i].digest;
         }
     }

--- a/src/signature.c
+++ b/src/signature.c
@@ -229,7 +229,7 @@ static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
-        if (strcasecmp(digest, digest_map[i].name) == 0) {
+        if (OPENSSL_strcasecmp(digest, digest_map[i].name) == 0) {
             return digest_map[i].mgf;
         }
     }
@@ -240,7 +240,7 @@ static CK_MECHANISM_TYPE p11prov_sig_map_digest(const char *digest)
 {
     for (int i = 0; digest_map[i].name != NULL; i++) {
         /* hate to strcasecmp but openssl forces us to */
-        if (strcasecmp(digest, digest_map[i].name) == 0) {
+        if (OPENSSL_strcasecmp(digest, digest_map[i].name) == 0) {
             return digest_map[i].digest;
         }
     }


### PR DESCRIPTION
The OPENSSL_strcasecmp() uses "C" locale for case insensitive comparison
in POSIX-compatible system and on Windows.

Signed-off-by: Ondřej Surý <ondrej@sury.org>