### PR TITLE
Session object pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tests/openssl.cnf
 tests/tokens
 tests/tmp
+tests/tsession
 tests/*.log
 tests/*.trs
 /pkcs11-provider-?.?/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ pkcs11_provider_la_SOURCES = \
 	platform/endian.h \
 	provider.h \
 	provider.c \
+	session.c \
 	signature.c \
 	store.c \
 	util.c \

--- a/src/keys.c
+++ b/src/keys.c
@@ -40,7 +40,7 @@ static P11PROV_KEY *p11prov_key_new(void)
 
 P11PROV_KEY *p11prov_key_ref(P11PROV_KEY *key)
 {
-    if (key && __atomic_fetch_add(&key->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
+    if (key && __atomic_fetch_add(&key->refcnt, 1, __ATOMIC_SEQ_CST) > 0) {
         return key;
     }
 
@@ -54,7 +54,7 @@ void p11prov_key_free(P11PROV_KEY *key)
     if (key == NULL) {
         return;
     }
-    if (__atomic_sub_fetch(&key->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
+    if (__atomic_sub_fetch(&key->refcnt, 1, __ATOMIC_SEQ_CST) != 0) {
         P11PROV_debug("key free: reference held");
         return;
     }

--- a/src/provider.h
+++ b/src/provider.h
@@ -95,6 +95,15 @@ extern int debug_lazy_init;
 #define P11PROV_debug_slot(...) \
     P11PROV_debug_status(p11prov_debug_slot(__VA_ARGS__))
 
+#define P11PROV_debug_once(...) \
+    do { \
+        static int called = 0; \
+        if (!called) { \
+            P11PROV_debug_status(p11prov_debug(__VA_ARGS__)); \
+            called = 1; \
+        } \
+    } while (0)
+
 void p11prov_debug_init(void);
 void p11prov_debug(const char *fmt, ...);
 void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
@@ -265,6 +274,8 @@ char *p11prov_uri_get_object(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
 int p11prov_get_pin(const char *in, char **out);
+bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
+                            uint64_t *start_time);
 
 /* Sessions */
 CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,

--- a/src/provider.h
+++ b/src/provider.h
@@ -43,11 +43,14 @@ typedef struct p11prov_key P11PROV_KEY;
 typedef struct p11prov_uri P11PROV_URI;
 typedef struct p11prov_obj P11PROV_OBJ;
 typedef struct p11prov_session P11PROV_SESSION;
+typedef struct p11prov_session_pool P11PROV_SESSION_POOL;
 
 struct p11prov_slot {
     CK_SLOT_ID id;
     CK_SLOT_INFO slot;
     CK_TOKEN_INFO token;
+
+    P11PROV_SESSION_POOL *pool;
 
     CK_ULONG profiles[5];
 };
@@ -56,12 +59,7 @@ struct p11prov_slot {
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_status(P11PROV_CTX *ctx, CK_FUNCTION_LIST **fns);
-int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
-void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
-/* the login_session functions must be called under lock */
-CK_RV p11prov_ctx_get_login_session(P11PROV_CTX *ctx,
-                                    P11PROV_SESSION **session);
-CK_RV p11prov_ctx_set_login_session(P11PROV_CTX *ctx, P11PROV_SESSION *session);
+int p11prov_ctx_get_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 
 /* Errors */
 void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
@@ -269,10 +267,9 @@ CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
 int p11prov_get_pin(const char *in, char **out);
 
 /* Sessions */
-P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid);
-P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session);
-CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,
-                           CK_UTF8CHAR_PTR pin, CK_ULONG pinlen);
+CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,
+                                P11PROV_SESSION_POOL **_pool);
+CK_RV p11prov_session_pool_free(P11PROV_SESSION_POOL *pool);
 void p11prov_session_free(P11PROV_SESSION *session);
 CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session);
 CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,

--- a/src/provider.h
+++ b/src/provider.h
@@ -264,8 +264,11 @@ void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
 char *p11prov_uri_get_object(P11PROV_URI *uri);
+char *p11prov_uri_get_pin(P11PROV_URI *uri);
+CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
 int p11prov_get_pin(const char *in, char **out);
 
+/* Sessions */
 P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid);
 P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session);
 CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,

--- a/src/provider.h
+++ b/src/provider.h
@@ -120,6 +120,10 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        P11PROV_SESSION *session,
                                        bool session_key, unsigned char *secret,
                                        size_t secretlen);
+CK_RV p11prov_derive_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
+                         CK_MECHANISM *mechanism, CK_OBJECT_HANDLE handle,
+                         CK_ATTRIBUTE *template, CK_ULONG nattrs,
+                         P11PROV_SESSION **session, CK_OBJECT_HANDLE *key);
 
 /* Object Store */
 void p11prov_object_free(P11PROV_OBJ *obj);
@@ -249,9 +253,10 @@ struct fetch_attrs {
         x.ulValueLen = _c; \
     } while (0)
 
-int p11prov_fetch_attributes(CK_FUNCTION_LIST *f, P11PROV_SESSION *session,
-                             CK_OBJECT_HANDLE object, struct fetch_attrs *attrs,
-                             unsigned long attrnums);
+CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
+                               CK_OBJECT_HANDLE object,
+                               struct fetch_attrs *attrs,
+                               unsigned long attrnums);
 
 #define MAX_PIN_LENGTH 32
 P11PROV_URI *p11prov_parse_uri(const char *uri);

--- a/src/session.c
+++ b/src/session.c
@@ -36,7 +36,7 @@ P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid)
 P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session)
 {
     if (session
-        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
+        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_SEQ_CST) > 0) {
         return session;
     }
 
@@ -88,7 +88,7 @@ void p11prov_session_free(P11PROV_SESSION *session)
         return;
     }
 
-    if (__atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
+    if (__atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_SEQ_CST) != 0) {
         return;
     }
 

