### PR TITLE
Repurpose p11prov_ctx_fns as status check function

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -111,9 +111,15 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
+    CK_RV ret;
 
     P11PROV_debug("encrypt init (ctx=%p, key=%p, params=%p)", ctx, provkey,
                   params);
+
+    ret = p11prov_ctx_status(encctx->provctx, NULL);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     encctx->key = p11prov_object_get_key(obj, 0);
     if (encctx->key == NULL) {
@@ -135,7 +141,7 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     CK_OBJECT_HANDLE handle;
     CK_ULONG out_size = *outlen;
     int result = RET_OSSL_ERR;
-    int ret;
+    CK_RV ret;
 
     P11PROV_debug("encrypt (ctx=%p)", ctx);
 
@@ -149,8 +155,8 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_OK;
     }
 
-    f = p11prov_ctx_fns(encctx->provctx);
-    if (f == NULL) {
+    ret = p11prov_ctx_status(encctx->provctx, &f);
+    if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
     slotid = p11prov_key_slotid(encctx->key);
@@ -212,9 +218,15 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
     P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
+    CK_RV ret;
 
     P11PROV_debug("encrypt init (ctx=%p, key=%p, params=%p)", ctx, provkey,
                   params);
+
+    ret = p11prov_ctx_status(encctx->provctx, NULL);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     encctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
     if (encctx->key == NULL) {
@@ -236,7 +248,7 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     CK_OBJECT_HANDLE handle;
     CK_ULONG out_size = *outlen;
     int result = RET_OSSL_ERR;
-    int ret;
+    CK_RV ret;
 
     P11PROV_debug("decrypt (ctx=%p)", ctx);
 
@@ -250,8 +262,8 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_OK;
     }
 
-    f = p11prov_ctx_fns(encctx->provctx);
-    if (f == NULL) {
+    ret = p11prov_ctx_status(encctx->provctx, &f);
+    if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
     slotid = p11prov_key_slotid(encctx->key);

--- a/src/debug.c
+++ b/src/debug.c
@@ -57,14 +57,14 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
     CK_MECHANISM_INFO info = { 0 };
     CK_FUNCTION_LIST *f;
     const char *mechname = "UNKNOWN";
-    int ret;
+    CK_RV ret;
 
     if (debug_lazy_init < 0) {
         return;
     }
 
-    f = p11prov_ctx_fns(ctx);
-    if (f == NULL) {
+    ret = p11prov_ctx_status(ctx, &f);
+    if (ret != CKR_OK) {
         return;
     }
 

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -180,8 +180,14 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
 {
     P11PROV_EXCH_CTX *ecdhctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJ *obj = (P11PROV_OBJ *)provkey;
+    CK_RV ret;
 
     if (ctx == NULL || provkey == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    ret = p11prov_ctx_status(ecdhctx->provctx, NULL);
+    if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
 
@@ -236,7 +242,12 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     CK_OBJECT_HANDLE secret_handle;
     CK_SLOT_ID slotid;
     int result = RET_OSSL_ERR;
-    int ret;
+    CK_RV ret;
+
+    ret = p11prov_ctx_status(ecdhctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
 
     if (ecdhctx->key == NULL || ecdhctx->peer_key == NULL) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
@@ -291,11 +302,6 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
         P11PROV_raise(ecdhctx->provctx, CKR_SLOT_ID_INVALID,
                       "Provided key has invalid slot");
         return RET_OSSL_ERR;
-    }
-
-    f = p11prov_ctx_fns(ecdhctx->provctx);
-    if (f == NULL) {
-        return CKR_GENERAL_ERROR;
     }
 
     ret = f->C_OpenSession(slotid, CKF_SERIAL_SESSION, NULL, NULL, &session);
@@ -606,11 +612,17 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
 {
     P11PROV_EXCH_CTX *hkdfctx = (P11PROV_EXCH_CTX *)ctx;
     P11PROV_OBJ *obj = (P11PROV_OBJ *)provobj;
+    CK_RV ret;
 
     P11PROV_debug("hkdf exchange init (ctx:%p obj:%p params:%p)", ctx, obj,
                   params);
 
     if (ctx == NULL || provobj == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    ret = p11prov_ctx_status(hkdfctx->provctx, NULL);
+    if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
 

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -144,6 +144,11 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     CK_OBJECT_HANDLE dkey_handle;
     int ret = RET_OSSL_ERR;
 
+    ret = p11prov_ctx_status(hkdfctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
     P11PROV_debug("hkdf derive (ctx:%p, key:%p[%zu], params:%p)", ctx, key,
                   keylen, params);
 
@@ -171,11 +176,6 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     /* no salt ? */
     if (hkdfctx->params.ulSaltType == 0) {
         hkdfctx->params.ulSaltType = CKF_HKDF_SALT_NULL;
-    }
-
-    f = p11prov_ctx_fns(hkdfctx->provctx);
-    if (f == NULL) {
-        return RET_OSSL_ERR;
     }
 
     ret = f->C_DeriveKey(hkdfctx->session, &mechanism, pkey_handle,

--- a/src/keys.c
+++ b/src/keys.c
@@ -289,7 +289,7 @@ CK_RV find_keys(P11PROV_CTX *provctx, CK_SESSION_HANDLE session,
                 CK_SLOT_ID slotid, P11PROV_URI *uri, store_key_callback cb,
                 void *cb_ctx)
 {
-    CK_FUNCTION_LIST *f = p11prov_ctx_fns(provctx);
+    CK_FUNCTION_LIST *f;
     CK_OBJECT_CLASS class = p11prov_uri_get_class(uri);
     CK_ATTRIBUTE id = p11prov_uri_get_id(uri);
     char *label = p11prov_uri_get_object(uri);
@@ -302,8 +302,9 @@ CK_RV find_keys(P11PROV_CTX *provctx, CK_SESSION_HANDLE session,
 
     P11PROV_debug("Find keys");
 
-    if (f == NULL) {
-        return result;
+    ret = p11prov_ctx_status(provctx, &f);
+    if (ret != CKR_OK) {
+        return ret;
     }
 
     if (class != CK_UNAVAILABLE_INFORMATION) {
@@ -384,8 +385,8 @@ P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
     P11PROV_debug("keys: create secret key (session:%lu secret:%p[%zu])",
                   session, secret, secretlen);
 
-    f = p11prov_ctx_fns(provctx);
-    if (f == NULL) {
+    ret = p11prov_ctx_status(provctx, &f);
+    if (ret != CKR_OK) {
         return NULL;
     }
 

--- a/src/provider.h
+++ b/src/provider.h
@@ -54,7 +54,7 @@ struct p11prov_slot {
 /* Provider ctx */
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
-CK_FUNCTION_LIST *p11prov_ctx_fns(P11PROV_CTX *ctx);
+CK_RV p11prov_ctx_status(P11PROV_CTX *ctx, CK_FUNCTION_LIST **fns);
 int p11prov_ctx_lock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 void p11prov_ctx_unlock_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 /* the login_session functions must be called under lock */

--- a/src/store.c
+++ b/src/store.c
@@ -199,8 +199,9 @@ static void p11prov_store_ctx_free(struct p11prov_store_ctx *ctx)
     }
 
     if (ctx->session != CK_INVALID_HANDLE) {
-        CK_FUNCTION_LIST_PTR f = p11prov_ctx_fns(ctx->provctx);
-        if (f) {
+        CK_FUNCTION_LIST_PTR f;
+        CK_RV ret = p11prov_ctx_status(ctx->provctx, &f);
+        if (ret == CKR_OK) {
             (void)f->C_CloseSession(ctx->session);
         }
     }


### PR DESCRIPTION
Change this function to be a status check function that can optionally
return  a functions pointer.

This will make the error reutrned consistent and will be used generally
to check the status of the provider before even initializing new
functions so that error conditions can be returned early.