### PR TITLE
Fix infinite loop in case no key was found.

### DIFF
--- a/src/kdf.c
+++ b/src/kdf.c
@@ -284,8 +284,11 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         /* Create Session  and key from key material */
 
         if (hkdfctx->session == CK_INVALID_HANDLE) {
-            hkdfctx->session = p11prov_get_session(hkdfctx->provctx, &slotid,
-                                                   NULL, NULL, NULL, NULL);
+            ret = p11prov_get_session(hkdfctx->provctx, &slotid, NULL, NULL,
+                                      NULL, NULL, &hkdfctx->session);
+            if (ret != CKR_OK) {
+                return RET_OSSL_ERR;
+            }
         }
         if (hkdfctx->session == CK_INVALID_HANDLE) {
             return RET_OSSL_ERR;

--- a/src/keys.c
+++ b/src/keys.c
@@ -363,6 +363,7 @@ again:
         }
     } else {
         P11PROV_raise(provctx, ret, "Error returned by C_FindObjectsInit");
+        result = ret;
     }
 
     if (result == CKR_OK) {

--- a/src/provider.h
+++ b/src/provider.h
@@ -238,9 +238,9 @@ CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
 char *p11prov_uri_get_object(P11PROV_URI *uri);
 int p11prov_get_pin(const char *in, char **out);
-CK_SESSION_HANDLE p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
-                                      CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
-                                      OSSL_PASSPHRASE_CALLBACK *pw_cb,
-                                      void *pw_cbarg);
+CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
+                          CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
+                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
+                          CK_SESSION_HANDLE *session);
 void p11prov_put_session(P11PROV_CTX *provctx, CK_SESSION_HANDLE session);
 #endif /* _PROVIDER_H */

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -212,6 +212,15 @@ ossl 'pkey -in $PRIURI -pubin -pubout -out ${TSTCRT}.pub'
 title LINE "Export Public key to a file (with pin)"
 ossl 'pkey -in $BASEURIWITHPIN -pubin -pubout -out ${TSTCRT}.pub'
 
+title PARA "Export Public check error"
+FAIL=0
+ossl 'pkey -in pkcs11:id=%de%ad -pubin
+           -pubout -out ${TSTCRT}-invlid.pub' || FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "Invalid pkcs11 uri resulted in no error exporting key"
+    exit 1
+fi
+
 title PARA "Export EC Public key to a file"
 #ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${ECCRT}.pub'
 


### PR DESCRIPTION
This happened while testing with an incorrect pkcs11_uri, the code now
always initialized ctx->loaded to an invalid value on unrecoverable
errors and causes the store load to properly fail.
