### PR TITLE
Key loading

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -115,10 +115,7 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
     p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
                   params);
 
-    encctx->key = p11prov_object_get_key(obj, false);
-    if (encctx->key == NULL) {
-        encctx->key = p11prov_object_get_key(obj, true);
-    }
+    encctx->key = p11prov_object_get_key(obj, 0);
     if (encctx->key == NULL) {
         return RET_OSSL_ERR;
     }
@@ -219,7 +216,7 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
     p11prov_debug("encrypt init (ctx=%p, key=%p, params=%p)\n", ctx, provkey,
                   params);
 
-    encctx->key = p11prov_object_get_key(obj, true);
+    encctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
     if (encctx->key == NULL) {
         return RET_OSSL_ERR;
     }

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -186,7 +186,7 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
     }
 
     p11prov_key_free(ecdhctx->key);
-    ecdhctx->key = p11prov_object_get_key(obj, true);
+    ecdhctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
     if (ecdhctx->key == NULL) {
         return RET_OSSL_ERR;
     }
@@ -204,7 +204,7 @@ static int p11prov_ecdh_set_peer(void *ctx, void *provkey)
     }
 
     p11prov_key_free(ecdhctx->peer_key);
-    ecdhctx->peer_key = p11prov_object_get_key(obj, false);
+    ecdhctx->peer_key = p11prov_object_get_key(obj, CKO_PUBLIC_KEY);
     if (ecdhctx->peer_key == NULL) {
         return RET_OSSL_ERR;
     }
@@ -616,7 +616,7 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
 
     if (provobj != &p11prov_hkdfkm_static_ctx) {
         p11prov_key_free(hkdfctx->key);
-        hkdfctx->key = p11prov_object_get_key(obj, true);
+        hkdfctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
         if (hkdfctx->key == NULL) {
             return RET_OSSL_ERR;
         }

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -190,7 +190,7 @@ static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
         return 0;
     }
 
-    key = p11prov_object_get_key(obj, false);
+    key = p11prov_object_get_key(obj, 0);
     if (key == NULL) {
         ret = RET_OSSL_ERR;
         goto done;
@@ -435,7 +435,7 @@ static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
         return 0;
     }
 
-    key = p11prov_object_get_key(obj, false);
+    key = p11prov_object_get_key(obj, 0);
     if (key == NULL) {
         ret = RET_OSSL_ERR;
         goto done;

--- a/src/provider.h
+++ b/src/provider.h
@@ -91,9 +91,10 @@ CK_SLOT_ID p11prov_key_slotid(P11PROV_KEY *key);
 CK_OBJECT_HANDLE p11prov_key_handle(P11PROV_KEY *key);
 CK_ULONG p11prov_key_size(P11PROV_KEY *key);
 
-int find_keys(P11PROV_CTX *provctx, P11PROV_KEY **priv, P11PROV_KEY **pub,
-              CK_SESSION_HANDLE session, CK_SLOT_ID slotid,
-              CK_OBJECT_CLASS class, P11PROV_URI *uri);
+typedef CK_RV (*store_key_callback)(void *, CK_OBJECT_CLASS, P11PROV_KEY *);
+CK_RV find_keys(P11PROV_CTX *provctx, CK_SESSION_HANDLE session,
+                CK_SLOT_ID slotid, P11PROV_URI *uri, store_key_callback cb,
+                void *cb_ctx);
 P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        CK_SESSION_HANDLE session,
                                        bool session_key, unsigned char *secret,
@@ -106,7 +107,7 @@ P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
                                         size_t reference_sz);
 int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                          void *cb_arg);
-P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj, bool priv);
+P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj, CK_OBJECT_CLASS class);
 
 /* dispatching */
 #define DECL_DISPATCH_FUNC(type, prefix, name) \