--- a/src/session.c
+++ b/src/session.c
@@ -1,0 +1,252 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include "provider.h"
+#include <string.h>
+
+/* Session stuff */
+struct p11prov_session {
+    P11PROV_CTX *provctx;
+
+    CK_SLOT_ID slotid;
+    CK_SESSION_HANDLE session;
+
+    int refcnt;
+};
+
+P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid)
+{
+    P11PROV_SESSION *sess;
+
+    sess = OPENSSL_zalloc(sizeof(P11PROV_SESSION));
+    if (sess == NULL) {
+        P11PROV_raise(ctx, CKR_HOST_MEMORY, "Failed to allocate session");
+        return NULL;
+    }
+
+    sess->provctx = ctx;
+    sess->slotid = slotid;
+    sess->session = CK_INVALID_HANDLE;
+
+    sess->refcnt = 1;
+
+    return sess;
+}
+
+P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session)
+{
+    if (session
+        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
+        return session;
+    }
+
+    return NULL;
+}
+
+CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,
+                           CK_UTF8CHAR_PTR pin, CK_ULONG pinlen)
+{
+    CK_FUNCTION_LIST *f;
+    CK_RV ret;
+
+    ret = p11prov_ctx_status(session->provctx, &f);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    ret = f->C_OpenSession(session->slotid, CKF_SERIAL_SESSION, NULL, NULL,
+                           &session->session);
+    if (ret != CKR_OK) {
+        P11PROV_raise(session->provctx, ret,
+                      "Failed to open session on slot %lu", session->slotid);
+        return CKR_FUNCTION_FAILED;
+    }
+
+    if (!login) {
+        return CKR_OK;
+    }
+
+    /* Supports only USER login sessions for now */
+    ret = f->C_Login(session->session, CKU_USER, pin, pinlen);
+    if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
+        int retc;
+        P11PROV_raise(session->provctx, ret, "Error returned by C_Login");
+        retc = f->C_CloseSession(session->session);
+        if (retc != CKR_OK) {
+            P11PROV_raise(session->provctx, retc, "Failed to close session %lu",
+                          session->session);
+        }
+        return ret;
+    }
+
+    return CKR_OK;
+}
+
+void p11prov_session_free(P11PROV_SESSION *session)
+{
+    if (session == NULL) {
+        return;
+    }
+
+    if (__atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
+        return;
+    }
+
+    if (session->session != CK_INVALID_HANDLE) {
+        CK_FUNCTION_LIST *f;
+        CK_RV ret;
+
+        ret = p11prov_ctx_status(session->provctx, &f);
+        if (ret == CKR_OK) {
+            ret = f->C_CloseSession(session->session);
+            if (ret != CKR_OK) {
+                P11PROV_raise(session->provctx, ret,
+                              "Failed to close session %lu", session->session);
+            }
+        }
+    }
+
+    OPENSSL_clear_free(session, sizeof(P11PROV_SESSION));
+}
+
+CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session)
+{
+    return session->session;
+}
+
+static CK_RV token_login(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
+                         P11PROV_URI *uri, OSSL_PASSPHRASE_CALLBACK *pw_cb,
+                         void *pw_cbarg)
+{
+    P11PROV_SESSION *sess;
+    char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
+    size_t cb_pin_len = 0;
+    CK_UTF8CHAR_PTR pin;
+    CK_ULONG pinlen = 0;
+    CK_RV ret;
+
+    ret = p11prov_ctx_get_login_session(provctx, &sess);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+    if (sess) {
+        /* we already have a login_session */
+        return CKR_OK;
+    }
+
+    sess = p11prov_session_new(provctx, slotid);
+    if (sess == NULL) {
+        return CKR_HOST_MEMORY;
+    }
+
+    pin = (CK_UTF8CHAR_PTR)p11prov_uri_get_pin(uri);
+    if (!pin) {
+        pin = p11prov_ctx_pin(provctx);
+    }
+    if (pin) {
+        pinlen = strlen((const char *)pin);
+    } else if (pw_cb) {
+        const char *info = "PKCS#11 Token";
+        OSSL_PARAM params[2] = {
+            OSSL_PARAM_DEFN(OSSL_PASSPHRASE_PARAM_INFO, OSSL_PARAM_UTF8_STRING,
+                            (void *)info, sizeof(info)),
+            OSSL_PARAM_END,
+        };
+        ret = pw_cb(cb_pin, sizeof(cb_pin), &cb_pin_len, params, pw_cbarg);
+        if (ret != RET_OSSL_OK) {
+            ret = CKR_GENERAL_ERROR;
+            goto done;
+        }
+
+        pin = (CK_UTF8CHAR_PTR)cb_pin;
+        pinlen = cb_pin_len;
+    } else {
+        ret = CKR_GENERAL_ERROR;
+        goto done;
+    }
+
+    ret = p11prov_session_open(sess, true, pin, pinlen);
+
+done:
+    OPENSSL_cleanse(cb_pin, cb_pin_len);
+    return ret;
+}
+
+CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
+                          CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
+                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
+                          P11PROV_SESSION **session)
+{
+    P11PROV_SESSION *sess;
+    CK_SLOT_ID id = *slotid;
+    struct p11prov_slot *slots = NULL;
+    int nslots = 0;
+    int i;
+    CK_RV ret = CKR_CANCEL;
+
+    nslots = p11prov_ctx_lock_slots(provctx, &slots);
+
+    for (i = 0; i < nslots; i++) {
+        if (id != CK_UNAVAILABLE_INFORMATION && id != slots[i].id) {
+            continue;
+        }
+
+        /* ignore slots that are not initialized */
+        if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
+            continue;
+        }
+        if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
+            continue;
+        }
+
+        id = slots[i].id;
+        ret = CKR_OK;
+
+        if (uri) {
+            CK_TOKEN_INFO token = slots[i].token;
+
+            /* skip slots that do not match */
+            ret = p11prov_uri_match_token(uri, &token);
+            if (ret == CKR_CANCEL) {
+                continue;
+            }
+            if (ret == CKR_OK && (token.flags & CKF_LOGIN_REQUIRED)) {
+                ret = token_login(provctx, id, uri, pw_cb, pw_cbarg);
+            }
+        }
+        break;
+    }
+
+    if (ret == CKR_OK) {
+        /* Found a slot, return it and the next slot to the caller for
+         * continuation if the current slot does not yield the desired
+         * results */
+        *slotid = id;
+        if (next_slotid) {
+            if (i + 1 < nslots) {
+                *next_slotid = slots[i + 1].id;
+            } else {
+                *next_slotid = CK_UNAVAILABLE_INFORMATION;
+            }
+        }
+    } else {
+        *next_slotid = CK_UNAVAILABLE_INFORMATION;
+    }
+
+    p11prov_ctx_unlock_slots(provctx, &slots);
+
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    sess = p11prov_session_new(provctx, id);
+    if (sess == NULL) {
+        return CKR_HOST_MEMORY;
+    }
+    ret = p11prov_session_open(sess, false, NULL, 0);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+    *session = sess;
+    return CKR_OK;
+}

