### PR TITLE
Allow store to enumerate objects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,7 +46,7 @@ AlignArrayOfStructures: None
 AlignTrailingComments: false
 AllowShortFunctionsOnASingleLine: Empty
 AlwaysBreakBeforeMultilineStrings: true
-IndentGotoLabels: false
+IndentGotoLabels: true
 SortIncludes: Never
 SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: false

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -110,7 +110,7 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
                                        const OSSL_PARAM params[])
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
 
     p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
                   params);
@@ -214,7 +214,7 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
                                        const OSSL_PARAM params[])
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
 
     p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
                   params);

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -179,7 +179,7 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
                              const OSSL_PARAM params[])
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
 
     if (ctx == NULL || provkey == NULL) {
         return RET_OSSL_ERR;
@@ -197,7 +197,7 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
 static int p11prov_ecdh_set_peer(void *ctx, void *provkey)
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
 
     if (ctx == NULL || provkey == NULL) {
         return RET_OSSL_ERR;
@@ -605,7 +605,7 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
                                   const OSSL_PARAM params[])
 {
     P11PROV_EXCH_CTX *hkdfctx = (P11PROV_EXCH_CTX *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provobj;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provobj;
 
     p11prov_debug("hkdf exchange init (ctx:%p obj:%p params:%p)\n", ctx, obj,
                   params);

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -272,6 +272,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY);
     if (p) {
+        CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
         void *secret = NULL;
         size_t secret_len;
         /* TODO: import into a pkcs11 key? */
@@ -283,8 +284,8 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         /* Create Session  and key from key material */
 
         if (hkdfctx->session == CK_INVALID_HANDLE) {
-            hkdfctx->session = p11prov_get_session(hkdfctx->provctx,
-                                                   CK_UNAVAILABLE_INFORMATION);
+            hkdfctx->session = p11prov_get_session(hkdfctx->provctx, &slotid,
+                                                   NULL, NULL, NULL, NULL);
         }
         if (hkdfctx->session == CK_INVALID_HANDLE) {
             return RET_OSSL_ERR;

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -44,28 +44,20 @@ static void p11prov_rsakm_gen_cleanup(void *genctx)
 static void p11prov_rsakm_free(void *key)
 {
     p11prov_debug("rsa free %p\n", key);
-    p11prov_object_free((P11PROV_OBJECT *)key);
+    p11prov_object_free((P11PROV_OBJ *)key);
 }
 
 static void *p11prov_rsakm_load(const void *reference, size_t reference_sz)
 {
-    P11PROV_OBJECT *obj = NULL;
-
     p11prov_debug("rsa load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj)) {
-        return NULL;
-    }
-
     /* the contents of the reference is the address to our object */
-    obj = (P11PROV_OBJECT *)reference;
-
-    return obj;
+    return p11prov_obj_from_reference(reference, reference_sz);
 }
 
 static int p11prov_rsakm_has(const void *keydata, int selection)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
     p11prov_debug("rsa has %p %d\n", obj, selection);
 
@@ -98,7 +90,7 @@ static int p11prov_rsakm_import(void *keydata, int selection,
 static int p11prov_rsakm_export(void *keydata, int selection,
                                 OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
     p11prov_debug("rsa export %p\n", keydata);
 
@@ -186,7 +178,7 @@ static int p11prov_rsakm_secbits(int bits)
 
 static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
     CK_ATTRIBUTE *modulus;
     P11PROV_KEY *key;
     OSSL_PARAM *p;
@@ -314,28 +306,20 @@ static void p11prov_eckm_gen_cleanup(void *genctx)
 static void p11prov_eckm_free(void *key)
 {
     p11prov_debug("ec free %p\n", key);
-    p11prov_object_free((P11PROV_OBJECT *)key);
+    p11prov_object_free((P11PROV_OBJ *)key);
 }
 
 static void *p11prov_eckm_load(const void *reference, size_t reference_sz)
 {
-    P11PROV_OBJECT *obj = NULL;
-
     p11prov_debug("ec load %p, %ld\n", reference, reference_sz);
 
-    if (!reference || reference_sz != sizeof(obj)) {
-        return NULL;
-    }
-
     /* the contents of the reference is the address to our object */
-    obj = (P11PROV_OBJECT *)reference;
-
-    return obj;
+    return p11prov_obj_from_reference(reference, reference_sz);
 }
 
 static int p11prov_eckm_has(const void *keydata, int selection)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
     p11prov_debug("ec has %p %d\n", obj, selection);
 
@@ -368,7 +352,7 @@ static int p11prov_eckm_import(void *keydata, int selection,
 static int p11prov_eckm_export(void *keydata, int selection,
                                OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
     p11prov_debug("ec export %p\n", keydata);
 
@@ -439,7 +423,7 @@ static int p11prov_eckm_secbits(int bits)
 
 static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)keydata;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
     P11PROV_KEY *key;
     OSSL_PARAM *p;
     CK_ULONG group_size;

--- a/src/keys.c
+++ b/src/keys.c
@@ -278,11 +278,12 @@ static P11PROV_KEY *object_handle_to_key(CK_FUNCTION_LIST *f, CK_SLOT_ID slotid,
 }
 
 int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
-              CK_SLOT_ID slotid, CK_OBJECT_CLASS class, const unsigned char *id,
-              size_t id_len, const char *label)
+              CK_SLOT_ID slotid, CK_OBJECT_CLASS class, P11PROV_URI *uri)
 {
     CK_FUNCTION_LIST *f = p11prov_ctx_fns(provctx);
     CK_SESSION_HANDLE session;
+    CK_ATTRIBUTE id = p11prov_uri_get_id(uri);
+    char *label = p11prov_uri_get_object(uri);
     CK_ATTRIBUTE template[3] = {
         { CKA_CLASS, &class, sizeof(class) },
     };
@@ -307,8 +308,8 @@ int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
         return ret;
     }
 
-    if (id_len) {
-        CKATTR_ASSIGN_ALL(template[tsize], CKA_ID, id, id_len);
+    if (id.type == CKA_ID) {
+        template[tsize] = id;
         tsize++;
     }
     if (label) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -375,7 +375,7 @@ static int p11prov_sig_op_init(void *ctx, void *provkey, CK_FLAGS operation,
                                const char *digest, const OSSL_PARAM params[])
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)provkey;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
 
     sigctx->priv_key = p11prov_object_get_key(obj, true);
     if (sigctx->priv_key == NULL) {

--- a/src/store.c
+++ b/src/store.c
@@ -4,55 +4,33 @@
 #include "provider.h"
 #include <openssl/store.h>
 #include "platform/endian.h"
-#include <string.h>
 
-struct p11prov_uri {
-    char *model;
-    char *manufacturer;
-    char *token;
-    char *serial;
-    char *object;
-    unsigned char *id;
-    size_t id_len;
-    char *pin;
-    CK_OBJECT_CLASS class;
-};
-
-struct p11prov_object {
-    P11PROV_CTX *provctx;
-    struct p11prov_uri *parsed_uri;
-    char *set_properties;
-    char *set_input_type;
-    int expected_type;
-    int loaded;
-
+struct p11prov_obj {
     struct p11prov_key *priv_key;
     struct p11prov_key *pub_key;
-
-    CK_SESSION_HANDLE login_session;
 
     int refcnt;
 };
 
-static void p11prov_uri_free(struct p11prov_uri *parsed_uri)
+static P11PROV_OBJ *p11prov_object_new(P11PROV_KEY *priv_key,
+                                       P11PROV_KEY *pub_key)
 {
-    if (parsed_uri == NULL) {
-        return;
+    P11PROV_OBJ *obj;
+
+    obj = OPENSSL_zalloc(sizeof(P11PROV_OBJ));
+    if (obj == NULL) {
+        return NULL;
     }
 
-    OPENSSL_free(parsed_uri->model);
-    OPENSSL_free(parsed_uri->manufacturer);
-    OPENSSL_free(parsed_uri->token);
-    OPENSSL_free(parsed_uri->serial);
-    OPENSSL_free(parsed_uri->object);
-    OPENSSL_free(parsed_uri->id);
-    if (parsed_uri->pin) {
-        OPENSSL_clear_free(parsed_uri->pin, strlen(parsed_uri->pin));
-    }
-    OPENSSL_clear_free(parsed_uri, sizeof(struct p11prov_uri));
+    obj->priv_key = p11prov_key_ref(priv_key);
+    obj->pub_key = p11prov_key_ref(pub_key);
+
+    obj->refcnt = 1;
+
+    return obj;
 }
 
-static P11PROV_OBJECT *p11prov_object_ref(P11PROV_OBJECT *obj)
+static P11PROV_OBJ *p11prov_object_ref(P11PROV_OBJ *obj)
 {
     if (obj && __atomic_fetch_add(&obj->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
         return obj;
@@ -61,7 +39,7 @@ static P11PROV_OBJECT *p11prov_object_ref(P11PROV_OBJECT *obj)
     return NULL;
 }
 
-void p11prov_object_free(P11PROV_OBJECT *obj)
+void p11prov_object_free(P11PROV_OBJ *obj)
 {
     p11prov_debug("object free (%p)\n", obj);
 
@@ -73,21 +51,13 @@ void p11prov_object_free(P11PROV_OBJECT *obj)
         return;
     }
 
-    if (obj->login_session != CK_INVALID_HANDLE) {
-        CK_FUNCTION_LIST_PTR f = p11prov_ctx_fns(obj->provctx);
-        if (f) {
-            (void)f->C_CloseSession(obj->login_session);
-        }
-    }
-
-    p11prov_uri_free(obj->parsed_uri);
     p11prov_key_free(obj->priv_key);
     p11prov_key_free(obj->pub_key);
 
-    OPENSSL_clear_free(obj, sizeof(P11PROV_OBJECT));
+    OPENSSL_clear_free(obj, sizeof(P11PROV_OBJ));
 }
 
-bool p11prov_object_check_key(P11PROV_OBJECT *obj, bool priv)
+bool p11prov_object_check_key(P11PROV_OBJ *obj, bool priv)
 {
     if (priv) {
         return obj->priv_key != NULL;
@@ -95,7 +65,7 @@ bool p11prov_object_check_key(P11PROV_OBJECT *obj, bool priv)
     return obj->pub_key != NULL;
 }
 
-P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJECT *obj, bool priv)
+P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj, bool priv)
 {
     if (priv) {
         return p11prov_key_ref(obj->priv_key);
@@ -133,8 +103,8 @@ static void endianfix(unsigned char *src, unsigned char *dest, size_t len)
 #else
 #define WITH_FIXED_BUFFER(src, ptr) ptr = src->pValue;
 #endif
-int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
-                                         OSSL_CALLBACK *cb_fn, void *cb_arg)
+int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
+                                         void *cb_arg)
 {
     OSSL_PARAM params[3];
     CK_ATTRIBUTE *n, *e;
@@ -167,256 +137,81 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJECT *obj,
     return cb_fn(params, cb_arg);
 }
 
-static int hex_to_byte(const char *in, unsigned char *byte)
-{
-    char c[2], s;
-    int i = 0;
+struct p11prov_store_ctx {
+    P11PROV_CTX *provctx;
+    P11PROV_URI *parsed_uri;
 
-    for (i = 0; i < 2; i++) {
-        s = in[i];
-        if ('0' <= s && s <= '9') {
-            c[i] = s - '0';
-        } else if ('a' <= s && s <= 'f') {
-            c[i] = s - 'a' + 10;
-        } else if ('A' <= s && s <= 'F') {
-            c[i] = s - 'A' + 10;
-        } else {
-            return EINVAL;
+    /* search filters set via params */
+    int expect;
+    CK_ATTRIBUTE subject;
+    CK_ATTRIBUTE issuer;
+    BIGNUM *serial;
+    char *digest;
+    CK_ATTRIBUTE fingerprint;
+    char *alias;
+    char *properties;
+    char *input_type;
+
+    CK_SESSION_HANDLE session;
+
+    int loaded;
+
+    /* objects found */
+    P11PROV_OBJ **objects;
+    int num_objs;
+    int fetched;
+};
+
+static void p11prov_store_ctx_free(struct p11prov_store_ctx *ctx)
+{
+    p11prov_debug("store ctx free (%p)\n", ctx);
+
+    if (ctx == NULL) {
+        return;
+    }
+
+    if (ctx->session != CK_INVALID_HANDLE) {
+        CK_FUNCTION_LIST_PTR f = p11prov_ctx_fns(ctx->provctx);
+        if (f) {
+            (void)f->C_CloseSession(ctx->session);
         }
     }
-    *byte = (c[0] << 4) | c[1];
-    return 0;
+
+    p11prov_uri_free(ctx->parsed_uri);
+    OPENSSL_free(ctx->subject.pValue);
+    OPENSSL_free(ctx->issuer.pValue);
+    OPENSSL_free(ctx->digest);
+    OPENSSL_free(ctx->fingerprint.pValue);
+    OPENSSL_free(ctx->alias);
+    OPENSSL_free(ctx->properties);
+    OPENSSL_free(ctx->input_type);
+
+    for (int i = 0; i < ctx->num_objs; i++) {
+        p11prov_object_free(ctx->objects[i]);
+    }
+    OPENSSL_free(ctx->objects);
+
+    OPENSSL_clear_free(ctx, sizeof(struct p11prov_store_ctx));
 }
 
-static int parse_attr(const char *str, size_t len, unsigned char **output,
-                      size_t *outlen)
+#define OBJS_ALLOC_SIZE 8
+static CK_RV p11prov_store_ctx_add_obj(struct p11prov_store_ctx *ctx,
+                                       P11PROV_OBJ *obj)
 {
-    unsigned char *out;
-    size_t index = 0;
-    int ret;
-
-    out = OPENSSL_malloc(len + 1);
-    if (out == NULL) {
-        return ENOMEM;
-    }
-
-    while (*str && len > 0) {
-        if (*str == '%') {
-            char hex[3] = { 0 };
-            if (len < 3) {
-                ret = EINVAL;
-                goto done;
-            }
-            hex[0] = str[1];
-            hex[1] = str[2];
-            ret = hex_to_byte(hex, &out[index]);
-            if (ret != 0) {
-                goto done;
-            }
-
-            index++;
-            str += 3;
-            len -= 3;
-        } else {
-            out[index] = *str;
-            index++;
-            str++;
-            len--;
+    if ((ctx->num_objs % OBJS_ALLOC_SIZE) == 0) {
+        P11PROV_OBJ **tmp =
+            OPENSSL_realloc(ctx->objects, ctx->num_objs + OBJS_ALLOC_SIZE);
+        if (tmp == NULL) {
+            P11PROV_raise(ctx->provctx, CKR_HOST_MEMORY,
+                          "Failed to allocate store objects");
+            return CKR_HOST_MEMORY;
         }
+        ctx->objects = tmp;
     }
+    ctx->objects[ctx->num_objs] = obj;
+    ctx->num_objs += 1;
 
-    out[index] = '\0';
-    ret = 0;
-
-done:
-    if (ret != 0) {
-        OPENSSL_free(out);
-    } else {
-        *output = out;
-        *outlen = index;
-    }
-    return ret;
-}
-
-#define MAX_PIN_LENGTH 32
-static int get_pin_file(const char *str, size_t len, char **output,
-                        size_t *outlen)
-{
-    char pin[MAX_PIN_LENGTH + 1];
-    char *pinfile;
-    char *filename;
-    BIO *fp;
-    int ret;
-
-    ret = parse_attr(str, len, (unsigned char **)&pinfile, outlen);
-    if (ret != 0) {
-        return ret;
-    }
-
-    if (strncmp((const char *)pinfile, "file:", 5) == 0) {
-        filename = pinfile + 5;
-    } else if (*pinfile == '|') {
-        ret = EINVAL;
-        goto done;
-    } else {
-        /* missing 'file:' is accepted */
-        filename = pinfile;
-    }
-
-    fp = BIO_new_file(filename, "r");
-    if (fp == NULL) {
-        p11prov_debug("Failed to get pin from %s\n", filename);
-        ret = ENOENT;
-        goto done;
-    }
-    ret = BIO_gets(fp, pin, MAX_PIN_LENGTH);
-    if (ret <= 0) {
-        p11prov_debug("Failed to get pin from %s (%d)\n", filename, ret);
-        ret = EINVAL;
-        BIO_free(fp);
-        goto done;
-    }
-    BIO_free(fp);
-
-    /* files may contain newlines, remove any control chracter at the end */
-    for (int i = ret - 1; i >= 0; i--) {
-        if (pin[i] == '\n' || pin[i] == '\r') {
-            pin[i] = '\0';
-        } else {
-            break;
-        }
-    }
-
-    *output = OPENSSL_strdup(pin);
-    if (*output == NULL) {
-        ret = ENOMEM;
-        goto done;
-    }
-
-    ret = 0;
-done:
-    OPENSSL_free(pinfile);
-    return ret;
-}
-
-static int parse_uri(struct p11prov_uri *u, const char *uri)
-{
-    const char *p, *end;
-    int ret;
-
-    if (strncmp(uri, "pkcs11:", 7) != 0) {
-        return EINVAL;
-    }
-
-    p = uri + 7;
-    while (p) {
-        size_t outlen;
-        unsigned char **ptr;
-        size_t *ptrlen;
-        size_t len;
-
-        end = strpbrk(p, ";?&");
-        if (end) {
-            len = end - p;
-        } else {
-            len = strlen(p);
-        }
-
-        ptr = NULL;
-        ptrlen = &outlen;
-
-        if (strncmp(p, "model=", 6) == 0) {
-            p += 6;
-            len -= 6;
-            ptr = (unsigned char **)&u->model;
-        } else if (strncmp(p, "manufacturer=", 13) == 0) {
-            p += 13;
-            len -= 13;
-            ptr = (unsigned char **)&u->manufacturer;
-        } else if (strncmp(p, "token=", 6) == 0) {
-            p += 6;
-            len -= 6;
-            ptr = (unsigned char **)&u->token;
-        } else if (strncmp(p, "serial=", 7) == 0) {
-            p += 7;
-            len -= 7;
-            ptr = (unsigned char **)&u->object;
-        } else if (strncmp(p, "id=", 3) == 0) {
-            p += 3;
-            len -= 3;
-            ptr = &u->id;
-            ptrlen = &u->id_len;
-        } else if (strncmp(p, "pin-value=", 10) == 0) {
-            p += 10;
-            len -= 10;
-            ptr = (unsigned char **)&u->pin;
-        } else if (strncmp(p, "pin-source=", 11) == 0) {
-            p += 11;
-            len -= 11;
-            ret = get_pin_file(p, len, &u->pin, ptrlen);
-            if (ret != 0) {
-                goto done;
-            }
-        } else if (strncmp(p, "type=", 5) == 0
-                   || strncmp(p, "object-type=", 12) == 0) {
-            p += 4;
-            if (*p == '=') {
-                p++;
-                len -= 5;
-            } else {
-                p += 8;
-                len -= 12;
-            }
-            if (len == 4 && strncmp(p, "cert", 4) == 0) {
-                u->class = CKO_CERTIFICATE;
-            } else if (len == 6 && strncmp(p, "public", 6) == 0) {
-                u->class = CKO_PUBLIC_KEY;
-            } else if (len == 7 && strncmp(p, "private", 7) == 0) {
-                u->class = CKO_PRIVATE_KEY;
-            } else if (len == 7 && strncmp(p, "secret", 7) == 0) {
-                u->class = CKO_SECRET_KEY;
-            } else {
-                p11prov_debug("Unknown object type\n");
-                ret = EINVAL;
-                goto done;
-            }
-        } else {
-            p11prov_debug("Ignoring unkown pkcs11 URI attribute\n");
-        }
-
-        if (ptr) {
-            ret = parse_attr(p, len, ptr, ptrlen);
-            if (ret != 0) {
-                goto done;
-            }
-        }
-
-        if (end) {
-            p = end + 1;
-        } else {
-            p = NULL;
-        }
-    }
-
-    ret = 0;
-done:
-    return ret;
-}
-
-int p11prov_get_pin(const char *in, char **out)
-{
-    size_t outlen;
-
-    if (strncmp(in, "file:", 5) == 0) {
-        return get_pin_file(in, strlen(in), out, &outlen);
-    }
-
-    *out = OPENSSL_strdup(in);
-    if (!*out) {
-        return ENOMEM;
-    }
-
-    return 0;
+    return CKR_OK;
 }
 
 DISPATCH_STORE_FN(open);
@@ -428,289 +223,232 @@ DISPATCH_STORE_FN(export_object);
 DISPATCH_STORE_FN(set_ctx_params);
 DISPATCH_STORE_FN(settable_ctx_params);
 
-static void *p11prov_store_open(void *provctx, const char *uri)
+static void store_load(struct p11prov_store_ctx *ctx,
+                       OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
-    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
-    P11PROV_OBJECT *obj;
-    int ret;
+    CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
+    CK_SLOT_ID nextid = CK_UNAVAILABLE_INFORMATION;
+    /* 0 is CKO_DATA but we do not use it */
+    CK_OBJECT_CLASS class = 0;
 
-    p11prov_debug("object open (%p, %s)\n", ctx, uri);
+    do {
+        nextid = CK_UNAVAILABLE_INFORMATION;
 
-    obj = OPENSSL_zalloc(sizeof(P11PROV_OBJECT));
-    if (obj == NULL) {
-        return NULL;
-    }
+        if (ctx->session != CK_INVALID_HANDLE) {
+            p11prov_put_session(ctx->provctx, ctx->session);
+        }
 
-    obj->parsed_uri = OPENSSL_zalloc(sizeof(struct p11prov_uri));
-    if (obj->parsed_uri == NULL) {
-        p11prov_object_free(obj);
-        return NULL;
-    }
+        ctx->session = p11prov_get_session(ctx->provctx, &slotid, &nextid,
+                                           ctx->parsed_uri, pw_cb, pw_cbarg);
+        if (ctx->session == CK_INVALID_HANDLE) {
+            return;
+        }
 
-    ret = parse_uri(obj->parsed_uri, uri);
-    if (ret != 0) {
-        p11prov_object_free(obj);
-        return NULL;
-    }
+        /* FIXME: we should probbaly just load everything, filter later */
+        class = CKO_PRIVATE_KEY;
+        if (p11prov_uri_get_class(ctx->parsed_uri) == CKO_PUBLIC_KEY) {
+            class = CKO_PUBLIC_KEY;
+        }
+        if (class == CKO_PUBLIC_KEY || class == CKO_PRIVATE_KEY) {
+            P11PROV_KEY *priv_key = NULL;
+            P11PROV_KEY *pub_key = NULL;
+            CK_RV ret;
 
-    obj->provctx = ctx;
-    obj->refcnt = 1;
+            ret = find_keys(ctx->provctx, &priv_key, &pub_key, slotid, class,
+                            ctx->parsed_uri);
+            if (ret == CKR_OK) {
+                /* new object */
+                P11PROV_OBJ *obj;
 
-    return obj;
+                obj = p11prov_object_new(priv_key, pub_key);
+                if (obj == NULL) {
+                    p11prov_key_free(priv_key);
+                    p11prov_key_free(pub_key);
+                    return;
+                }
+                ret = p11prov_store_ctx_add_obj(ctx, obj);
+                if (ret != CKR_OK) {
+                    p11prov_key_free(priv_key);
+                    p11prov_key_free(pub_key);
+                    p11prov_object_free(obj);
+                    return;
+                }
+
+                /* we successflly loaded at least one object,
+                 * mark overall load as a success */
+                ctx->loaded = 1;
+            }
+            p11prov_key_free(priv_key);
+            p11prov_key_free(pub_key);
+        }
+        slotid = nextid;
+
+    } while (nextid != CK_UNAVAILABLE_INFORMATION);
 }
 
-static void *p11prov_store_attach(void *provctx, OSSL_CORE_BIO *in)
+static void *p11prov_store_open(void *pctx, const char *uri)
 {
-    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
+    struct p11prov_store_ctx *ctx = NULL;
+    CK_RV result = CKR_CANCEL;
+
+    p11prov_debug("object open (%p, %s)\n", pctx, uri);
+
+    ctx = OPENSSL_zalloc(sizeof(struct p11prov_store_ctx));
+    if (ctx == NULL) {
+        return NULL;
+    }
+    ctx->provctx = (P11PROV_CTX *)pctx;
+
+    ctx->parsed_uri = p11prov_parse_uri(uri);
+    if (ctx->parsed_uri == NULL) {
+        goto done;
+    }
+
+    store_load(ctx, NULL, NULL);
+
+    result = CKR_OK;
+
+done:
+    if (result != CKR_OK) {
+        p11prov_store_ctx_free(ctx);
+        ctx = NULL;
+    }
+    return ctx;
+}
+
+static void *p11prov_store_attach(void *pctx, OSSL_CORE_BIO *in)
+{
+    struct p11prov_store_ctx *ctx = (struct p11prov_store_ctx *)pctx;
 
     p11prov_debug("object attach (%p, %p)\n", ctx, in);
 
     return NULL;
 }
 
-static int p11prov_store_load(void *ctx, OSSL_CALLBACK *object_cb,
+static int p11prov_store_load(void *pctx, OSSL_CALLBACK *object_cb,
                               void *object_cbarg,
                               OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)ctx;
-    struct p11prov_slot *slots = NULL;
-    char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
-    /* 0 is CKO_DATA ibut we do not use it */
-    CK_OBJECT_CLASS class = 0;
-    int nslots = 0;
+    struct p11prov_store_ctx *ctx = (struct p11prov_store_ctx *)pctx;
+    P11PROV_OBJ *obj = NULL;
+    OSSL_PARAM params[4];
+    int object_type;
+    CK_KEY_TYPE type;
+    char *data_type;
 
-    p11prov_debug("object load (%p)\n", obj);
+    p11prov_debug("store load (%p)\n", ctx);
 
-    nslots = p11prov_ctx_lock_slots(obj->provctx, &slots);
-
-    for (int i = 0; i < nslots; i++) {
-        CK_TOKEN_INFO token;
-
-        /* ignore slots that are not initialized */
-        if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
-            continue;
-        }
-        if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
-            continue;
-        }
-
-        token = slots[i].token;
-
-        /* skip slots that do not match */
-        if (obj->parsed_uri->model
-            && strncmp(obj->parsed_uri->model, (const char *)token.model, 16)
-                   != 0) {
-            continue;
-        }
-        if (obj->parsed_uri->manufacturer
-            && strncmp(obj->parsed_uri->manufacturer,
-                       (const char *)token.manufacturerID, 32)
-                   != 0) {
-            continue;
-        }
-        if (obj->parsed_uri->token
-            && strncmp(obj->parsed_uri->token, (const char *)token.label, 32)
-                   != 0) {
-            continue;
-        }
-        if (obj->parsed_uri->serial
-            && strncmp(obj->parsed_uri->serial,
-                       (const char *)token.serialNumber, 16)
-                   != 0) {
-            continue;
-        }
-
-        if (token.flags & CKF_LOGIN_REQUIRED) {
-            CK_FUNCTION_LIST *f = p11prov_ctx_fns(obj->provctx);
-            CK_UTF8CHAR_PTR pin = NULL;
-            CK_ULONG pinlen = 0;
-            int ret;
-
-            if (f == NULL) {
-                break;
-            }
-            if (obj->parsed_uri->pin) {
-                pin = (CK_UTF8CHAR_PTR)obj->parsed_uri->pin;
-            } else {
-                pin = p11prov_ctx_pin(obj->provctx);
-            }
-            if (pin) {
-                pinlen = strlen((const char *)pin);
-            } else {
-                const char *info = "PKCS#11 Token";
-                OSSL_PARAM params[2] = {
-                    OSSL_PARAM_DEFN(OSSL_PASSPHRASE_PARAM_INFO,
-                                    OSSL_PARAM_UTF8_STRING, (void *)info,
-                                    sizeof(info)),
-                    OSSL_PARAM_END,
-                };
-                size_t cb_pin_len = 0;
-                ret = pw_cb(cb_pin, sizeof(cb_pin), &cb_pin_len, params,
-                            pw_cbarg);
-                if (ret != RET_OSSL_OK) {
-                    continue;
-                }
-
-                pin = (CK_UTF8CHAR_PTR)cb_pin;
-                pinlen = cb_pin_len;
-            }
-
-            if (obj->login_session == CK_INVALID_HANDLE) {
-                ret = f->C_OpenSession(slots[i].id, CKF_SERIAL_SESSION, NULL,
-                                       NULL, &obj->login_session);
-                if (ret != CKR_OK) {
-                    P11PROV_raise(obj->provctx, ret,
-                                  "Failed to open session on slot %lu",
-                                  slots[i].id);
-                    continue;
-                }
-            }
-
-            /* Supports only USER login sessions for now */
-            ret = f->C_Login(obj->login_session, CKU_USER, pin, pinlen);
-            if (ret && ret != CKR_USER_ALREADY_LOGGED_IN) {
-                P11PROV_raise(obj->provctx, ret, "Error returned by C_Login");
-                continue;
-            }
-        }
-
-        /* match class */
-        switch (obj->parsed_uri->class) {
-        case CKO_CERTIFICATE:
-            /* not yet */
-            break;
-        case CKO_PUBLIC_KEY:
-            class = CKO_PUBLIC_KEY;
-            break;
-        case CKO_PRIVATE_KEY:
-            class = CKO_PRIVATE_KEY;
-            break;
-        default:
-            /* nothing matches, see what openssl expects */
-            switch (obj->expected_type) {
-            case OSSL_STORE_INFO_PUBKEY:
-                class = CKO_PUBLIC_KEY;
-                break;
-            case OSSL_STORE_INFO_PKEY:
-                class = CKO_PRIVATE_KEY;
-                break;
-            case OSSL_STORE_INFO_CERT:
-                /* not yet */
-            case OSSL_STORE_INFO_CRL:
-                /* not yet */
-            default:
-                break;
-            }
-        }
-        if (class == CKO_PUBLIC_KEY || class == CKO_PRIVATE_KEY) {
-            int ret =
-                find_keys(obj->provctx, &obj->priv_key, &obj->pub_key,
-                          slots[i].id, class, obj->parsed_uri->id,
-                          obj->parsed_uri->id_len, obj->parsed_uri->object);
-            /* for keys return on first match */
-            if (ret == CKR_OK) {
-                break;
-            }
-        }
+    if (ctx->loaded == 0) {
+        store_load(ctx, pw_cb, pw_cbarg);
     }
 
-    p11prov_ctx_unlock_slots(obj->provctx, &slots);
+    if (ctx->loaded != 1 || ctx->fetched >= ctx->num_objs) {
+        return RET_OSSL_ERR;
+    }
 
-    obj->loaded = 1;
+    /* FIXME: fetch next object with filters as set by openssl */
+    obj = ctx->objects[ctx->fetched];
+    ctx->fetched++;
 
-    if (obj->pub_key || obj->priv_key) {
-        OSSL_PARAM params[4];
-        int object_type = OSSL_OBJECT_PKEY;
-        CK_KEY_TYPE type;
-        char *data_type;
+    /* FIXME: always a key for now */
+    object_type = OSSL_OBJECT_PKEY;
+    params[0] = OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
 
-        params[0] =
-            OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
-
-        if (obj->pub_key) {
-            type = p11prov_key_type(obj->pub_key);
-        } else {
-            type = p11prov_key_type(obj->priv_key);
-        }
-        switch (type) {
-        case CKK_RSA:
-            /* REMOVE once we have decoders.
-             *  we have to handle private keys as our own type,
-             * while we can let openssl import public keys and
-             * deal with them in the default provider */
-            switch (obj->expected_type) {
-            case OSSL_STORE_INFO_PKEY:
+    if (obj->pub_key) {
+        type = p11prov_key_type(obj->pub_key);
+    } else {
+        type = p11prov_key_type(obj->priv_key);
+    }
+    switch (type) {
+    case CKK_RSA:
+        /* REMOVE once we have encoders to export pub keys.
+         *  we have to handle private keys as our own type,
+         * while we can let openssl import public keys and
+         * deal with them in the default provider */
+        switch (ctx->expect) {
+        case OSSL_STORE_INFO_PKEY:
+            data_type = (char *)P11PROV_NAMES_RSA;
+            break;
+        case OSSL_STORE_INFO_PUBKEY:
+            data_type = (char *)"RSA";
+            break;
+        default:
+            if (obj->priv_key) {
                 data_type = (char *)P11PROV_NAMES_RSA;
-                break;
-            case OSSL_STORE_INFO_PUBKEY:
+            } else {
                 data_type = (char *)"RSA";
-                break;
-            default:
-                if (obj->priv_key) {
-                    data_type = (char *)P11PROV_NAMES_RSA;
-                } else {
-                    data_type = (char *)"RSA";
-                }
-                break;
             }
             break;
-        case CKK_EC:
-            data_type = (char *)P11PROV_NAMES_ECDSA;
-            break;
-        default:
-            return RET_OSSL_ERR;
         }
-        params[1] = OSSL_PARAM_construct_utf8_string(
-            OSSL_OBJECT_PARAM_DATA_TYPE, data_type, 0);
-
-        /* giving away the object by reference */
-        params[2] = OSSL_PARAM_construct_octet_string(
-            OSSL_OBJECT_PARAM_REFERENCE, p11prov_object_ref(obj), sizeof(obj));
-        params[3] = OSSL_PARAM_construct_end();
-
-        return object_cb(params, object_cbarg);
+        break;
+    case CKK_EC:
+        data_type = (char *)P11PROV_NAMES_ECDSA;
+        break;
+    default:
+        return RET_OSSL_ERR;
     }
+    params[1] = OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,
+                                                 data_type, 0);
 
-    return RET_OSSL_ERR;
+    /* giving away the object by reference */
+    params[2] = OSSL_PARAM_construct_octet_string(OSSL_OBJECT_PARAM_REFERENCE,
+                                                  p11prov_object_ref(obj),
+                                                  sizeof(P11PROV_OBJ));
+    params[3] = OSSL_PARAM_construct_end();
+
+    return object_cb(params, object_cbarg);
 }
 
-static int p11prov_store_eof(void *ctx)
+static int p11prov_store_eof(void *pctx)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)ctx;
+    struct p11prov_store_ctx *ctx = (struct p11prov_store_ctx *)pctx;
 
-    p11prov_debug("object eof (%p)\n", obj);
+    p11prov_debug("store eof (%p)\n", ctx);
 
-    return obj->loaded ? 1 : 0;
+    if (ctx->loaded && (ctx->fetched >= ctx->num_objs)) {
+        return 1;
+    }
+    return 0;
 }
 
-static int p11prov_store_close(void *ctx)
+static int p11prov_store_close(void *pctx)
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)ctx;
+    struct p11prov_store_ctx *ctx = (struct p11prov_store_ctx *)pctx;
 
-    p11prov_debug("object close (%p)\n", obj);
+    p11prov_debug("store close (%p)\n", ctx);
 
-    if (obj == NULL) {
+    if (ctx == NULL) {
         return 0;
     }
 
-    p11prov_object_free(obj);
+    p11prov_store_ctx_free(ctx);
     return 1;
+}
+
+P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
+                                        size_t reference_sz)
+{
+    if (!reference || reference_sz != sizeof(P11PROV_OBJ)) {
+        return NULL;
+    }
+
+    return (P11PROV_OBJ *)reference;
 }
 
 static int p11prov_store_export_object(void *loaderctx, const void *reference,
                                        size_t reference_sz,
                                        OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    P11PROV_OBJECT *obj = NULL;
+    P11PROV_OBJ *obj = NULL;
 
-    p11prov_debug("object export %p, %ld\n", reference, reference_sz);
-
-    if (!reference || reference_sz != sizeof(obj)) {
-        return RET_OSSL_ERR;
-    }
+    p11prov_debug("store (%p) export object %p, %zu\n", loaderctx, reference,
+                  reference_sz);
 
     /* the contents of the reference is the address to our object */
-    obj = (P11PROV_OBJECT *)reference;
+    obj = p11prov_obj_from_reference(reference, reference_sz);
+    if (!obj) {
+        return RET_OSSL_ERR;
+    }
 
     /* we can only export public bits, so that's all we do */
     switch (p11prov_key_type(obj->pub_key)) {
@@ -718,27 +456,31 @@ static int p11prov_store_export_object(void *loaderctx, const void *reference,
         return p11prov_object_export_public_rsa_key(obj, cb_fn, cb_arg);
     case CKK_EC:
     default:
-        return RET_OSSL_ERR;
+        break;
     }
+    return RET_OSSL_ERR;
 }
 
 static const OSSL_PARAM *p11prov_store_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
-        OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_PROPERTIES, NULL, 0),
         OSSL_PARAM_int(OSSL_STORE_PARAM_EXPECT, NULL),
-        /* not yet: SUBJECT is a DER object that needs parsing
         OSSL_PARAM_octet_string(OSSL_STORE_PARAM_SUBJECT, NULL, 0),
-         */
+        OSSL_PARAM_octet_string(OSSL_STORE_PARAM_ISSUER, NULL, 0),
+        OSSL_PARAM_BN(OSSL_STORE_PARAM_SERIAL, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_STORE_PARAM_FINGERPRINT, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_ALIAS, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_PROPERTIES, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_STORE_PARAM_INPUT_TYPE, NULL, 0),
         OSSL_PARAM_END,
     };
     return known_settable_ctx_params;
 }
 
-static int p11prov_store_set_ctx_params(void *ctx, const OSSL_PARAM params[])
+static int p11prov_store_set_ctx_params(void *pctx, const OSSL_PARAM params[])
 {
-    P11PROV_OBJECT *obj = (P11PROV_OBJECT *)ctx;
+    struct p11prov_store_ctx *ctx = (struct p11prov_store_ctx *)pctx;
     const OSSL_PARAM *p;
     int ret;
 
@@ -748,27 +490,81 @@ static int p11prov_store_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         return RET_OSSL_OK;
     }
 
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_EXPECT);
+    if (p) {
+        ret = OSSL_PARAM_get_int(p, &ctx->expect);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_SUBJECT);
+    if (p) {
+        size_t len = 0;
+        OPENSSL_free(ctx->subject.pValue);
+        ctx->subject.type = CKA_SUBJECT;
+        ctx->subject.pValue = NULL;
+        ret = OSSL_PARAM_get_octet_string(p, &ctx->subject.pValue, 0, &len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+        ctx->subject.ulValueLen = len;
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_ISSUER);
+    if (p) {
+        size_t len = 0;
+        OPENSSL_free(ctx->issuer.pValue);
+        ctx->issuer.type = CKA_ISSUER;
+        ctx->issuer.pValue = NULL;
+        ret = OSSL_PARAM_get_octet_string(p, &ctx->issuer.pValue, 0, &len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+        ctx->issuer.ulValueLen = len;
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_DIGEST);
+    if (p) {
+        OPENSSL_free(ctx->digest);
+        ctx->digest = NULL;
+        ret = OSSL_PARAM_get_utf8_string(p, &ctx->digest, 0);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_FINGERPRINT);
+    if (p) {
+        size_t len = 0;
+        OPENSSL_free(ctx->fingerprint.pValue);
+        ctx->fingerprint.type = CKA_VALUE;
+        ctx->fingerprint.pValue = NULL;
+        ret = OSSL_PARAM_get_octet_string(p, &ctx->fingerprint.pValue, 0, &len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+        ctx->fingerprint.ulValueLen = len;
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_ALIAS);
+    if (p) {
+        OPENSSL_free(ctx->alias);
+        ctx->alias = NULL;
+        ret = OSSL_PARAM_get_utf8_string(p, &ctx->alias, 0);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
     p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_PROPERTIES);
     if (p) {
-        OPENSSL_free(obj->set_properties);
-        obj->set_properties = NULL;
-        ret = OSSL_PARAM_get_utf8_string(p, &obj->set_properties, 0);
+        OPENSSL_free(ctx->properties);
+        ctx->properties = NULL;
+        ret = OSSL_PARAM_get_utf8_string(p, &ctx->properties, 0);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
     }
     p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_INPUT_TYPE);
     if (p) {
-        OPENSSL_free(obj->set_input_type);
-        obj->set_input_type = NULL;
-        ret = OSSL_PARAM_get_utf8_string(p, &obj->set_input_type, 0);
-        if (ret != RET_OSSL_OK) {
-            return ret;
-        }
-    }
-    p = OSSL_PARAM_locate_const(params, OSSL_STORE_PARAM_EXPECT);
-    if (p) {
-        ret = OSSL_PARAM_get_int(p, &obj->expected_type);
+        OPENSSL_free(ctx->input_type);
+        ctx->input_type = NULL;
+        ret = OSSL_PARAM_get_utf8_string(p, &ctx->input_type, 0);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/util.c
+++ b/src/util.c
@@ -2,6 +2,7 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include "provider.h"
+#include <string.h>
 
 int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
                              CK_OBJECT_HANDLE object, struct fetch_attrs *attrs,
@@ -91,49 +92,487 @@ int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, CK_SESSION_HANDLE session,
     return ret;
 }
 
-CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid)
+struct p11prov_uri {
+    char *model;
+    char *manufacturer;
+    char *token;
+    char *serial;
+    char *object;
+    CK_ATTRIBUTE id;
+    char *pin;
+    CK_OBJECT_CLASS class;
+};
+
+static int hex_to_byte(const char *in, unsigned char *byte)
 {
-    CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
-    CK_FUNCTION_LIST *f;
-    CK_RV ret;
+    char c[2], s;
+    int i = 0;
 
-    if (slotid == CK_UNAVAILABLE_INFORMATION) {
-        struct p11prov_slot *slots = NULL;
-        int nslots = 0;
-
-        nslots = p11prov_ctx_lock_slots(provctx, &slots);
-
-        for (int i = 0; i < nslots; i++) {
-            /* ignore slots that are not initialized */
-            if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
-                continue;
-            }
-            if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
-                continue;
-            }
-
-            slotid = slots[i].id;
+    for (i = 0; i < 2; i++) {
+        s = in[i];
+        if ('0' <= s && s <= '9') {
+            c[i] = s - '0';
+        } else if ('a' <= s && s <= 'f') {
+            c[i] = s - 'a' + 10;
+        } else if ('A' <= s && s <= 'F') {
+            c[i] = s - 'A' + 10;
+        } else {
+            return EINVAL;
         }
+    }
+    *byte = (c[0] << 4) | c[1];
+    return 0;
+}
 
-        p11prov_ctx_unlock_slots(provctx, &slots);
+static int parse_attr(const char *str, size_t len, unsigned char **output,
+                      size_t *outlen)
+{
+    unsigned char *out;
+    size_t index = 0;
+    int ret;
+
+    out = OPENSSL_malloc(len + 1);
+    if (out == NULL) {
+        return ENOMEM;
     }
 
-    if (slotid == CK_UNAVAILABLE_INFORMATION) {
+    while (*str && len > 0) {
+        if (*str == '%') {
+            char hex[3] = { 0 };
+            if (len < 3) {
+                ret = EINVAL;
+                goto done;
+            }
+            hex[0] = str[1];
+            hex[1] = str[2];
+            ret = hex_to_byte(hex, &out[index]);
+            if (ret != 0) {
+                goto done;
+            }
+
+            index++;
+            str += 3;
+            len -= 3;
+        } else {
+            out[index] = *str;
+            index++;
+            str++;
+            len--;
+        }
+    }
+
+    out[index] = '\0';
+    ret = 0;
+
+done:
+    if (ret != 0) {
+        OPENSSL_free(out);
+    } else {
+        *output = out;
+        *outlen = index;
+    }
+    return ret;
+}
+
+static int get_pin_file(const char *str, size_t len, char **output,
+                        size_t *outlen)
+{
+    char pin[MAX_PIN_LENGTH + 1];
+    char *pinfile;
+    char *filename;
+    BIO *fp;
+    int ret;
+
+    ret = parse_attr(str, len, (unsigned char **)&pinfile, outlen);
+    if (ret != 0) {
+        return ret;
+    }
+
+    if (strncmp((const char *)pinfile, "file:", 5) == 0) {
+        filename = pinfile + 5;
+    } else if (*pinfile == '|') {
+        ret = EINVAL;
         goto done;
+    } else {
+        /* missing 'file:' is accepted */
+        filename = pinfile;
+    }
+
+    fp = BIO_new_file(filename, "r");
+    if (fp == NULL) {
+        p11prov_debug("Failed to get pin from %s\n", filename);
+        ret = ENOENT;
+        goto done;
+    }
+    ret = BIO_gets(fp, pin, MAX_PIN_LENGTH);
+    if (ret <= 0) {
+        p11prov_debug("Failed to get pin from %s (%d)\n", filename, ret);
+        ret = EINVAL;
+        BIO_free(fp);
+        goto done;
+    }
+    BIO_free(fp);
+
+    /* files may contain newlines, remove any control chracter at the end */
+    for (int i = ret - 1; i >= 0; i--) {
+        if (pin[i] == '\n' || pin[i] == '\r') {
+            pin[i] = '\0';
+        } else {
+            break;
+        }
+    }
+
+    *output = OPENSSL_strdup(pin);
+    if (*output == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    ret = 0;
+done:
+    OPENSSL_free(pinfile);
+    return ret;
+}
+
+P11PROV_URI *p11prov_parse_uri(const char *uri)
+{
+    struct p11prov_uri *u;
+    const char *p, *end;
+    int ret;
+
+    u = OPENSSL_zalloc(sizeof(struct p11prov_uri));
+    if (u == NULL) {
+        return NULL;
+    }
+    u->class = CK_UNAVAILABLE_INFORMATION;
+
+    if (strncmp(uri, "pkcs11:", 7) != 0) {
+        p11prov_uri_free(u);
+        return NULL;
+    }
+
+    p = uri + 7;
+    while (p) {
+        size_t outlen;
+        unsigned char **ptr;
+        size_t *ptrlen;
+        size_t len;
+        bool id_fill = false;
+
+        end = strpbrk(p, ";?&");
+        if (end) {
+            len = end - p;
+        } else {
+            len = strlen(p);
+        }
+
+        ptr = NULL;
+        ptrlen = &outlen;
+
+        if (strncmp(p, "model=", 6) == 0) {
+            p += 6;
+            len -= 6;
+            ptr = (unsigned char **)&u->model;
+        } else if (strncmp(p, "manufacturer=", 13) == 0) {
+            p += 13;
+            len -= 13;
+            ptr = (unsigned char **)&u->manufacturer;
+        } else if (strncmp(p, "token=", 6) == 0) {
+            p += 6;
+            len -= 6;
+            ptr = (unsigned char **)&u->token;
+        } else if (strncmp(p, "serial=", 7) == 0) {
+            p += 7;
+            len -= 7;
+            ptr = (unsigned char **)&u->object;
+        } else if (strncmp(p, "id=", 3) == 0) {
+            p += 3;
+            len -= 3;
+            ptr = (unsigned char **)&u->id.pValue;
+            id_fill = true;
+        } else if (strncmp(p, "pin-value=", 10) == 0) {
+            p += 10;
+            len -= 10;
+            ptr = (unsigned char **)&u->pin;
+        } else if (strncmp(p, "pin-source=", 11) == 0) {
+            p += 11;
+            len -= 11;
+            ret = get_pin_file(p, len, &u->pin, ptrlen);
+            if (ret != 0) {
+                goto done;
+            }
+        } else if (strncmp(p, "type=", 5) == 0
+                   || strncmp(p, "object-type=", 12) == 0) {
+            p += 4;
+            if (*p == '=') {
+                p++;
+                len -= 5;
+            } else {
+                p += 8;
+                len -= 12;
+            }
+            if (len == 4 && strncmp(p, "cert", 4) == 0) {
+                u->class = CKO_CERTIFICATE;
+            } else if (len == 6 && strncmp(p, "public", 6) == 0) {
+                u->class = CKO_PUBLIC_KEY;
+            } else if (len == 7 && strncmp(p, "private", 7) == 0) {
+                u->class = CKO_PRIVATE_KEY;
+            } else if (len == 7 && strncmp(p, "secret", 7) == 0) {
+                u->class = CKO_SECRET_KEY;
+            } else {
+                p11prov_debug("Unknown object type\n");
+                ret = EINVAL;
+                goto done;
+            }
+        } else {
+            p11prov_debug("Ignoring unkown pkcs11 URI attribute\n");
+        }
+
+        if (ptr) {
+            ret = parse_attr(p, len, ptr, ptrlen);
+            if (ret != 0) {
+                goto done;
+            }
+            if (id_fill) {
+                u->id.type = CKA_ID;
+                u->id.ulValueLen = outlen;
+            }
+        }
+
+        if (end) {
+            p = end + 1;
+        } else {
+            p = NULL;
+        }
+    }
+
+    ret = 0;
+done:
+    if (ret != 0) {
+        p11prov_uri_free(u);
+        return NULL;
+    }
+    return u;
+}
+
+void p11prov_uri_free(P11PROV_URI *uri)
+{
+    if (uri == NULL) {
+        return;
+    }
+
+    OPENSSL_free(uri->model);
+    OPENSSL_free(uri->manufacturer);
+    OPENSSL_free(uri->token);
+    OPENSSL_free(uri->serial);
+    OPENSSL_free(uri->object);
+    OPENSSL_free(uri->id.pValue);
+    if (uri->pin) {
+        OPENSSL_clear_free(uri->pin, strlen(uri->pin));
+    }
+    OPENSSL_clear_free(uri, sizeof(struct p11prov_uri));
+}
+
+CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri)
+{
+    return uri->class;
+}
+
+CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri)
+{
+    return uri->id;
+}
+
+char *p11prov_uri_get_object(P11PROV_URI *uri)
+{
+    return uri->object;
+}
+
+int p11prov_get_pin(const char *in, char **out)
+{
+    size_t outlen;
+
+    if (strncmp(in, "file:", 5) == 0) {
+        return get_pin_file(in, strlen(in), out, &outlen);
+    }
+
+    *out = OPENSSL_strdup(in);
+    if (!*out) {
+        return ENOMEM;
+    }
+
+    return 0;
+}
+
+static CK_RV match_token(CK_TOKEN_INFO *token, P11PROV_URI *uri)
+{
+    if (uri->model
+        && strncmp(uri->model, (const char *)token->model, 16) != 0) {
+        return CKR_CANCEL;
+    }
+    if (uri->manufacturer
+        && strncmp(uri->manufacturer, (const char *)token->manufacturerID, 32)
+               != 0) {
+        return CKR_CANCEL;
+    }
+    if (uri->token
+        && strncmp(uri->token, (const char *)token->label, 32) != 0) {
+        return CKR_CANCEL;
+    }
+    if (uri->serial
+        && strncmp(uri->serial, (const char *)token->serialNumber, 16) != 0) {
+        return CKR_CANCEL;
+    }
+
+    return CKR_OK;
+}
+
+static CK_RV token_login(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
+                         P11PROV_URI *uri, OSSL_PASSPHRASE_CALLBACK *pw_cb,
+                         void *pw_cbarg)
+{
+    CK_SESSION_HANDLE s;
+    CK_FUNCTION_LIST *f;
+    char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
+    CK_UTF8CHAR_PTR pin = NULL;
+    CK_ULONG pinlen = 0;
+    CK_RV ret;
+
+    ret = p11prov_ctx_get_login_session(provctx, &s);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+    if (s != CK_INVALID_HANDLE) {
+        /* we already have a login_session */
+        return CKR_OK;
     }
 
     f = p11prov_ctx_fns(provctx);
     if (f == NULL) {
-        goto done;
+        return CKR_FUNCTION_FAILED;
+    }
+    if (uri->pin) {
+        pin = (CK_UTF8CHAR_PTR)uri->pin;
+    } else {
+        pin = p11prov_ctx_pin(provctx);
+    }
+    if (pin) {
+        pinlen = strlen((const char *)pin);
+    } else if (pw_cb) {
+        const char *info = "PKCS#11 Token";
+        size_t cb_pin_len = 0;
+        OSSL_PARAM params[2] = {
+            OSSL_PARAM_DEFN(OSSL_PASSPHRASE_PARAM_INFO, OSSL_PARAM_UTF8_STRING,
+                            (void *)info, sizeof(info)),
+            OSSL_PARAM_END,
+        };
+        ret = pw_cb(cb_pin, sizeof(cb_pin), &cb_pin_len, params, pw_cbarg);
+        if (ret != RET_OSSL_OK) {
+            return CKR_GENERAL_ERROR;
+        }
+
+        pin = (CK_UTF8CHAR_PTR)cb_pin;
+        pinlen = cb_pin_len;
+    } else {
+        return CKR_GENERAL_ERROR;
     }
 
-    ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
+    ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &s);
     if (ret != CKR_OK) {
         P11PROV_raise(provctx, ret, "Failed to open session on slot %lu",
                       slotid);
+        return ret;
     }
 
-done:
+    /* Supports only USER login sessions for now */
+    ret = f->C_Login(s, CKU_USER, pin, pinlen);
+    if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
+        int retc;
+        P11PROV_raise(provctx, ret, "Error returned by C_Login");
+        retc = f->C_CloseSession(s);
+        if (retc != CKR_OK) {
+            P11PROV_raise(provctx, retc, "Failed to close session %lu", s);
+        }
+        return ret;
+    }
+
+    return p11prov_ctx_set_login_session(provctx, s);
+}
+
+CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
+                                      CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
+                                      OSSL_PASSPHRASE_CALLBACK *pw_cb,
+                                      void *pw_cbarg)
+{
+    CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
+    CK_SLOT_ID id = *slotid;
+    CK_FUNCTION_LIST *f;
+    struct p11prov_slot *slots = NULL;
+    int nslots = 0;
+    int i;
+    CK_RV ret = CKR_CANCEL;
+
+    nslots = p11prov_ctx_lock_slots(provctx, &slots);
+
+    for (i = 0; i < nslots; i++) {
+        if (id != CK_UNAVAILABLE_INFORMATION && id != slots[i].id) {
+            continue;
+        }
+
+        /* ignore slots that are not initialized */
+        if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
+            continue;
+        }
+        if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
+            continue;
+        }
+
+        id = slots[i].id;
+        ret = CKR_OK;
+
+        if (uri) {
+            CK_TOKEN_INFO token = slots[i].token;
+
+            /* skip slots that do not match */
+            ret = match_token(&token, uri);
+            if (ret == CKR_OK && (token.flags & CKF_LOGIN_REQUIRED)) {
+                ret = token_login(provctx, id, uri, pw_cb, pw_cbarg);
+            }
+        }
+
+        if (ret == CKR_CANCEL) {
+            continue;
+        }
+        break;
+    }
+
+    /* Found a slot, return it and the next slot to the caller for continuation
+     * if the current slot does not yield the desired results */
+    *slotid = id;
+    if (next_slotid) {
+        if (i + 1 < nslots) {
+            *next_slotid = slots[i + 1].id;
+        } else {
+            *next_slotid = CK_UNAVAILABLE_INFORMATION;
+        }
+    }
+
+    p11prov_ctx_unlock_slots(provctx, &slots);
+
+    if (ret != CKR_OK) {
+        return CK_INVALID_HANDLE;
+    }
+
+    f = p11prov_ctx_fns(provctx);
+    if (f == NULL) {
+        return CK_INVALID_HANDLE;
+    }
+
+    ret = f->C_OpenSession(id, CKF_SERIAL_SESSION, NULL, NULL, &session);
+    if (ret != CKR_OK) {
+        P11PROV_raise(provctx, ret, "Failed to open session on slot %lu", id);
+        return CK_INVALID_HANDLE;
+    }
     return session;
 }
 


### PR DESCRIPTION
This allows to load multiple objects (currently only keys) and enumerate
them all.

Note: We need to store the login_session on the provider context because
otherwise we can't guarantee the token is "logged in" for the duration
of operations on private key later on.
We could create a session object and take a refeence on key that come
from logged in slots, but will leave that for later.

Issue that had to be wroked around: the password callback.
I used it to allow interactive pin usage, but the callabcks are only passed
to the _load() function.

Therefore we need code to defer loading or retry loading if a login was
required (basically always for private keys).

May be a bug to open with OpenSSL, UI pin callbacks should be provided
also at store open.

Fixes #37 