### PR TITLE
fixes for git, autotools and library lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# project-specific ignore patterns
+tests/openssl.cnf
+tests/tokens
+tests/tmp
+
+# generic ignore patterns (c, autotools, etc)
 INSTALL
 Makefile
 Makefile.in
@@ -21,20 +27,14 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 missing
-src/.deps/
-src/Makefile
-src/Makefile.in
 src/config.h
 src/config.h.in
 src/stamp-h1
 cscope.out
-src/.libs/
-src/*.la
-src/*.lo
-src/*.o
+.deps/
+.libs/
+*.la
+*.lo
+*.o
 *~
-src/*~
 test-driver
-tests/openssl.cnf
-tests/tokens
-tests/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 tests/openssl.cnf
 tests/tokens
 tests/tmp
+tests/*.log
+tests/*.trs
+/pkcs11-provider-?.?/
+/pkcs11-provider-?.?.tar.?z
 
 # generic ignore patterns (c, autotools, etc)
 INSTALL

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ missing
 src/config.h
 src/config.h.in
 src/stamp-h1
-cscope.out
 .deps/
 .libs/
 *.la
@@ -38,3 +37,18 @@ cscope.out
 *.o
 *~
 test-driver
+tags
+.tags
+!tags/
+TAGS
+.TAGS
+!TAGS/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,3 +17,20 @@ check-style-show:
 
 check-style-fix:
 	git diff -U0 --no-color --relative origin/main | clang-format-diff -i -p1
+
+DISTCLEANFILES = \
+	*~
+
+MAINTAINERCLEANFILES = \
+	Makefile.in \
+	aclocal.m4 \
+	ar-lib compile \
+	config.guess \
+	config.sub \
+	configure \
+	depcomp \
+	install-sh \
+	ltmain.sh \
+	m4/* \
+	missing \
+	test-driver

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,4 +35,8 @@ pkcs11_provider_la_LDFLAGS = \
 	-avoid-version \
 	-export-symbols "$(srcdir)/provider.exports"
 
+DISTCLEANFILES = \
+	*~
 
+MAINTAINERCLEANFILES = \
+	Makefile.in config.h.in

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,12 @@ clean-local:
 	rm -Rf tmp
 	rm -Rf tokens
 
+DISTCLEANFILES = \
+	*~
+
+MAINTAINERCLEANFILES = \
+	Makefile.in
+
 edit_cmd = $(SED) \
     -e 's|@softokenpath[@]|$(softokenpath)|g' \
     -e 's|@libtoollibs[@]|$(libtoollibs)|g' \


### PR DESCRIPTION
As I started to work with the project, I realized some missing git ignore patterns and files the base automake targets. This series contains some fixes for these issues.

I decided to split my changes into multiple commits, just to make it more clear, what I've changed. But I'm open to merge some of them, if you prefer it.