--- a/src/session.c
+++ b/src/session.c
@@ -7,91 +7,32 @@
 /* Session stuff */
 struct p11prov_session {
     P11PROV_CTX *provctx;
+    P11PROV_SESSION_POOL *pool;
 
     CK_SLOT_ID slotid;
     CK_SESSION_HANDLE session;
 
     int refcnt;
+    int free;
 };
 
-P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid)
+struct p11prov_session_pool {
+    P11PROV_CTX *provctx;
+
+    CK_ULONG max_sessions;
+    CK_ULONG limit_sessions;
+    CK_ULONG cur_sessions;
+
+    P11PROV_SESSION **sessions;
+    int num_p11sessions;
+
+    P11PROV_SESSION *login_session;
+
+    pthread_mutex_t lock;
+};
+
+static void internal_session_close(P11PROV_SESSION *session)
 {
-    P11PROV_SESSION *sess;
-
-    sess = OPENSSL_zalloc(sizeof(P11PROV_SESSION));
-    if (sess == NULL) {
-        P11PROV_raise(ctx, CKR_HOST_MEMORY, "Failed to allocate session");
-        return NULL;
-    }
-
-    sess->provctx = ctx;
-    sess->slotid = slotid;
-    sess->session = CK_INVALID_HANDLE;
-
-    sess->refcnt = 1;
-
-    return sess;
-}
-
-P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session)
-{
-    if (session
-        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_SEQ_CST) > 0) {
-        return session;
-    }
-
-    return NULL;
-}
-
-CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,
-                           CK_UTF8CHAR_PTR pin, CK_ULONG pinlen)
-{
-    CK_FUNCTION_LIST *f;
-    CK_RV ret;
-
-    ret = p11prov_ctx_status(session->provctx, &f);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-
-    ret = f->C_OpenSession(session->slotid, CKF_SERIAL_SESSION, NULL, NULL,
-                           &session->session);
-    if (ret != CKR_OK) {
-        P11PROV_raise(session->provctx, ret,
-                      "Failed to open session on slot %lu", session->slotid);
-        return CKR_FUNCTION_FAILED;
-    }
-
-    if (!login) {
-        return CKR_OK;
-    }
-
-    /* Supports only USER login sessions for now */
-    ret = f->C_Login(session->session, CKU_USER, pin, pinlen);
-    if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
-        int retc;
-        P11PROV_raise(session->provctx, ret, "Error returned by C_Login");
-        retc = f->C_CloseSession(session->session);
-        if (retc != CKR_OK) {
-            P11PROV_raise(session->provctx, retc, "Failed to close session %lu",
-                          session->session);
-        }
-        return ret;
-    }
-
-    return CKR_OK;
-}
-
-void p11prov_session_free(P11PROV_SESSION *session)
-{
-    if (session == NULL) {
-        return;
-    }
-
-    if (__atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_SEQ_CST) != 0) {
-        return;
-    }
-
     if (session->session != CK_INVALID_HANDLE) {
         CK_FUNCTION_LIST *f;
         CK_RV ret;
@@ -104,9 +45,265 @@ void p11prov_session_free(P11PROV_SESSION *session)
                               "Failed to close session %lu", session->session);
             }
         }
