### PR TITLE
Debug: remove zero bytes after newlines

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -40,7 +40,7 @@ void p11prov_debug(const char *fmt, ...)
     va_start(args, fmt);
     vfprintf(stddebug, fmt, args);
     va_end(args);
-    fwrite(newline, sizeof(newline), 1, stddebug);
+    fwrite(newline, 1, 1, stddebug);
     fflush(stddebug);
 }
 


### PR DESCRIPTION
Last PR ended up adding a zero byte after each newline character in
error.