### PR TITLE
Fix covscan detected issues

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -76,7 +76,7 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 
     ret = f->C_GetMechanismInfo(slotid, type, &info);
     if (ret != CKR_OK) {
-        p11prov_debug("C_GetMechanismInfo for %s(%lu) failed %d\n", mechname,
+        p11prov_debug("C_GetMechanismInfo for %s(%lu) failed %lu\n", mechname,
                       type, ret);
     } else {
         p11prov_debug(

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -321,7 +321,7 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
         };
         ret = p11prov_fetch_attributes(f, session, secret_handle, attrs, 1);
         if (ret != CKR_OK) {
-            P11PROV_debug("ecdh failed to retrieve secret %d", ret);
+            P11PROV_debug("ecdh failed to retrieve secret %lu", ret);
         }
         *psecretlen = secret_len;
         result = RET_OSSL_OK;


### PR DESCRIPTION
Changing the type of the return error in some function caused some printf format argument to not match the correct type anymore.