+        /* regardless of the result the sesssion is gone */
+        if (session->pool) {
+            (void)__atomic_fetch_sub(&session->pool->cur_sessions, 1,
+                                     __ATOMIC_SEQ_CST);
+        }
+        session->session = CK_INVALID_HANDLE;
+    }
+}
+
+CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,
+                                P11PROV_SESSION_POOL **_pool)
+{
+    P11PROV_SESSION_POOL *pool;
+
+    P11PROV_debug("Creating new session pool");
+
+    pool = OPENSSL_zalloc(sizeof(P11PROV_SESSION_POOL));
+    if (!pool) {
+        return CKR_HOST_MEMORY;
+    }
+    pool->provctx = ctx;
+
+    pthread_mutex_init(&pool->lock, 0);
+
+    if (token->ulMaxSessionCount != CK_EFFECTIVELY_INFINITE
+        && token->ulMaxSessionCount != CK_UNAVAILABLE_INFORMATION) {
+        pool->max_sessions = token->ulMaxSessionCount;
+        /* keep a max of 10% of the sessions */
+        pool->limit_sessions = pool->max_sessions / 10;
+        if (pool->limit_sessions == 0) {
+            pool->limit_sessions = 3;
+        }
+    } else {
+        /* arbitrary max concurrent open sessions */
+        pool->max_sessions = 1024;
+        pool->limit_sessions = 8;
+    }
+    if (pool->limit_sessions > pool->max_sessions) {
+        pool->limit_sessions = pool->max_sessions;
     }
 
-    OPENSSL_clear_free(session, sizeof(P11PROV_SESSION));
+    P11PROV_debug("New session pool %p created", pool);
+
+    *_pool = pool;
+    return CKR_OK;
+}
+
+CK_RV p11prov_session_pool_free(P11PROV_SESSION_POOL *pool)
+{
+    P11PROV_SESSION *session;
+
+    P11PROV_debug("Freeing session pool %p", pool);
+
+    if (!pool) {
+        return CKR_OK;
+    }
+
+    /* deref login_session first */
+    p11prov_session_free(pool->login_session);
+
+    /* LOCKED SECTION ------------- */
+    pthread_mutex_lock(&pool->lock);
+    for (int i = 0; i < pool->num_p11sessions; i++) {
+        session = pool->sessions[i];
+        if (session->refcnt > 1) {
+            P11PROV_raise(pool->provctx, CKR_GENERAL_ERROR,
+                          "Can't free multiply-referenced session (%u)", i);
+            /* orphan this session */
+            session->pool = NULL;
+            pool->sessions[i] = NULL;
+            continue;
+        }
+        internal_session_close(session);
+        OPENSSL_clear_free(session, sizeof(P11PROV_SESSION));
+        pool->sessions[i] = NULL;
+    }
+    OPENSSL_free(pool->sessions);
+    pool->sessions = NULL;
+    pool->num_p11sessions = 0;
+    pthread_mutex_unlock(&pool->lock);
+    /* ------------- LOCKED SECTION */
+
+    pthread_mutex_destroy(&pool->lock);
+    OPENSSL_clear_free(pool, sizeof(P11PROV_SESSION_POOL));
+
+    return CKR_OK;
+}
+
+#define SESS_ALLOC_SIZE 32
+static P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx,
+                                            struct p11prov_slot *slot)
+{
+    P11PROV_SESSION_POOL *p = slot->pool;
+    P11PROV_SESSION *session;
+
+    P11PROV_debug("Creating new P11PROV_SESSION session on pool %p", p);
+
+    /* cap the amount of obtainable P11PROV_SESSIONs to double the max
+     * number of available pkcs11 token sessions, just to have a limit
+     * in case of runaway concurrent threads */
+    if (p->num_p11sessions > (int)(p->max_sessions * 2)) {
+        P11PROV_raise(ctx, CKR_SESSION_COUNT, "Max sessions limit reached");
+        return NULL;
+    }
+
+    session = OPENSSL_zalloc(sizeof(P11PROV_SESSION));
+    if (session == NULL) {
+        P11PROV_raise(ctx, CKR_HOST_MEMORY, "Failed to allocate session");
+        return NULL;
+    }
+
+    session->provctx = ctx;
+    session->slotid = slot->id;
+    session->session = CK_INVALID_HANDLE;
+    session->pool = p;
+    session->refcnt = 1;
+
+    /* LOCKED SECTION ------------- */
+    pthread_mutex_lock(&p->lock);
+
+    /* check if we need to expand the sessions array */
+    if ((p->num_p11sessions % SESS_ALLOC_SIZE) == 0) {
+        P11PROV_SESSION **tmp =
+            OPENSSL_realloc(p->sessions, (p->num_p11sessions + SESS_ALLOC_SIZE)
+                                             * sizeof(P11PROV_SESSION *));
+        if (tmp == NULL) {
+            P11PROV_raise(ctx, CKR_HOST_MEMORY,
+                          "Failed to re-allocate sessions array");
+            OPENSSL_free(session);
+            pthread_mutex_unlock(&p->lock);
+            return NULL;
+        }
+        p->sessions = tmp;
+    }
+    p->sessions[p->num_p11sessions] = session;
+    p->num_p11sessions++;
+
+    pthread_mutex_unlock(&p->lock);
+    /* ------------- LOCKED SECTION */
+
+    P11PROV_debug("Total sessions: %d", p->num_p11sessions);
+
+    return session;
+}
+
+static P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session)
+{
+    if (session
+        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_SEQ_CST) > 0) {
+        return session;
+    }
+
+    return NULL;
+}
+
+static CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,
+                                  CK_UTF8CHAR_PTR pin, CK_ULONG pinlen)
+{
+    P11PROV_SESSION_POOL *p = session->pool;
+    CK_ULONG cur_sessions;
+    CK_FUNCTION_LIST *f;
+    CK_RV ret;
+
+    ret = p11prov_ctx_status(session->provctx, &f);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    cur_sessions = __atomic_add_fetch(&p->cur_sessions, 1, __ATOMIC_SEQ_CST);
+    if (cur_sessions > p->max_sessions) {
+        P11PROV_raise(session->provctx, ret, "Max sessions limit");
+        (void)__atomic_sub_fetch(&p->cur_sessions, 1, __ATOMIC_SEQ_CST);
+        return CKR_SESSION_COUNT;
+    }
+
+    ret = f->C_OpenSession(session->slotid, CKF_SERIAL_SESSION, NULL, NULL,
+                           &session->session);
+    if (ret != CKR_OK) {
+        P11PROV_raise(session->provctx, ret,
+                      "Failed to open session on slot %lu", session->slotid);
+        (void)__atomic_sub_fetch(&p->cur_sessions, 1, __ATOMIC_SEQ_CST);
+        return ret;
+    }
+
+    if (login) {
+        /* Supports only USER login sessions for now */
+        ret = f->C_Login(session->session, CKU_USER, pin, pinlen);
+        if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
+            P11PROV_raise(session->provctx, ret, "Error returned by C_Login");
+            internal_session_close(session);
+            return ret;
+        }
+    }
+
+    return CKR_OK;
+}
+
+void p11prov_session_free(P11PROV_SESSION *session)
+{
+    int ref;
+
+    P11PROV_debug("Session Free %p", session);
+
+    if (session == NULL) {
+        return;
+    }
+
+    ref = __atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_SEQ_CST);
+    if (ref > 1) {
+        return;
+    }
+    if (ref < 1) {
+        /* only the pool should really free sessions.
+         * raise a warning */
+        P11PROV_raise(session->provctx, CKR_GENERAL_ERROR,
+                      "Potential double free in the calling code");
+        /* and restore the refcnt to 1 */
+        __atomic_store_n(&session->refcnt, 1, __ATOMIC_SEQ_CST);
+        return;
+    }
+    /* last ref means we go busy -> free */
+    if (ref == 1) {
+        P11PROV_SESSION_POOL *p = session->pool;
+        CK_ULONG cur_sessions;
+        bool ok;
+        int expected = 0;
+
+        if (p == NULL) {
+            /* session was orphaned, just free it */
+            internal_session_close(session);
+            OPENSSL_clear_free(session, sizeof(P11PROV_SESSION));
+            return;
+        }
+
+        if (p->login_session == session) {
+            __atomic_store_n(&session->pool->login_session, NULL,
+                             __ATOMIC_SEQ_CST);
+        }
+
+        /* check if we used more than threshold sessions, in that case also
+         * close the session to avoid hogging all the sessions of a token */
+        cur_sessions = __atomic_load_n(&p->cur_sessions, __ATOMIC_SEQ_CST);
+        if (cur_sessions > p->limit_sessions) {
+            P11PROV_debug(
+                "Session Free: Soft limit (%lu/%lu), releasing session: %lu",
+                cur_sessions, p->limit_sessions, session->session);
+            internal_session_close(session);
+        }
+
+        /* now that all is taken care of, set session to free so it can be
+         * immediately taken by another thread */
+        ok = __atomic_compare_exchange_n(&session->free, &expected, 1, false,
+                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+        if (!ok) {
+            P11PROV_raise(session->provctx, CKR_GENERAL_ERROR,
+                          "Expected a busy session on freeing, got: %d",
+                          expected);
+        }
+    }
 }
 
 CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session)
