### PR TITLE
Fail hard make check if nss-softokn devel files were not found

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,8 @@ testsdir=@abs_top_builddir@/tests
 dist_check_SCRIPTS = \
 	test.sh
 
+check_SCRIPTS = $(softokenpath)
+
 TESTS = $(dist_check_SCRIPTS)
 
 TESTS_ENVIRONMENT =     \


### PR DESCRIPTION
The test would fail if softokn has wrong path detected. It is required
just for testing, not a normal build. Add a simple check to makefile to
indicate a working path is expected.