### PR TITLE
Make use of the session stored on the store ctx

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -285,10 +285,10 @@ static P11PROV_KEY *object_handle_to_key(CK_FUNCTION_LIST *f, CK_SLOT_ID slotid,
 }
 
 int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
-              CK_SLOT_ID slotid, CK_OBJECT_CLASS class, P11PROV_URI *uri)
+              CK_SESSION_HANDLE session, CK_SLOT_ID slotid,
+              CK_OBJECT_CLASS class, P11PROV_URI *uri)
 {
     CK_FUNCTION_LIST *f = p11prov_ctx_fns(provctx);
-    CK_SESSION_HANDLE session;
     CK_ATTRIBUTE id = p11prov_uri_get_id(uri);
     char *label = p11prov_uri_get_object(uri);
     CK_ATTRIBUTE template[3] = {
@@ -306,13 +306,6 @@ int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
 
     if (f == NULL) {
         return result;
-    }
-
-    ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
-    if (ret != CKR_OK) {
-        P11PROV_raise(provctx, ret, "Failed to open session on slot %lu",
-                      slotid);
-        return ret;
     }
 
     if (id.type == CKA_ID) {
@@ -370,11 +363,6 @@ again:
         }
     } else {
         P11PROV_raise(provctx, ret, "Error returned by C_FindObjectsInit");
-    }
-
-    ret = f->C_CloseSession(session);
-    if (ret != CKR_OK) {
-        P11PROV_raise(provctx, ret, "Failed to close session %lu", session);
     }
 
     if (result == CKR_OK) {

--- a/src/provider.h
+++ b/src/provider.h
@@ -92,7 +92,8 @@ CK_OBJECT_HANDLE p11prov_key_handle(P11PROV_KEY *key);
 CK_ULONG p11prov_key_size(P11PROV_KEY *key);
 
 int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
-              CK_SLOT_ID slotid, CK_OBJECT_CLASS class, P11PROV_URI *uri);
+              CK_SESSION_HANDLE session, CK_SLOT_ID slotid,
+              CK_OBJECT_CLASS class, P11PROV_URI *uri);
 P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        CK_SESSION_HANDLE session,
                                        bool session_key, unsigned char *secret,

--- a/src/store.c
+++ b/src/store.c
@@ -254,8 +254,8 @@ static void store_load(struct p11prov_store_ctx *ctx,
             P11PROV_KEY *pub_key = NULL;
             CK_RV ret;
 
-            ret = find_keys(ctx->provctx, &priv_key, &pub_key, slotid, class,
-                            ctx->parsed_uri);
+            ret = find_keys(ctx->provctx, &priv_key, &pub_key, ctx->session,
+                            slotid, class, ctx->parsed_uri);
             if (ret == CKR_OK) {
                 /* new object */
                 P11PROV_OBJ *obj;


### PR DESCRIPTION
No need to open a new session in find_keys when we already have
one on the store context.