@@ -114,29 +311,35 @@ CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session)
     return session->session;
 }
 
-static CK_RV token_login(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
+static CK_RV token_login(P11PROV_CTX *provctx, struct p11prov_slot *slot,
                          P11PROV_URI *uri, OSSL_PASSPHRASE_CALLBACK *pw_cb,
                          void *pw_cbarg)
 {
-    P11PROV_SESSION *sess;
+    P11PROV_SESSION *session;
     char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
     size_t cb_pin_len = 0;
     CK_UTF8CHAR_PTR pin;
     CK_ULONG pinlen = 0;
     CK_RV ret;
 
-    ret = p11prov_ctx_get_login_session(provctx, &sess);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-    if (sess) {
+    if (slot->pool->login_session) {
         /* we already have a login_session */
         return CKR_OK;
     }
 
-    sess = p11prov_session_new(provctx, slotid);
-    if (sess == NULL) {
-        return CKR_HOST_MEMORY;
+    session = p11prov_session_new(provctx, slot);
+    if (session == NULL) {
+        return CKR_GENERAL_ERROR;
+    }
+
+    /* ref now, so we can simply p11prov_ession_free() later on errors */
+    session = p11prov_session_ref(session);
+    if (session == NULL) {
+        P11PROV_raise(provctx, CKR_GENERAL_ERROR,
+                      "Failed to ref count session");
+        /* intentionally leave this broken session busy so it won't be
+         * used anymore */
+        return CKR_GENERAL_ERROR;
     }
 
     pin = (CK_UTF8CHAR_PTR)p11prov_uri_get_pin(uri);
@@ -165,9 +368,14 @@ static CK_RV token_login(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
         goto done;
     }
 
-    ret = p11prov_session_open(sess, true, pin, pinlen);
+    ret = p11prov_session_open(session, true, pin, pinlen);
 
 done:
+    if (ret == CKR_OK) {
+        session->pool->login_session = session;
+    } else {
+        p11prov_session_free(session);
+    }
     OPENSSL_cleanse(cb_pin, cb_pin_len);
     return ret;
 }
@@ -175,16 +383,19 @@ done:
 CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
-                          P11PROV_SESSION **session)
+                          P11PROV_SESSION **_session)
 {
-    P11PROV_SESSION *sess;
+    P11PROV_SESSION *session = NULL;
     CK_SLOT_ID id = *slotid;
     struct p11prov_slot *slots = NULL;
+    struct p11prov_slot *slot = NULL;
     int nslots = 0;
     int i;
     CK_RV ret = CKR_CANCEL;
 
-    nslots = p11prov_ctx_lock_slots(provctx, &slots);
+    P11PROV_debug("Get session on slot %lu", id);
+
+    nslots = p11prov_ctx_get_slots(provctx, &slots);
 
     for (i = 0; i < nslots; i++) {
         if (id != CK_UNAVAILABLE_INFORMATION && id != slots[i].id) {
@@ -200,10 +411,11 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
         }
 
         id = slots[i].id;
+        slot = &slots[i];
         ret = CKR_OK;
 
         if (uri) {
-            CK_TOKEN_INFO token = slots[i].token;
+            CK_TOKEN_INFO token = slot->token;
 
             /* skip slots that do not match */
             ret = p11prov_uri_match_token(uri, &token);
@@ -211,7 +423,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                 continue;
             }
             if (ret == CKR_OK && (token.flags & CKF_LOGIN_REQUIRED)) {
-                ret = token_login(provctx, id, uri, pw_cb, pw_cbarg);
+                ret = token_login(provctx, slot, uri, pw_cb, pw_cbarg);
             }
         }
         break;
@@ -233,20 +445,102 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
         *next_slotid = CK_UNAVAILABLE_INFORMATION;
     }
 
-    p11prov_ctx_unlock_slots(provctx, &slots);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    ret = CKR_OK;
+
+    /* LOCKED SECTION ------------- */
+    pthread_mutex_lock(&slot->pool->lock);
+    for (i = 0; i < slot->pool->num_p11sessions; i++) {
+        if (slot->pool->sessions[i]->free) {
+            if (slot->pool->sessions[i]->session == CK_INVALID_HANDLE) {
+                /* store session found but continue to search for one with
+                 * an actual cached token session if any is available */
+                if (session != NULL) {
+                    session = slot->pool->sessions[i];
+                }
+                continue;
+            } else {
+                /* Bingo! This is it, a free session with a cached handle */
+                session = slot->pool->sessions[i];
+                break;
+            }
+        }
+    }
+    if (session != NULL) {
+        bool ok;
+        int expected = 1;
+
+        ok = __atomic_compare_exchange_n(&session->free, &expected, 0, false,
+                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+        if (!ok) {
+            P11PROV_raise(provctx, CKR_GENERAL_ERROR,
+                          "Unexpectd busy session while holding lock");
+            ret = CKR_GENERAL_ERROR;
+        }
+    }
+    pthread_mutex_unlock(&slot->pool->lock);
+    /* ------------- LOCKED SECTION */
 
     if (ret != CKR_OK) {
         return ret;
     }
 
-    sess = p11prov_session_new(provctx, id);
-    if (sess == NULL) {
-        return CKR_HOST_MEMORY;
+    if (session == NULL) {
+        session = p11prov_session_new(provctx, slot);
+        if (session == NULL) {
+            return CKR_GENERAL_ERROR;
+        }
     }
-    ret = p11prov_session_open(sess, false, NULL, 0);
-    if (ret != CKR_OK) {
-        return ret;
+
+    /* ref now, so we can simply p11prov_session_free() later on errors */
+    session = p11prov_session_ref(session);
+    if (session == NULL) {
+        P11PROV_raise(provctx, CKR_GENERAL_ERROR,
+                      "Failed to ref count session");
+        /* intentionally leave this broken session busy so it won't be
+         * used anymore */
+        return CKR_GENERAL_ERROR;
     }
-    *session = sess;
-    return CKR_OK;
+
+    if (session->session != CK_INVALID_HANDLE) {
+        /* check that the pkcs11 session is still ok */
+        CK_FUNCTION_LIST *f;
+        CK_SESSION_INFO session_info;
+
+        ret = p11prov_ctx_status(provctx, &f);
+        if (ret != CKR_OK) {
+            goto done;
+        }
+
+        ret = f->C_GetSessionInfo(session->session, &session_info);
+        switch (ret) {
+        case CKR_OK:
+            break;
+        case CKR_SESSION_CLOSED:
+        case CKR_SESSION_HANDLE_INVALID:
+            (void)__atomic_sub_fetch(&slot->pool->cur_sessions, 1,
+                                     __ATOMIC_SEQ_CST);
+            session->session = CK_INVALID_HANDLE;
+            break;
+        default:
+            P11PROV_raise(provctx, ret, "Error returned by C_GetSessionInfo");
+            ret = CKR_GENERAL_ERROR;
+            goto done;
+        }
+    }
+
+    if (session->session == CK_INVALID_HANDLE) {
+        ret = p11prov_session_open(session, false, NULL, 0);
+    }
+
+done:
+    if (ret == CKR_OK) {
+        *_session = session;
+    } else {
+        p11prov_session_free(session);
+    }
+    return ret;
 }

--- a/src/store.c
+++ b/src/store.c
@@ -43,7 +43,7 @@ static CK_RV p11prov_object_new(P11PROV_CTX *ctx, CK_OBJECT_CLASS class,
 
 static P11PROV_OBJ *p11prov_object_ref(P11PROV_OBJ *obj)
 {
-    if (obj && __atomic_fetch_add(&obj->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
+    if (obj && __atomic_fetch_add(&obj->refcnt, 1, __ATOMIC_SEQ_CST) > 0) {
         return obj;
     }
 
@@ -57,7 +57,7 @@ void p11prov_object_free(P11PROV_OBJ *obj)
     if (obj == NULL) {
         return;
     }
-    if (__atomic_sub_fetch(&obj->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
+    if (__atomic_sub_fetch(&obj->refcnt, 1, __ATOMIC_SEQ_CST) != 0) {
         P11PROV_debug("object free: reference held");
         return;
     }

--- a/src/store.c
+++ b/src/store.c
@@ -180,7 +180,7 @@ struct p11prov_store_ctx {
     char *properties;
     char *input_type;
 
-    CK_SESSION_HANDLE session;
+    P11PROV_SESSION *session;
 
     int loaded;
 
@@ -198,12 +198,8 @@ static void p11prov_store_ctx_free(struct p11prov_store_ctx *ctx)
         return;
     }
 
-    if (ctx->session != CK_INVALID_HANDLE) {
-        CK_FUNCTION_LIST_PTR f;
-        CK_RV ret = p11prov_ctx_status(ctx->provctx, &f);
-        if (ret == CKR_OK) {
-            (void)f->C_CloseSession(ctx->session);
-        }
+    if (ctx->session != NULL) {
+        p11prov_session_free(ctx->session);
     }
 
     p11prov_uri_free(ctx->parsed_uri);
@@ -264,8 +260,8 @@ static void store_load(struct p11prov_store_ctx *ctx,
     do {
         nextid = CK_UNAVAILABLE_INFORMATION;
 
-        if (ctx->session != CK_INVALID_HANDLE) {
-            p11prov_put_session(ctx->provctx, ctx->session);
+        if (ctx->session != NULL) {
+            p11prov_session_free(ctx->session);
         }
 
         ret =

--- a/src/util.c
+++ b/src/util.c
@@ -396,132 +396,12 @@ char *p11prov_uri_get_object(P11PROV_URI *uri)
     return uri->object;
 }
 
-int p11prov_get_pin(const char *in, char **out)
+char *p11prov_uri_get_pin(P11PROV_URI *uri)
 {
-    size_t outlen;
-
-    if (strncmp(in, "file:", 5) == 0) {
-        return get_pin_file(in, strlen(in), out, &outlen);
-    }
-
-    *out = OPENSSL_strdup(in);
-    if (!*out) {
-        return ENOMEM;
-    }
-
-    return 0;
+    return uri->pin;
 }
 
-/* Session stuff */
-struct p11prov_session {
-    P11PROV_CTX *provctx;
-
-    CK_SLOT_ID slotid;
-    CK_SESSION_HANDLE session;
-
-    int refcnt;
-};
-
-P11PROV_SESSION *p11prov_session_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid)
-{
-    P11PROV_SESSION *sess;
-
-    sess = OPENSSL_zalloc(sizeof(P11PROV_SESSION));
-    if (sess == NULL) {
-        P11PROV_raise(ctx, CKR_HOST_MEMORY, "Failed to allocate session");
-        return NULL;
-    }
-
-    sess->provctx = ctx;
-    sess->slotid = slotid;
-    sess->session = CK_INVALID_HANDLE;
-
-    sess->refcnt = 1;
-
-    return sess;
-}
-
-P11PROV_SESSION *p11prov_session_ref(P11PROV_SESSION *session)
-{
-    if (session
-        && __atomic_fetch_add(&session->refcnt, 1, __ATOMIC_ACQ_REL) > 0) {
-        return session;
-    }
-
-    return NULL;
-}
-
-CK_RV p11prov_session_open(P11PROV_SESSION *session, bool login,
-                           CK_UTF8CHAR_PTR pin, CK_ULONG pinlen)
-{
-    CK_FUNCTION_LIST *f;
-    CK_RV ret;
-
-    ret = p11prov_ctx_status(session->provctx, &f);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-    ret = f->C_OpenSession(session->slotid, CKF_SERIAL_SESSION, NULL, NULL,
-                           &session->session);
-    if (ret != CKR_OK) {
-        P11PROV_raise(session->provctx, ret,
-                      "Failed to open session on slot %lu", session->slotid);
-        return CKR_FUNCTION_FAILED;
-    }
-
-    if (!login) {
-        return CKR_OK;
-    }
-
-    /* Supports only USER login sessions for now */
-    ret = f->C_Login(session->session, CKU_USER, pin, pinlen);
-    if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
-        int retc;
-        P11PROV_raise(session->provctx, ret, "Error returned by C_Login");
-        retc = f->C_CloseSession(session->session);
-        if (retc != CKR_OK) {
-            P11PROV_raise(session->provctx, retc, "Failed to close session %lu",
-                          session->session);
-        }
-        return ret;
-    }
-
-    return CKR_OK;
-}
-
-void p11prov_session_free(P11PROV_SESSION *session)
-{
-    if (session == NULL) {
-        return;
-    }
-
-    if (__atomic_sub_fetch(&session->refcnt, 1, __ATOMIC_ACQ_REL) != 0) {
-        return;
-    }
-
-    if (session->session != CK_INVALID_HANDLE) {
-        CK_FUNCTION_LIST *f;
-        CK_RV ret;
-
-        ret = p11prov_ctx_status(session->provctx, &f);
-        if (ret == CKR_OK) {
-            ret = f->C_CloseSession(session->session);
-            if (ret != CKR_OK) {
-                P11PROV_raise(session->provctx, ret,
-                              "Failed to close session %lu", session->session);
-            }
-        }
-    }
-
-    OPENSSL_clear_free(session, sizeof(P11PROV_SESSION));
-}
-
-CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session)
-{
-    return session->session;
-}
-
-static CK_RV match_token(CK_TOKEN_INFO *token, P11PROV_URI *uri)
+CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token)
 {
     if (uri->model
         && strncmp(uri->model, (const char *)token->model, 16) != 0) {
@@ -544,140 +424,18 @@ static CK_RV match_token(CK_TOKEN_INFO *token, P11PROV_URI *uri)
     return CKR_OK;
 }
 
-static CK_RV token_login(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
-                         P11PROV_URI *uri, OSSL_PASSPHRASE_CALLBACK *pw_cb,
-                         void *pw_cbarg)
+int p11prov_get_pin(const char *in, char **out)
 {
-    P11PROV_SESSION *sess;
-    char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
-    size_t cb_pin_len = 0;
-    CK_UTF8CHAR_PTR pin = NULL;
-    CK_ULONG pinlen = 0;
-    CK_RV ret;
+    size_t outlen;
 
-    ret = p11prov_ctx_get_login_session(provctx, &sess);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-    if (sess) {
-        /* we already have a login_session */
-        return CKR_OK;
+    if (strncmp(in, "file:", 5) == 0) {
+        return get_pin_file(in, strlen(in), out, &outlen);
     }
 
-    sess = p11prov_session_new(provctx, slotid);
-    if (sess == NULL) {
-        return CKR_HOST_MEMORY;
+    *out = OPENSSL_strdup(in);
+    if (!*out) {
+        return ENOMEM;
     }
 
-    if (uri->pin) {
-        pin = (CK_UTF8CHAR_PTR)uri->pin;
-    } else {
-        pin = p11prov_ctx_pin(provctx);
-    }
-    if (pin) {
-        pinlen = strlen((const char *)pin);
-    } else if (pw_cb) {
-        const char *info = "PKCS#11 Token";
-        OSSL_PARAM params[2] = {
-            OSSL_PARAM_DEFN(OSSL_PASSPHRASE_PARAM_INFO, OSSL_PARAM_UTF8_STRING,
-                            (void *)info, sizeof(info)),
-            OSSL_PARAM_END,
-        };
-        ret = pw_cb(cb_pin, sizeof(cb_pin), &cb_pin_len, params, pw_cbarg);
-        if (ret != RET_OSSL_OK) {
-            ret = CKR_GENERAL_ERROR;
-            goto done;
-        }
-
-        pin = (CK_UTF8CHAR_PTR)cb_pin;
-        pinlen = cb_pin_len;
-    } else {
-        ret = CKR_GENERAL_ERROR;
-        goto done;
-    }
-
-    ret = p11prov_session_open(sess, true, pin, pinlen);
-
-done:
-    OPENSSL_cleanse(cb_pin, cb_pin_len);
-    return ret;
-}
-
-CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
-                          CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
-                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
-                          P11PROV_SESSION **session)
-{
-    P11PROV_SESSION *sess;
-    CK_SLOT_ID id = *slotid;
-    struct p11prov_slot *slots = NULL;
-    int nslots = 0;
-    int i;
-    CK_RV ret = CKR_CANCEL;
-
-    nslots = p11prov_ctx_lock_slots(provctx, &slots);
-
-    for (i = 0; i < nslots; i++) {
-        if (id != CK_UNAVAILABLE_INFORMATION && id != slots[i].id) {
-            continue;
-        }
-
-        /* ignore slots that are not initialized */
-        if ((slots[i].slot.flags & CKF_TOKEN_PRESENT) == 0) {
-            continue;
-        }
-        if ((slots[i].token.flags & CKF_TOKEN_INITIALIZED) == 0) {
-            continue;
-        }
-
-        id = slots[i].id;
-        ret = CKR_OK;
-
-        if (uri) {
-            CK_TOKEN_INFO token = slots[i].token;
-
-            /* skip slots that do not match */
-            ret = match_token(&token, uri);
-            if (ret == CKR_CANCEL) {
-                continue;
-            }
-            if (ret == CKR_OK && (token.flags & CKF_LOGIN_REQUIRED)) {
-                ret = token_login(provctx, id, uri, pw_cb, pw_cbarg);
-            }
-        }
-        break;
-    }
-
-    if (ret == CKR_OK) {
-        /* Found a slot, return it and the next slot to the caller for
-         * continuation if the current slot does not yield the desired
-         * results */
-        *slotid = id;
-        if (next_slotid) {
-            if (i + 1 < nslots) {
-                *next_slotid = slots[i + 1].id;
-            } else {
-                *next_slotid = CK_UNAVAILABLE_INFORMATION;
-            }
-        }
-    } else {
-        *next_slotid = CK_UNAVAILABLE_INFORMATION;
-    }
-
-    p11prov_ctx_unlock_slots(provctx, &slots);
-
-    if (ret != CKR_OK) {
-        return ret;
-    }
-
-    sess = p11prov_session_new(provctx, id);
-    if (sess == NULL) {
-        return CKR_HOST_MEMORY;
-    }
-    ret = p11prov_session_open(sess, false, NULL, 0);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-    *session = sess;
-    return CKR_OK;
+    return 0;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,6 +5,12 @@ softokenpath=@SOFTOKENDIR@/@SOFTOKEN_SUBDIR@libsoftokn3.so
 libtoollibs=@abs_top_builddir@/src/.libs
 testsdir=@abs_top_builddir@/tests
 
+check_PROGRAMS = tsession
+
+tsession_SOURCES = tsession.c
+tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tsession_LDADD = $(OPENSSL_LIBS)
+
 dist_check_SCRIPTS = \
 	test.sh
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -415,4 +415,7 @@ pkeyutl -derive -kdf HKDF -kdflen 48
                 -out ${TMPDIR}/hkdf2-out.bin'
 diff ${TMPDIR}/hkdf2-out-pkcs11.bin ${TMPDIR}/hkdf2-out.bin
 
+title PARA "Test session support"
+BASEURI="${BASEURI}" ./tsession
+
 exit 0

--- a/tests/tsession.c
+++ b/tests/tsession.c
@@ -1,0 +1,104 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/store.h>
+
+/* concurrent operations */
+#define CNUM 16
+
+int main(int argc, char *argv[])
+{
+    const char *baseuri;
+    OSSL_STORE_CTX *store;
+    OSSL_STORE_INFO *info;
+    EVP_PKEY *prikey = NULL;
+    EVP_PKEY *pubkey = NULL;
+    EVP_MD_CTX *sign_md[CNUM] = {};
+    int ret;
+
+    baseuri = getenv("BASEURI");
+    if (baseuri == NULL) {
+        fprintf(stderr, "No BASEURI\n");
+        exit(EXIT_FAILURE);
+    }
+
+    store = OSSL_STORE_open(baseuri, NULL, NULL, NULL, NULL);
+    if (store == NULL) {
+        fprintf(stderr, "Failed to open pkcs11 store\n");
+        exit(EXIT_FAILURE);
+    }
+
+    for (info = OSSL_STORE_load(store); info != NULL;
+         info = OSSL_STORE_load(store)) {
+        int type = OSSL_STORE_INFO_get_type(info);
+
+        switch (type) {
+        case OSSL_STORE_INFO_PUBKEY:
+            pubkey = OSSL_STORE_INFO_get1_PUBKEY(info);
+            break;
+        case OSSL_STORE_INFO_PKEY:
+            prikey = OSSL_STORE_INFO_get1_PKEY(info);
+            break;
+        }
+    }
+
+    if (pubkey == NULL) {
+        fprintf(stderr, "Failed to load public key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (prikey == NULL) {
+        fprintf(stderr, "Failed to load private key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    /* Do this twice to check that freeing and taling again sessions
+     * works correctly and caching of open sessions work as expected */
+    for (int r = 0; r < 2; r++) {
+        /* Start a series of signin operation so code grabs sessions */
+        for (int c = 0; c < CNUM; c++) {
+            const char *data = "Sign Me!";
+            sign_md[c] = EVP_MD_CTX_new();
+            if (sign_md[c] == NULL) {
+                fprintf(stderr, "Failed to init EVP_MD_CTX\n");
+                exit(EXIT_FAILURE);
+            }
+
+            ret = EVP_DigestSignInit_ex(sign_md[c], NULL, "SHA256", NULL, NULL,
+                                        prikey, NULL);
+            if (ret != 1) {
+                fprintf(stderr, "Failed to init EVP_DigestSign\n");
+                exit(EXIT_FAILURE);
+            }
+
+            ret = EVP_DigestSignUpdate(sign_md[c], data, sizeof(data));
+            if (ret != 1) {
+                fprintf(stderr, "Failed to EVP_DigestSignUpdate\n");
+                exit(EXIT_FAILURE);
+            }
+
+            /* do not finalize just yet, leave this open to hold on sessions */
+        }
+
+        for (int c = 0; c < CNUM; c++) {
+            size_t size = EVP_PKEY_get_size(prikey);
+            unsigned char sig[size];
+            ret = EVP_DigestSignFinal(sign_md[c], sig, &size);
+            if (ret != 1) {
+                fprintf(stderr, "Failed to EVP_DigestSignFinal-ize\n");
+                exit(EXIT_FAILURE);
+            }
+            EVP_MD_CTX_free(sign_md[c]);
+        }
+    }
+
+    OSSL_STORE_close(store);
+    EVP_PKEY_free(prikey);
+    EVP_PKEY_free(pubkey);
+
+    fprintf(stderr, "ALL A-OK!");
+
+    exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
This PR implement a session object as well as pooling of session objects.

The design reuses allocated objects to minimize memory allocation on reuse, it also permits referencing of session objects multiple times. No code uses this currently but I can see it done when the code currently tries to duplicate sessions perhaps. This is a detail that will need discussion.

freeing a session object causes locking to be used in order to move a session object from the busy_sessions list to the free_sessions list. This is something we may want to avoid, so needs discussion.

Fixes #32 

- [x] tests for concurrent use of sessions