@@ -198,8 +199,8 @@ extern const OSSL_DISPATCH p11prov_hkdf_kdf_functions[];
 
 struct fetch_attrs {
     CK_ATTRIBUTE_TYPE type;
-    unsigned char **value;
-    unsigned long *value_len;
+    CK_BYTE **value;
+    CK_ULONG *value_len;
     bool allocate;
     bool required;
 };

--- a/src/store.c
+++ b/src/store.c
@@ -79,7 +79,7 @@ bool p11prov_object_check_key(P11PROV_OBJ *obj, bool priv)
     if (priv) {
         return obj->class == CKO_PRIVATE_KEY;
     }
-    return obj->class == CKO_PRIVATE_KEY;
+    return obj->class == CKO_PUBLIC_KEY;
 }
 
 P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj, CK_OBJECT_CLASS class)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -243,14 +243,10 @@ fi
 title PARA "Sign and Verify with provided Hash and RSA"
 ossl 'dgst -sha256 -binary -out ${TMPDIR}/sha256.bin ${SEEDFILE}'
 ossl '
-pkeyutl -sign -inkey "${BASEURI}"
+pkeyutl -sign -inkey "${PRIURI}"
               -in ${TMPDIR}/sha256.bin
               -out ${TMPDIR}/sha256-sig.bin'
 
-ossl '
-pkeyutl -verify -inkey "${PRIURI}"
-                -in ${TMPDIR}/sha256.bin
-                -sigfile ${TMPDIR}/sha256-sig.bin'
 ossl '
 pkeyutl -verify -inkey "${PUBURI}"
                 -pubin
@@ -264,7 +260,7 @@ pkeyutl -sign -inkey "${ECBASEURI}"
               -out ${TMPDIR}/sha256-ecsig.bin'
 
 ossl '
-pkeyutl -verify -inkey "${ECBASEURI}"
+pkeyutl -verify -inkey "${ECBASEURI}" -pubin
                 -in ${TMPDIR}/sha256.bin
                 -sigfile ${TMPDIR}/sha256-ecsig.bin'
 
@@ -278,7 +274,7 @@ pkeyutl -sign -inkey "${BASEURI}"
               -rawin
               -out ${TMPDIR}/sha256-dgstsig.bin'
 ossl '
-pkeyutl -verify -inkey "${BASEURI}"
+pkeyutl -verify -inkey "${BASEURI}" -pubin
                 -digest sha256
                 -in ${TMPDIR}/64krandom.bin
                 -rawin
@@ -302,7 +298,7 @@ pkeyutl -sign -inkey "${BASEURI}"
               -rawin
               -out ${TMPDIR}/sha256-dgstsig.bin'
 ossl '
-pkeyutl -verify -inkey "${BASEURI}"
+pkeyutl -verify -inkey "${BASEURI}" -pubin
                 -digest sha256
                 -pkeyopt pad-mode:pss
                 -pkeyopt mgf1-digest:sha256
@@ -331,7 +327,7 @@ pkeyutl -sign -inkey "${ECBASEURI}"
               -rawin
               -out ${TMPDIR}/sha256-ecdgstsig.bin'
 ossl '
-pkeyutl -verify -inkey "${ECBASEURI}"
+pkeyutl -verify -inkey "${ECBASEURI}" -pubin
                 -digest sha256
                 -in ${TMPDIR}/64krandom.bin
                 -rawin
@@ -359,7 +355,7 @@ diff ${TMPDIR}/secret.txt ${TMPDIR}/secret.txt.dec
 
 title LINE "Now again all in the token"
 ossl '
-pkeyutl -encrypt -inkey "${PRIURI}"
+pkeyutl -encrypt -inkey "${PUBURI}" -pubin
                  -in ${TMPDIR}/secret.txt
                  -out ${TMPDIR}/secret.txt.enc2'
 ossl '


### PR DESCRIPTION
Always load all keys in the token when the store is queried.

Store only one key per p11prov_obj, prepare it to contain other object types in the future.