### PR TITLE
Rsa keygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tests/openssl.cnf
 tests/tokens
 tests/tmp
 tests/tsession
+tests/tgenkey
 tests/*.log
 tests/*.trs
 /pkcs11-provider-?.?/

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,6 +9,7 @@ SHARED_EXT=@SHARED_EXT@
 pkcs11_provider_la_SOURCES = \
 	asymmetric_cipher.c \
 	debug.c \
+	encoder.c \
 	exchange.c \
 	kdf.c \
 	keymgmt.c \

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -179,7 +179,7 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              &session);
+                              false, false, &session);
     if (ret != CKR_OK) {
         P11PROV_raise(encctx->provctx, ret,
                       "Failed to open session on slot %lu", slotid);
@@ -284,7 +284,7 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
 
     ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              &session);
+                              true, false, &session);
     if (ret != CKR_OK) {
         P11PROV_raise(encctx->provctx, ret,
                       "Failed to open session on slot %lu", slotid);

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -1,0 +1,230 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include "provider.h"
+#include <openssl/bio.h>
+
+static void print_data_buffer(BIO *out, CK_BYTE *buf, int len, int justify,
+                              int linelen)
+{
+    int lines = 1;
+    int plen = len;
+    int pidx = 0;
+
+    if (linelen) {
+        lines = len / linelen;
+        if (len % linelen) {
+            lines++;
+        }
+        plen = linelen;
+    }
+
+    for (int l = 0; l < lines; l++) {
+        int i;
+        if (plen > len) {
+            plen = len;
+        }
+        if (justify) {
+            BIO_printf(out, "%*s", justify, "");
+        }
+        for (i = 0; i < plen; i++) {
+            char c[2];
+            c[0] = (buf[pidx + i] >> 4);
+            c[1] = (buf[pidx + i] & 0x0f);
+            for (int j = 0; j < 2; j++) {
+                c[j] += '0';
+                if (c[j] > '9') {
+                    c[j] += ('a' - '0' - 10);
+                }
+            }
+            BIO_write(out, c, 2);
+        }
+        len -= plen;
+        pidx += i;
+        BIO_write(out, "\n", 1);
+    }
+}
+
+DISPATCH_BASE_ENCODER_FN(rsa, newctx);
+DISPATCH_BASE_ENCODER_FN(rsa, freectx);
+DISPATCH_TEXT_ENCODER_FN(rsa, encode);
+
+struct p11prov_encoder_ctx {
+    P11PROV_CTX *provctx;
+};
+
+static void *p11prov_rsa_encoder_newctx(void *provctx)
+{
+    struct p11prov_encoder_ctx *ctx;
+
+    ctx = OPENSSL_zalloc(sizeof(struct p11prov_encoder_ctx));
+    if (!ctx) {
+        P11PROV_raise(provctx, CKR_HOST_MEMORY, "Allocation failed");
+        return NULL;
+    }
+    ctx->provctx = provctx;
+    return ctx;
+}
+
+static void p11prov_rsa_encoder_freectx(void *ctx)
+{
+    OPENSSL_free(ctx);
+}
+
+static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
+                                           const void *inkey,
+                                           const OSSL_PARAM key_abstract[],
+                                           int selection,
+                                           OSSL_PASSPHRASE_CALLBACK *cb,
+                                           void *cbarg)
+{
+    struct p11prov_encoder_ctx *ctx = (struct p11prov_encoder_ctx *)inctx;
+    CK_OBJECT_CLASS class = CK_UNAVAILABLE_INFORMATION;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)inkey;
+    P11PROV_KEY *key;
+    CK_KEY_TYPE type;
+    CK_ULONG keysize;
+    CK_ATTRIBUTE *a;
+    BIO *out;
+
+    P11PROV_debug("RSA Text Encoder");
+
+    switch (selection) {
+    case OSSL_KEYMGMT_SELECT_PRIVATE_KEY:
+        class = CKO_PRIVATE_KEY;
+        break;
+    case OSSL_KEYMGMT_SELECT_PUBLIC_KEY:
+        class = CKO_PUBLIC_KEY;
+        break;
+    case OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS:
+        return RET_OSSL_ERR;
+    }
+
+    key = p11prov_object_get_key(obj, class);
+    if (!key) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Object class");
+        return RET_OSSL_ERR;
+    }
+
+    type = p11prov_key_type(key);
+    if (type != CKK_RSA) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Key Type");
+        return RET_OSSL_ERR;
+    }
+
+    out = BIO_new_from_core_bio(p11prov_ctx_get_libctx(ctx->provctx), cbio);
+    if (!out) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Failed to init BIO");
+        return RET_OSSL_ERR;
+    }
+
+    keysize = p11prov_key_size(key);
+    if (class == CKO_PRIVATE_KEY) {
+        BIO_printf(out, "PKCS11 RSA Private Key (%lu bits)\n", keysize * 8);
+    } else {
+        BIO_printf(out, "PKCS11 RSA Public Key (%lu bits)\n", keysize * 8);
+    }
+
+    a = p11prov_key_attr(key, CKA_ID);
+    if (a) {
+        if (a->ulValueLen > 16) {
+            BIO_printf(out, "  Key ID:\n");
+            print_data_buffer(out, a->pValue, a->ulValueLen, 4, 16);
+        } else {
+            BIO_printf(out, "  Key ID: ");
+            print_data_buffer(out, a->pValue, a->ulValueLen, 0, 0);
+        }
+    }
+    a = p11prov_key_attr(key, CKA_LABEL);
+    if (a) {
+        BIO_printf(out, "  Label: %*s\n", (int)a->ulValueLen,
+                   (char *)a->pValue);
+    }
+    a = p11prov_key_attr(key, CKA_PUBLIC_EXPONENT);
+    if (a) {
+        BIO_printf(out, "  Exponent: 0x");
+        print_data_buffer(out, a->pValue, a->ulValueLen, 0, 0);
+        BIO_write(out, "\n", 1);
+    }
+    a = p11prov_key_attr(key, CKA_MODULUS);
+    if (a) {
+        BIO_printf(out, "  Modulus:\n");
+        print_data_buffer(out, a->pValue, a->ulValueLen, 4, 16);
+    }
+
+    BIO_free(out);
+    return RET_OSSL_OK;
+}
+
+const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
+    DISPATCH_BASE_ENCODER_ELEM(ENCODE, rsa, encode_text),
+    { 0, NULL },
+};
+
+DISPATCH_ENCODER_FN(rsa, pkcs1, der, does_selection);
+
+static int p11prov_rsa_encoder_pkcs1_der_does_selection(void *inctx,
+                                                        int selection)
+{
+    switch (selection) {
+    case OSSL_KEYMGMT_SELECT_PRIVATE_KEY:
+        return RET_OSSL_ERR;
+    case OSSL_KEYMGMT_SELECT_PUBLIC_KEY:
+        return RET_OSSL_ERR;
+    case OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS:
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_rsa_encoder_pkcs1_der_encode(
+    void *inctx, OSSL_CORE_BIO *cbio, const void *inkey,
+    const OSSL_PARAM key_abstract[], int selection,
+    OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+{
+    return RET_OSSL_ERR;
+}
+
+const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, pkcs1, der, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, rsa, pkcs1, der, encode),
+    { 0, NULL },
+};
+
+DISPATCH_ENCODER_FN(rsa, pkcs1, pem, does_selection);
+
+static int p11prov_rsa_encoder_pkcs1_pem_does_selection(void *inctx,
+                                                        int selection)
+{
+    switch (selection) {
+    case OSSL_KEYMGMT_SELECT_PRIVATE_KEY:
+        return RET_OSSL_ERR;
+    case OSSL_KEYMGMT_SELECT_PUBLIC_KEY:
+        return RET_OSSL_ERR;
+    case OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS:
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_rsa_encoder_pkcs1_pem_encode(
+    void *inctx, OSSL_CORE_BIO *cbio, const void *inkey,
+    const OSSL_PARAM key_abstract[], int selection,
+    OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+{
+    return RET_OSSL_ERR;
+}
+
+const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, pkcs1, pem, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, rsa, pkcs1, pem, encode),
+    { 0, NULL },
+};

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -605,7 +605,7 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
         return RET_OSSL_ERR;
     }
 
-    if (provobj != &p11prov_hkdfkm_static_ctx) {
+    if (provobj != &p11prov_hkdf_static_ctx) {
         p11prov_key_free(hkdfctx->key);
         hkdfctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
         if (hkdfctx->key == NULL) {

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -291,8 +291,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
         /* Create Session  and key from key material */
         if (hkdfctx->session == NULL) {
-            ret = p11prov_get_session(hkdfctx->provctx, &slotid, NULL, NULL,
-                                      NULL, NULL, &hkdfctx->session);
+            ret =
+                p11prov_get_session(hkdfctx->provctx, &slotid, NULL, NULL, NULL,
+                                    NULL, false, false, &hkdfctx->session);
             if (ret != CKR_OK) {
                 return RET_OSSL_ERR;
             }

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -2,52 +2,475 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include "provider.h"
+#include "platform/endian.h"
+#include <string.h>
 
-DISPATCH_RSAKM_FN(new);
-DISPATCH_RSAKM_FN(gen_init);
-DISPATCH_RSAKM_FN(gen);
-DISPATCH_RSAKM_FN(gen_cleanup);
-DISPATCH_RSAKM_FN(load);
-DISPATCH_RSAKM_FN(free);
-DISPATCH_RSAKM_FN(has);
-DISPATCH_RSAKM_FN(import);
-DISPATCH_RSAKM_FN(import_types);
-DISPATCH_RSAKM_FN(export);
-DISPATCH_RSAKM_FN(export_types);
-DISPATCH_RSAKM_FN(query_operation_name);
-DISPATCH_RSAKM_FN(get_params);
-DISPATCH_RSAKM_FN(gettable_params);
+DISPATCH_KEYMGMT_FN(common, gen_set_params);
+DISPATCH_KEYMGMT_FN(common, gen_settable_params);
+DISPATCH_KEYMGMT_FN(common, gen_cleanup);
 
-static void *p11prov_rsakm_new(void *provctx)
+DISPATCH_KEYMGMT_FN(rsa, new);
+DISPATCH_KEYMGMT_FN(rsa, gen_init);
+DISPATCH_KEYMGMT_FN(rsa, gen);
+DISPATCH_KEYMGMT_FN(rsa, load);
+DISPATCH_KEYMGMT_FN(rsa, free);
+DISPATCH_KEYMGMT_FN(rsa, has);
+DISPATCH_KEYMGMT_FN(rsa, import);
+DISPATCH_KEYMGMT_FN(rsa, import_types);
+DISPATCH_KEYMGMT_FN(rsa, export);
+DISPATCH_KEYMGMT_FN(rsa, export_types);
+DISPATCH_KEYMGMT_FN(rsa, query_operation_name);
+DISPATCH_KEYMGMT_FN(rsa, get_params);
+DISPATCH_KEYMGMT_FN(rsa, gettable_params);
+
+#define X962_PRIME_OID 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01
+#define X962_PRIME_OID_LEN 7
+#define SECG_OID 0x2B, 0x81, 0x04, 0x00
+#define SECG_OID_LEN 4
+#define OID_ID 0x06
+
+#define DEF_EC_PARAM(cname, base, num) \
+    const CK_BYTE cname##_param[] = { OID_ID, base##_LEN + 1, base, num }
+#define NAME_TO_PARAM(cname) \
+    { \
+        .name = #cname, .ec_param = cname##_param, \
+        .ec_param_size = sizeof(cname##_param) \
+    }
+#define ALIAS_TO_PARAM(alias, cname) \
+    { \
+        .name = alias, .ec_param = cname##_param, \
+        .ec_param_size = sizeof(cname##_param) \
+    }
+
+DEF_EC_PARAM(secp112r1, SECG_OID, 0x06);
+DEF_EC_PARAM(secp112r2, SECG_OID, 0x07);
+DEF_EC_PARAM(secp128r1, SECG_OID, 0x1C);
+DEF_EC_PARAM(secp128r2, SECG_OID, 0x1D);
+DEF_EC_PARAM(secp160k1, SECG_OID, 0x09);
+DEF_EC_PARAM(secp160r1, SECG_OID, 0x08);
+DEF_EC_PARAM(secp160r2, SECG_OID, 0x1E);
+DEF_EC_PARAM(secp192k1, SECG_OID, 0x1F);
+DEF_EC_PARAM(secp224k1, SECG_OID, 0x20);
+DEF_EC_PARAM(secp224r1, SECG_OID, 0x21);
+DEF_EC_PARAM(secp256k1, SECG_OID, 0x0A);
+DEF_EC_PARAM(secp384r1, SECG_OID, 0x22);
+DEF_EC_PARAM(secp521r1, SECG_OID, 0x23);
+DEF_EC_PARAM(prime192v1, X962_PRIME_OID, 0x01);
+DEF_EC_PARAM(prime192v2, X962_PRIME_OID, 0x02);
+DEF_EC_PARAM(prime192v3, X962_PRIME_OID, 0x03);
+DEF_EC_PARAM(prime239v1, X962_PRIME_OID, 0x04);
+DEF_EC_PARAM(prime239v2, X962_PRIME_OID, 0x05);
+DEF_EC_PARAM(prime239v3, X962_PRIME_OID, 0x06);
+DEF_EC_PARAM(prime256v1, X962_PRIME_OID, 0x07);
+
+struct {
+    const char *name;
+    const CK_BYTE *ec_param;
+    CK_ULONG ec_param_size;
+} ec_name_to_params[] = {
+    /* secg curves */
+    NAME_TO_PARAM(secp112r1),
+    NAME_TO_PARAM(secp112r2),
+    NAME_TO_PARAM(secp128r1),
+    NAME_TO_PARAM(secp128r2),
+    NAME_TO_PARAM(secp160k1),
+    NAME_TO_PARAM(secp160r1),
+    NAME_TO_PARAM(secp160r2),
+    NAME_TO_PARAM(secp192k1),
+    NAME_TO_PARAM(secp224k1),
+    NAME_TO_PARAM(secp224r1),
+    NAME_TO_PARAM(secp256k1),
+    NAME_TO_PARAM(secp384r1),
+    NAME_TO_PARAM(secp521r1),
+    /* X9.62 prime curves */
+    NAME_TO_PARAM(prime192v1),
+    NAME_TO_PARAM(prime192v2),
+    NAME_TO_PARAM(prime192v3),
+    NAME_TO_PARAM(prime239v1),
+    NAME_TO_PARAM(prime239v2),
+    NAME_TO_PARAM(prime239v3),
+    NAME_TO_PARAM(prime256v1),
+    /* NIST aliases */
+    ALIAS_TO_PARAM("P-192", prime192v1),
+    ALIAS_TO_PARAM("P-224", secp224r1),
+    ALIAS_TO_PARAM("P-256", prime256v1),
+    ALIAS_TO_PARAM("P-384", secp384r1),
+    ALIAS_TO_PARAM("P-521", secp521r1),
+    { NULL, NULL, 0 },
+};
+
+struct key_generator {
+    P11PROV_CTX *provctx;
+
+    CK_KEY_TYPE type;
+
+    char *label;
+    CK_BYTE *id;
+    CK_ULONG id_len;
+
+    union {
+        struct {
+            CK_ULONG modulus_bits;
+            CK_BYTE exponent[8];
+            CK_ULONG exponent_size;
+        } rsa;
+        struct {
+            const CK_BYTE *ec_params;
+            CK_ULONG ec_params_size;
+        } ec;
+    } data;
+};
+
+static void *p11prov_common_gen_init(void *provctx, int selection,
+                                     CK_KEY_TYPE type,
+                                     const OSSL_PARAM params[])
+{
+    struct key_generator *ctx = NULL;
+    /* big endian 65537 */
+    unsigned char def_e[] = { 0x01, 0x00, 0x01 };
+    int ret;
+
+    P11PROV_debug("rsa gen_init %p", provctx);
+
+    ret = p11prov_ctx_status(provctx, NULL);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
+    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0) {
+        P11PROV_raise(provctx, CKR_ARGUMENTS_BAD, "Unsupported selection");
+        return NULL;
+    }
+
+    ctx = OPENSSL_zalloc(sizeof(struct key_generator));
+    if (ctx == NULL) {
+        P11PROV_raise(provctx, CKR_HOST_MEMORY, "Failed to get key_generator");
+        return NULL;
+    }
+    ctx->provctx = (P11PROV_CTX *)provctx;
+    ctx->type = type;
+
+    /* set defaults */
+    switch (type) {
+    case CKK_RSA:
+        ctx->data.rsa.modulus_bits = 2048;
+        ctx->data.rsa.exponent_size = sizeof(def_e);
+        memcpy(ctx->data.rsa.exponent, def_e, ctx->data.rsa.exponent_size);
+        break;
+    case CKK_EC:
+        ctx->data.ec.ec_params = prime256v1_param;
+        ctx->data.ec.ec_params_size = sizeof(prime256v1_param);
+        break;
+    default:
+        P11PROV_raise(provctx, CKR_ARGUMENTS_BAD, "Invalid type %lu", type);
+        OPENSSL_free(ctx);
+        return NULL;
+    }
+
+    ret = p11prov_common_gen_set_params(ctx, params);
+    if (ret != RET_OSSL_OK) {
+        p11prov_common_gen_cleanup(ctx);
+        ctx = NULL;
+    }
+    return ctx;
+}
+
+static const OSSL_PARAM p11prov_rsa_params[] = {
+    OSSL_PARAM_utf8_string(P11PROV_PARAM_KEY_LABEL, NULL, 0),
+    OSSL_PARAM_octet_string(P11PROV_PARAM_KEY_ID, NULL, 0),
+    OSSL_PARAM_size_t(OSSL_PKEY_PARAM_RSA_BITS, NULL),
+    OSSL_PARAM_size_t(OSSL_PKEY_PARAM_RSA_PRIMES, NULL),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
+    OSSL_PARAM_END,
+};
+
+static const OSSL_PARAM p11prov_ec_params[] = {
+    OSSL_PARAM_utf8_string(P11PROV_PARAM_KEY_LABEL, NULL, 0),
+    OSSL_PARAM_octet_string(P11PROV_PARAM_KEY_ID, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
+    OSSL_PARAM_END,
+};
+
+static const OSSL_PARAM *p11prov_common_gen_settable_params(void *genctx,
+                                                            void *provctx)
+{
+    struct key_generator *ctx = (struct key_generator *)genctx;
+
+    switch (ctx->type) {
+    case CKK_RSA:
+        return p11prov_rsa_params;
+    case CKK_EC:
+        return p11prov_ec_params;
+    default:
+        P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                      "Invalid key gen type %lu", ctx->type);
+    }
+    return NULL;
+}
+
+static int p11prov_common_gen_set_params(void *genctx,
+                                         const OSSL_PARAM params[])
+{
+    struct key_generator *ctx = (struct key_generator *)genctx;
+    const OSSL_PARAM *p;
+    int ret;
+
+    if (params == NULL) {
+        return RET_OSSL_OK;
+    }
+
+    p = OSSL_PARAM_locate_const(params, P11PROV_PARAM_KEY_LABEL);
+    if (p) {
+        ret = OSSL_PARAM_get_utf8_string(p, &ctx->label, 0);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+    p = OSSL_PARAM_locate_const(params, P11PROV_PARAM_KEY_ID);
+    if (p) {
+        size_t id_len;
+        ret = OSSL_PARAM_get_octet_string(p, (void **)&ctx->id, 0, &id_len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+        ctx->id_len = id_len;
+    }
+    switch (ctx->type) {
+    case CKK_RSA:
+        p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_BITS);
+        if (p) {
+            size_t nbits;
+            ret = OSSL_PARAM_get_size_t(p, &nbits);
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
+            ctx->data.rsa.modulus_bits = nbits;
+        }
+        p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_PRIMES);
+        if (p) {
+            size_t primes;
+            ret = OSSL_PARAM_get_size_t(p, &primes);
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
+            if (primes != 2) {
+                P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                              "No multi-prime support");
+                return RET_OSSL_ERR;
+            }
+        }
+        p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E);
+        if (p) {
+            if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER) {
+                if (p->data_size > 8) {
+                    P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                                  "Unsupported RSA exponent size");
+                }
+                /* fix byte order if necessary while copying */
+                byteswap_buf(p->data, ctx->data.rsa.exponent, p->data_size);
+                ctx->data.rsa.exponent_size = p->data_size;
+            } else {
+                P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                              "Only unsigned integers for RSA Exponent");
+                return RET_OSSL_ERR;
+            }
+        }
+        break;
+    case CKK_EC:
+        p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
+        if (p) {
+            int i;
+            if (p->data_type != OSSL_PARAM_UTF8_STRING) {
+                return RET_OSSL_ERR;
+            }
+            for (i = 0; ec_name_to_params[i].name != NULL; i++) {
+                if (strcmp(ec_name_to_params[i].name, p->data) == 0) {
+                    break;
+                }
+            }
+            if (ec_name_to_params[i].name == NULL) {
+                P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                              "Unknown Curve %*s", p->data_size, p->data);
+                return RET_OSSL_ERR;
+            }
+            ctx->data.ec.ec_params = ec_name_to_params[i].ec_param;
+            ctx->data.ec.ec_params_size = ec_name_to_params[i].ec_param_size;
+        }
+        break;
+    default:
+        P11PROV_raise(ctx->provctx, CKR_ARGUMENTS_BAD,
+                      "Invalid key gen type %lu", ctx->type);
+        return RET_OSSL_ERR;
+    }
+    return RET_OSSL_OK;
+}
+
+static void *p11prov_common_gen(struct key_generator *ctx,
+                                CK_MECHANISM *mechanism,
+                                CK_ATTRIBUTE *pubkey_template,
+                                CK_ATTRIBUTE *privkey_template, int pubtsize,
+                                int privtsize)
+{
+    CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
+    CK_BYTE id[16];
+    CK_BYTE_PTR id_ptr;
+    CK_ULONG id_len;
+    CK_OBJECT_HANDLE privkey;
+    CK_OBJECT_HANDLE pubkey;
+    P11PROV_SESSION *session = NULL;
+    CK_SESSION_HANDLE sh;
+    P11PROV_KEY *key = NULL;
+    P11PROV_OBJ *obj;
+    CK_FUNCTION_LIST *f;
+    CK_RV ret;
+
+    ret = p11prov_ctx_status(ctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
+    /* FIXME: how do we get a URI to select the right slot ? */
+    ret = p11prov_get_session(ctx->provctx, &slotid, NULL, NULL, NULL, NULL,
+                              true, true, &session);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
+    sh = p11prov_session_handle(session);
+
+    if (ctx->id_len != 0) {
+        id_ptr = ctx->id;
+        id_len = ctx->id_len;
+    } else {
+        /* generate unique id for the key */
+        ret = f->C_GenerateRandom(sh, id, sizeof(id));
+        if (ret != CKR_OK) {
+            p11prov_session_free(session);
+            return NULL;
+        }
+        id_ptr = id;
+        id_len = 16;
+    }
+    pubkey_template[pubtsize].type = CKA_ID;
+    pubkey_template[pubtsize].pValue = id_ptr;
+    pubkey_template[pubtsize].ulValueLen = id_len;
+    pubtsize++;
+    privkey_template[privtsize].type = CKA_ID;
+    privkey_template[privtsize].pValue = id_ptr;
+    privkey_template[privtsize].ulValueLen = id_len;
+    privtsize++;
+    if (ctx->label) {
+        CK_ULONG len = strlen(ctx->label);
+        pubkey_template[pubtsize].type = CKA_LABEL;
+        pubkey_template[pubtsize].pValue = ctx->label;
+        pubkey_template[pubtsize].ulValueLen = len;
+        pubtsize++;
+        privkey_template[privtsize].type = CKA_LABEL;
+        privkey_template[privtsize].pValue = ctx->label;
+        privkey_template[privtsize].ulValueLen = len;
+        privtsize++;
+    }
+
+    ret = f->C_GenerateKeyPair(sh, mechanism, pubkey_template, pubtsize,
+                               privkey_template, privtsize, &pubkey, &privkey);
+    if (ret != CKR_OK) {
+        p11prov_session_free(session);
+        return NULL;
+    }
+
+    key = p11prov_object_handle_to_key(ctx->provctx, slotid, session, privkey);
+    if (key == NULL) {
+        p11prov_session_free(session);
+        return NULL;
+    }
+
+    ret = p11prov_object_new(ctx->provctx, CKO_PRIVATE_KEY, key, &obj);
+    if (ret != CKR_OK) {
+        obj = NULL;
+    }
+    p11prov_session_free(session);
+    p11prov_key_free(key);
+    return obj;
+}
+
+static void p11prov_common_gen_cleanup(void *genctx)
+{
+    struct key_generator *ctx = (struct key_generator *)genctx;
+
+    P11PROV_debug("rsa gen_cleanup %p", genctx);
+
+    if (ctx->label) {
+        OPENSSL_free(ctx->label);
+    }
+    if (ctx->id) {
+        OPENSSL_clear_free(ctx->id, ctx->id_len);
+    }
+
+    OPENSSL_clear_free(genctx, sizeof(struct key_generator));
+}
+
+/* RSA gen key */
+static void *p11prov_rsa_gen_init(void *provctx, int selection,
+                                  const OSSL_PARAM params[])
+{
+    P11PROV_debug("rsa gen_init %p", provctx);
+
+    return p11prov_common_gen_init(provctx, selection, CKK_RSA, params);
+}
+
+static void *p11prov_rsa_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
+{
+    struct key_generator *ctx = (struct key_generator *)genctx;
+    CK_MECHANISM mechanism = { CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0 };
+    CK_BBOOL val_true = CK_TRUE;
+    /* CK_BBOOL val_false = CK_FALSE; */
+
+    /* always leave space for CKA_ID and CKA_LABEL */
+#define RSA_PUBKEY_TMPL_SIZE 5
+    CK_ATTRIBUTE pubkey_template[RSA_PUBKEY_TMPL_SIZE + 2] = {
+        { CKA_ENCRYPT, &val_true, sizeof(val_true) },
+        { CKA_VERIFY, &val_true, sizeof(val_true) },
+        { CKA_WRAP, &val_true, sizeof(val_true) },
+        { CKA_MODULUS_BITS, &ctx->data.rsa.modulus_bits,
+          sizeof(ctx->data.rsa.modulus_bits) },
+        { CKA_PUBLIC_EXPONENT, &ctx->data.rsa.exponent,
+          ctx->data.rsa.exponent_size },
+    };
+#define RSA_PRIVKEY_TMPL_SIZE 6
+    CK_ATTRIBUTE privkey_template[RSA_PRIVKEY_TMPL_SIZE + 2] = {
+        { CKA_TOKEN, &val_true, sizeof(CK_BBOOL) },
+        { CKA_PRIVATE, &val_true, sizeof(CK_BBOOL) },
+        { CKA_SENSITIVE, &val_true, sizeof(CK_BBOOL) },
+        { CKA_DECRYPT, &val_true, sizeof(CK_BBOOL) },
+        { CKA_SIGN, &val_true, sizeof(CK_BBOOL) },
+        { CKA_UNWRAP, &val_true, sizeof(CK_BBOOL) },
+        /* TODO?
+         * CKA_SUBJECT
+         * CKA_COPYABLE = true ?
+         */
+    };
+    int pubtsize = RSA_PUBKEY_TMPL_SIZE;
+    int privtsize = RSA_PRIVKEY_TMPL_SIZE;
+
+    P11PROV_debug("rsa gen %p %p %p", genctx, cb_fn, cb_arg);
+
+    return p11prov_common_gen(ctx, &mechanism, pubkey_template,
+                              privkey_template, pubtsize, privtsize);
+}
+
+static void *p11prov_rsa_new(void *provctx)
 {
     P11PROV_debug("rsa new");
     return NULL;
 }
 
-static void *p11prov_rsakm_gen_init(void *provctx, int selection,
-                                    const OSSL_PARAM params[])
-{
-    P11PROV_debug("rsa gen_init");
-    return NULL;
-}
-
-static void *p11prov_rsakm_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
-{
-    P11PROV_debug("rsa gen %p %p %p", genctx, cb_fn, cb_arg);
-    return NULL;
-}
-static void p11prov_rsakm_gen_cleanup(void *genctx)
-{
-    P11PROV_debug("rsa gen_cleanup %p", genctx);
-}
-
-static void p11prov_rsakm_free(void *key)
+static void p11prov_rsa_free(void *key)
 {
     P11PROV_debug("rsa free %p", key);
     p11prov_object_free((P11PROV_OBJ *)key);
 }
 
-static void *p11prov_rsakm_load(const void *reference, size_t reference_sz)
+static void *p11prov_rsa_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("rsa load %p, %ld", reference, reference_sz);
 
@@ -55,7 +478,7 @@ static void *p11prov_rsakm_load(const void *reference, size_t reference_sz)
     return p11prov_obj_from_reference(reference, reference_sz);
 }
 
-static int p11prov_rsakm_has(const void *keydata, int selection)
+static int p11prov_rsa_has(const void *keydata, int selection)
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
@@ -80,15 +503,15 @@ static int p11prov_rsakm_has(const void *keydata, int selection)
     return 1;
 }
 
-static int p11prov_rsakm_import(void *keydata, int selection,
-                                const OSSL_PARAM params[])
+static int p11prov_rsa_import(void *keydata, int selection,
+                              const OSSL_PARAM params[])
 {
     P11PROV_debug("rsa import %p", keydata);
     return 0;
 }
 
-static int p11prov_rsakm_export(void *keydata, int selection,
-                                OSSL_CALLBACK *cb_fn, void *cb_arg)
+static int p11prov_rsa_export(void *keydata, int selection,
+                              OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
@@ -105,31 +528,31 @@ static int p11prov_rsakm_export(void *keydata, int selection,
     return 0;
 }
 
-static const OSSL_PARAM p11prov_rsakm_key_types[] = {
+static const OSSL_PARAM p11prov_rsa_key_types[] = {
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
     OSSL_PARAM_END,
 };
 
-static const OSSL_PARAM *p11prov_rsakm_import_types(int selection)
+static const OSSL_PARAM *p11prov_rsa_import_types(int selection)
 {
     P11PROV_debug("rsa import types");
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        return p11prov_rsakm_key_types;
+        return p11prov_rsa_key_types;
     }
     return NULL;
 }
 
-static const OSSL_PARAM *p11prov_rsakm_export_types(int selection)
+static const OSSL_PARAM *p11prov_rsa_export_types(int selection)
 {
     P11PROV_debug("rsa export types");
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        return p11prov_rsakm_key_types;
+        return p11prov_rsa_key_types;
     }
     return NULL;
 }
 
-static const char *p11prov_rsakm_query_operation_name(int operation_id)
+static const char *p11prov_rsa_query_operation_name(int operation_id)
 {
     switch (operation_id) {
     case OSSL_OP_SIGNATURE:
@@ -140,7 +563,7 @@ static const char *p11prov_rsakm_query_operation_name(int operation_id)
     }
 }
 
-static int p11prov_rsakm_secbits(int bits)
+static int p11prov_rsa_secbits(int bits)
 {
     /* common values from various NIST documents */
     switch (bits) {
@@ -176,7 +599,7 @@ static int p11prov_rsakm_secbits(int bits)
     return 0;
 }
 
-static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
+static int p11prov_rsa_get_params(void *keydata, OSSL_PARAM params[])
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
     CK_ATTRIBUTE *modulus;
@@ -213,7 +636,7 @@ static int p11prov_rsakm_get_params(void *keydata, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS);
     if (p) {
         /* TODO: as above, plus use log() for intermediate values */
-        int secbits = p11prov_rsakm_secbits(modulus->ulValueLen * 8);
+        int secbits = p11prov_rsa_secbits(modulus->ulValueLen * 8);
         ret = OSSL_PARAM_set_int(p, secbits);
         if (ret != RET_OSSL_OK) {
             goto done;
@@ -233,7 +656,7 @@ done:
     return ret;
 }
 
-static const OSSL_PARAM *p11prov_rsakm_gettable_params(void *provctx)
+static const OSSL_PARAM *p11prov_rsa_gettable_params(void *provctx)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
@@ -248,68 +671,97 @@ static const OSSL_PARAM *p11prov_rsakm_gettable_params(void *provctx)
 }
 
 const OSSL_DISPATCH p11prov_rsa_keymgmt_functions[] = {
-    DISPATCH_RSAKM_ELEM(NEW, new),
-    DISPATCH_RSAKM_ELEM(GEN_INIT, gen_init),
-    DISPATCH_RSAKM_ELEM(GEN, gen),
-    DISPATCH_RSAKM_ELEM(GEN_CLEANUP, gen_cleanup),
-    DISPATCH_RSAKM_ELEM(LOAD, load),
-    DISPATCH_RSAKM_ELEM(FREE, free),
-    DISPATCH_RSAKM_ELEM(HAS, has),
-    DISPATCH_RSAKM_ELEM(IMPORT, import),
-    DISPATCH_RSAKM_ELEM(IMPORT_TYPES, import_types),
-    DISPATCH_RSAKM_ELEM(EXPORT, export),
-    DISPATCH_RSAKM_ELEM(EXPORT_TYPES, export_types),
-    DISPATCH_RSAKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
-    DISPATCH_RSAKM_ELEM(GET_PARAMS, get_params),
-    DISPATCH_RSAKM_ELEM(GETTABLE_PARAMS, gettable_params),
+    DISPATCH_KEYMGMT_ELEM(rsa, NEW, new),
+    DISPATCH_KEYMGMT_ELEM(rsa, GEN_INIT, gen_init),
+    DISPATCH_KEYMGMT_ELEM(rsa, GEN, gen),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_SET_PARAMS, gen_set_params),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_SETTABLE_PARAMS, gen_settable_params),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_CLEANUP, gen_cleanup),
+    DISPATCH_KEYMGMT_ELEM(rsa, LOAD, load),
+    DISPATCH_KEYMGMT_ELEM(rsa, FREE, free),
+    DISPATCH_KEYMGMT_ELEM(rsa, HAS, has),
+    DISPATCH_KEYMGMT_ELEM(rsa, IMPORT, import),
+    DISPATCH_KEYMGMT_ELEM(rsa, IMPORT_TYPES, import_types),
+    DISPATCH_KEYMGMT_ELEM(rsa, EXPORT, export),
+    DISPATCH_KEYMGMT_ELEM(rsa, EXPORT_TYPES, export_types),
+    DISPATCH_KEYMGMT_ELEM(rsa, QUERY_OPERATION_NAME, query_operation_name),
+    DISPATCH_KEYMGMT_ELEM(rsa, GET_PARAMS, get_params),
+    DISPATCH_KEYMGMT_ELEM(rsa, GETTABLE_PARAMS, gettable_params),
     { 0, NULL },
 };
 
-DISPATCH_ECKM_FN(new);
-DISPATCH_ECKM_FN(gen_init);
-DISPATCH_ECKM_FN(gen);
-DISPATCH_ECKM_FN(gen_cleanup);
-DISPATCH_ECKM_FN(load);
-DISPATCH_ECKM_FN(free);
-DISPATCH_ECKM_FN(has);
-DISPATCH_ECKM_FN(import);
-DISPATCH_ECKM_FN(import_types);
-DISPATCH_ECKM_FN(export);
-DISPATCH_ECKM_FN(export_types);
-DISPATCH_ECKM_FN(query_operation_name);
-DISPATCH_ECKM_FN(get_params);
-DISPATCH_ECKM_FN(gettable_params);
+DISPATCH_KEYMGMT_FN(ec, new);
+DISPATCH_KEYMGMT_FN(ec, gen_init);
+DISPATCH_KEYMGMT_FN(ec, gen);
+DISPATCH_KEYMGMT_FN(ec, load);
+DISPATCH_KEYMGMT_FN(ec, free);
+DISPATCH_KEYMGMT_FN(ec, has);
+DISPATCH_KEYMGMT_FN(ec, import);
+DISPATCH_KEYMGMT_FN(ec, import_types);
+DISPATCH_KEYMGMT_FN(ec, export);
+DISPATCH_KEYMGMT_FN(ec, export_types);
+DISPATCH_KEYMGMT_FN(ec, query_operation_name);
+DISPATCH_KEYMGMT_FN(ec, get_params);
+DISPATCH_KEYMGMT_FN(ec, gettable_params);
 
-static void *p11prov_eckm_new(void *provctx)
+static void *p11prov_ec_new(void *provctx)
 {
     P11PROV_debug("ec new");
     return NULL;
 }
 
-static void *p11prov_eckm_gen_init(void *provctx, int selection,
-                                   const OSSL_PARAM params[])
+static void *p11prov_ec_gen_init(void *provctx, int selection,
+                                 const OSSL_PARAM params[])
 {
-    P11PROV_debug("ec gen_init");
-    return NULL;
+    P11PROV_debug("ec gen_init %p", provctx);
+
+    return p11prov_common_gen_init(provctx, selection, CKK_EC, params);
 }
 
-static void *p11prov_eckm_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
+static void *p11prov_ec_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    P11PROV_debug("ec gen %p %p %p", genctx, cb_fn, cb_arg);
-    return NULL;
-}
-static void p11prov_eckm_gen_cleanup(void *genctx)
-{
-    P11PROV_debug("ec gen_cleanup %p", genctx);
+    struct key_generator *ctx = (struct key_generator *)genctx;
+    CK_MECHANISM mechanism = { CKM_EC_KEY_PAIR_GEN, NULL_PTR, 0 };
+    CK_BBOOL val_true = CK_TRUE;
+    /* CK_BBOOL val_false = CK_FALSE; */
+
+    /* always leave space for CKA_ID and CKA_LABEL */
+#define EC_PUBKEY_TMPL_SIZE 4
+    CK_ATTRIBUTE pubkey_template[EC_PUBKEY_TMPL_SIZE + 2] = {
+        { CKA_DERIVE, &val_true, sizeof(val_true) },
+        { CKA_VERIFY, &val_true, sizeof(val_true) },
+        { CKA_WRAP, &val_true, sizeof(val_true) },
+        { CKA_EC_PARAMS, (CK_BYTE *)ctx->data.ec.ec_params,
+          ctx->data.ec.ec_params_size },
+    };
+#define EC_PRIVKEY_TMPL_SIZE 6
+    CK_ATTRIBUTE privkey_template[EC_PRIVKEY_TMPL_SIZE + 2] = {
+        { CKA_TOKEN, &val_true, sizeof(CK_BBOOL) },
+        { CKA_PRIVATE, &val_true, sizeof(CK_BBOOL) },
+        { CKA_SENSITIVE, &val_true, sizeof(CK_BBOOL) },
+        { CKA_SIGN, &val_true, sizeof(CK_BBOOL) },
+        { CKA_UNWRAP, &val_true, sizeof(CK_BBOOL) },
+        /* TODO?
+         * CKA_SUBJECT
+         * CKA_COPYABLE = true ?
+         */
+    };
+    int pubtsize = EC_PUBKEY_TMPL_SIZE;
+    int privtsize = EC_PRIVKEY_TMPL_SIZE;
+
+    P11PROV_debug("ec gen %p %p %p", ctx, cb_fn, cb_arg);
+
+    return p11prov_common_gen(ctx, &mechanism, pubkey_template,
+                              privkey_template, pubtsize, privtsize);
 }
 
-static void p11prov_eckm_free(void *key)
+static void p11prov_ec_free(void *key)
 {
     P11PROV_debug("ec free %p", key);
     p11prov_object_free((P11PROV_OBJ *)key);
 }
 
-static void *p11prov_eckm_load(const void *reference, size_t reference_sz)
+static void *p11prov_ec_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("ec load %p, %ld", reference, reference_sz);
 
@@ -317,7 +769,7 @@ static void *p11prov_eckm_load(const void *reference, size_t reference_sz)
     return p11prov_obj_from_reference(reference, reference_sz);
 }
 
-static int p11prov_eckm_has(const void *keydata, int selection)
+static int p11prov_ec_has(const void *keydata, int selection)
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
@@ -342,15 +794,15 @@ static int p11prov_eckm_has(const void *keydata, int selection)
     return 1;
 }
 
-static int p11prov_eckm_import(void *keydata, int selection,
-                               const OSSL_PARAM params[])
+static int p11prov_ec_import(void *keydata, int selection,
+                             const OSSL_PARAM params[])
 {
     P11PROV_debug("ec import %p", keydata);
     return 0;
 }
 
-static int p11prov_eckm_export(void *keydata, int selection,
-                               OSSL_CALLBACK *cb_fn, void *cb_arg)
+static int p11prov_ec_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
+                             void *cb_arg)
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
 
@@ -365,7 +817,7 @@ static int p11prov_eckm_export(void *keydata, int selection,
     return RET_OSSL_ERR;
 }
 
-static const OSSL_PARAM p11prov_eckm_key_types[] = {
+static const OSSL_PARAM p11prov_ec_key_types[] = {
     /*
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
@@ -373,25 +825,25 @@ static const OSSL_PARAM p11prov_eckm_key_types[] = {
     OSSL_PARAM_END,
 };
 
-static const OSSL_PARAM *p11prov_eckm_import_types(int selection)
+static const OSSL_PARAM *p11prov_ec_import_types(int selection)
 {
     P11PROV_debug("ec import types");
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        return p11prov_eckm_key_types;
+        return p11prov_ec_key_types;
     }
     return NULL;
 }
 
-static const OSSL_PARAM *p11prov_eckm_export_types(int selection)
+static const OSSL_PARAM *p11prov_ec_export_types(int selection)
 {
     P11PROV_debug("ec export types");
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        return p11prov_eckm_key_types;
+        return p11prov_ec_key_types;
     }
     return NULL;
 }
 
-static const char *p11prov_eckm_query_operation_name(int operation_id)
+static const char *p11prov_ec_query_operation_name(int operation_id)
 {
     switch (operation_id) {
     case OSSL_OP_SIGNATURE:
@@ -403,7 +855,7 @@ static const char *p11prov_eckm_query_operation_name(int operation_id)
     }
 }
 
-static int p11prov_eckm_secbits(int bits)
+static int p11prov_ec_secbits(int bits)
 {
     /* common values from various NIST documents */
     if (bits < 224) {
@@ -421,7 +873,7 @@ static int p11prov_eckm_secbits(int bits)
     return 256;
 }
 
-static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
+static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
 {
     P11PROV_OBJ *obj = (P11PROV_OBJ *)keydata;
     P11PROV_KEY *key;
@@ -458,7 +910,7 @@ static int p11prov_eckm_get_params(void *keydata, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS);
     if (p) {
         /* TODO: as above, plus use log() for intermediate values */
-        int secbits = p11prov_eckm_secbits(group_size * 8);
+        int secbits = p11prov_ec_secbits(group_size * 8);
         ret = OSSL_PARAM_set_int(p, secbits);
         if (ret != RET_OSSL_OK) {
             goto done;
@@ -478,7 +930,7 @@ done:
     return ret;
 }
 
-static const OSSL_PARAM *p11prov_eckm_gettable_params(void *provctx)
+static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
 {
     static const OSSL_PARAM params[] = {
         OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
@@ -511,47 +963,49 @@ static const OSSL_PARAM *p11prov_eckm_gettable_params(void *provctx)
 }
 
 const OSSL_DISPATCH p11prov_ecdsa_keymgmt_functions[] = {
-    DISPATCH_ECKM_ELEM(NEW, new),
-    DISPATCH_ECKM_ELEM(GEN_INIT, gen_init),
-    DISPATCH_ECKM_ELEM(GEN, gen),
-    DISPATCH_ECKM_ELEM(GEN_CLEANUP, gen_cleanup),
-    DISPATCH_ECKM_ELEM(LOAD, load),
-    DISPATCH_ECKM_ELEM(FREE, free),
-    DISPATCH_ECKM_ELEM(HAS, has),
-    DISPATCH_ECKM_ELEM(IMPORT, import),
-    DISPATCH_ECKM_ELEM(IMPORT_TYPES, import_types),
-    DISPATCH_ECKM_ELEM(EXPORT, export),
-    DISPATCH_ECKM_ELEM(EXPORT_TYPES, export_types),
-    DISPATCH_ECKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
-    DISPATCH_ECKM_ELEM(GET_PARAMS, get_params),
-    DISPATCH_ECKM_ELEM(GETTABLE_PARAMS, gettable_params),
+    DISPATCH_KEYMGMT_ELEM(ec, NEW, new),
+    DISPATCH_KEYMGMT_ELEM(ec, GEN_INIT, gen_init),
+    DISPATCH_KEYMGMT_ELEM(ec, GEN, gen),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_CLEANUP, gen_cleanup),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_SET_PARAMS, gen_set_params),
+    DISPATCH_KEYMGMT_ELEM(common, GEN_SETTABLE_PARAMS, gen_settable_params),
+    DISPATCH_KEYMGMT_ELEM(ec, LOAD, load),
+    DISPATCH_KEYMGMT_ELEM(ec, FREE, free),
+    DISPATCH_KEYMGMT_ELEM(ec, HAS, has),
+    DISPATCH_KEYMGMT_ELEM(ec, IMPORT, import),
+    DISPATCH_KEYMGMT_ELEM(ec, IMPORT_TYPES, import_types),
+    DISPATCH_KEYMGMT_ELEM(ec, EXPORT, export),
+    DISPATCH_KEYMGMT_ELEM(ec, EXPORT_TYPES, export_types),
+    DISPATCH_KEYMGMT_ELEM(ec, QUERY_OPERATION_NAME, query_operation_name),
+    DISPATCH_KEYMGMT_ELEM(ec, GET_PARAMS, get_params),
+    DISPATCH_KEYMGMT_ELEM(ec, GETTABLE_PARAMS, gettable_params),
     { 0, NULL },
 };
 
-DISPATCH_HKDFKM_FN(new);
-DISPATCH_HKDFKM_FN(free);
-DISPATCH_HKDFKM_FN(query_operation_name);
-DISPATCH_HKDFKM_FN(has);
+DISPATCH_KEYMGMT_FN(hkdf, new);
+DISPATCH_KEYMGMT_FN(hkdf, free);
+DISPATCH_KEYMGMT_FN(hkdf, query_operation_name);
+DISPATCH_KEYMGMT_FN(hkdf, has);
 
-const void *p11prov_hkdfkm_static_ctx = NULL;
+const void *p11prov_hkdf_static_ctx = NULL;
 
-static void *p11prov_hkdfkm_new(void *provctx)
+static void *p11prov_hkdf_new(void *provctx)
 {
     P11PROV_debug("hkdf keymgmt new");
-    return (void *)&p11prov_hkdfkm_static_ctx;
+    return (void *)&p11prov_hkdf_static_ctx;
 }
 
-static void p11prov_hkdfkm_free(void *kdfdata)
+static void p11prov_hkdf_free(void *kdfdata)
 {
     P11PROV_debug("hkdf keymgmt free %p", kdfdata);
 
-    if (kdfdata != &p11prov_hkdfkm_static_ctx) {
+    if (kdfdata != &p11prov_hkdf_static_ctx) {
         P11PROV_debug("Invalid HKDF Keymgmt context: %p != %p", kdfdata,
-                      &p11prov_hkdfkm_static_ctx);
+                      &p11prov_hkdf_static_ctx);
     }
 }
 
-static const char *p11prov_hkdfkm_query_operation_name(int operation_id)
+static const char *p11prov_hkdf_query_operation_name(int operation_id)
 {
     P11PROV_debug("hkdf keymgmt query op name %d", operation_id);
 
@@ -563,21 +1017,21 @@ static const char *p11prov_hkdfkm_query_operation_name(int operation_id)
     }
 }
 
-static int p11prov_hkdfkm_has(const void *kdfdata, int selection)
+static int p11prov_hkdf_has(const void *kdfdata, int selection)
 {
     P11PROV_debug("hkdf keymgmt has");
-    if (kdfdata != &p11prov_hkdfkm_static_ctx) {
+    if (kdfdata != &p11prov_hkdf_static_ctx) {
         P11PROV_debug("Invalid HKDF Keymgmt context: %p != %p", kdfdata,
-                      &p11prov_hkdfkm_static_ctx);
+                      &p11prov_hkdf_static_ctx);
         return RET_OSSL_ERR;
     }
     return RET_OSSL_OK;
 }
 
 const OSSL_DISPATCH p11prov_hkdf_keymgmt_functions[] = {
-    DISPATCH_HKDFKM_ELEM(NEW, new),
-    DISPATCH_HKDFKM_ELEM(FREE, free),
-    DISPATCH_HKDFKM_ELEM(QUERY_OPERATION_NAME, query_operation_name),
-    DISPATCH_HKDFKM_ELEM(HAS, has),
+    DISPATCH_KEYMGMT_ELEM(hkdf, NEW, new),
+    DISPATCH_KEYMGMT_ELEM(hkdf, FREE, free),
+    DISPATCH_KEYMGMT_ELEM(hkdf, QUERY_OPERATION_NAME, query_operation_name),
+    DISPATCH_KEYMGMT_ELEM(hkdf, HAS, has),
     { 0, NULL },
 };

--- a/src/keys.c
+++ b/src/keys.c
@@ -456,7 +456,8 @@ CK_RV p11prov_derive_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 
 again:
     if (!s) {
-        ret = p11prov_get_session(ctx, &slotid, NULL, NULL, NULL, NULL, &s);
+        ret = p11prov_get_session(ctx, &slotid, NULL, NULL, NULL, NULL, false,
+                                  false, &s);
         if (ret != CKR_OK) {
             P11PROV_raise(ctx, ret, "Failed to open session on slot %lu",
                           slotid);

--- a/src/platform/endian.h
+++ b/src/platform/endian.h
@@ -156,4 +156,6 @@
 #endif /* WORDS_BIGENDIAN */
 #endif /* !htobe64 */
 
+void byteswap_buf(unsigned char *src, unsigned char *dest, size_t len);
+
 #endif /* _P11PROV_ENDIAN_H */

--- a/src/provider.c
+++ b/src/provider.c
@@ -234,7 +234,25 @@ static const OSSL_ALGORITHM p11prov_keymgmt[] = {
         P11PROV_DESCS_RSA,
     },
     {
+        "RSA",
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_rsa_keymgmt_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
         P11PROV_NAMES_ECDSA,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_ecdsa_keymgmt_functions,
+        P11PROV_DESCS_ECDSA,
+    },
+    {
+        P11PROV_NAMES_EC,
+        P11PROV_DEFAULT_PROPERTIES,
+        p11prov_ecdsa_keymgmt_functions,
+        P11PROV_DESCS_ECDSA,
+    },
+    {
+        "EC",
         P11PROV_DEFAULT_PROPERTIES,
         p11prov_ecdsa_keymgmt_functions,
         P11PROV_DESCS_ECDSA,

--- a/src/provider.c
+++ b/src/provider.c
@@ -340,6 +340,46 @@ static const OSSL_ALGORITHM p11prov_kdf[] = {
     { NULL, NULL, NULL, NULL },
 };
 
+static const OSSL_ALGORITHM p11prov_encoder[] = {
+    {
+        "RSA",
+        "provider=pkcs11,output=text",
+        p11prov_rsa_encoder_text_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        "RSA",
+        "provider=pkcs11,output=der,structure=pkcs1",
+        p11prov_rsa_encoder_pkcs1_der_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        "RSA",
+        "provider=pkcs11,output=pem,structure=pkcs1",
+        p11prov_rsa_encoder_pkcs1_pem_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        P11PROV_NAMES_RSA,
+        "output=text",
+        p11prov_rsa_encoder_text_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        P11PROV_NAMES_RSA,
+        "output=der,structure=pkcs1",
+        p11prov_rsa_encoder_pkcs1_der_functions,
+        P11PROV_DESCS_RSA,
+    },
+    {
+        P11PROV_NAMES_RSA,
+        "output=pem,structure=pkcs1",
+        p11prov_rsa_encoder_pkcs1_pem_functions,
+        P11PROV_DESCS_RSA,
+    },
+    { NULL, NULL, NULL, NULL },
+};
+
 static const OSSL_ALGORITHM *
 p11prov_query_operation(void *provctx, int operation_id, int *no_cache)
 {
@@ -357,6 +397,8 @@ p11prov_query_operation(void *provctx, int operation_id, int *no_cache)
         return p11prov_exchange;
     case OSSL_OP_KDF:
         return p11prov_kdf;
+    case OSSL_OP_ENCODER:
+        return p11prov_encoder;
     }
     return NULL;
 }

--- a/src/provider.h
+++ b/src/provider.h
@@ -286,5 +286,5 @@ CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session);
 CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
-                          P11PROV_SESSION **session);
+                          bool reqlogin, bool rw, P11PROV_SESSION **session);
 #endif /* _PROVIDER_H */

--- a/src/provider.h
+++ b/src/provider.h
@@ -223,6 +223,29 @@ extern const OSSL_DISPATCH p11prov_hkdf_exchange_functions[];
 extern const void *p11prov_hkdf_static_ctx;
 extern const OSSL_DISPATCH p11prov_hkdf_kdf_functions[];
 
+/* Encoders */
+#define DISPATCH_TEXT_ENCODER_FN(type, name) \
+    static OSSL_FUNC_encoder_##name##_fn p11prov_##type##_encoder_##name##_text
+#define DISPATCH_BASE_ENCODER_FN(type, name) \
+    DECL_DISPATCH_FUNC(encoder, p11prov_##type##_encoder, name)
+#define DISPATCH_BASE_ENCODER_ELEM(NAME, type, name) \
+    { \
+        OSSL_FUNC_ENCODER_##NAME, \
+            (void (*)(void))p11prov_##type##_encoder_##name \
+    }
+#define DISPATCH_ENCODER_FN(type, structure, format, name) \
+    DECL_DISPATCH_FUNC(encoder, \
+                       p11prov_##type##_encoder_##structure##_##format, name)
+#define DISPATCH_ENCODER_ELEM(NAME, type, structure, format, name) \
+    { \
+        OSSL_FUNC_ENCODER_##NAME, \
+            (void (*)( \
+                void))p11prov_##type##_encoder_##structure##_##format##_##name \
+    }
+extern const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[];
+extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[];
+extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[];
+
 /* Utilities to fetch objects from tokens */
 
 struct fetch_attrs {

--- a/src/store.c
+++ b/src/store.c
@@ -266,7 +266,7 @@ static void store_load(struct p11prov_store_ctx *ctx,
 
         ret =
             p11prov_get_session(ctx->provctx, &slotid, &nextid, ctx->parsed_uri,
-                                pw_cb, pw_cbarg, &ctx->session);
+                                pw_cb, pw_cbarg, false, false, &ctx->session);
         switch (ret) {
         case CKR_OK:
             break;

--- a/src/util.c
+++ b/src/util.c
@@ -5,6 +5,7 @@
 #include "provider.h"
 #include <string.h>
 #include <time.h>
+#include "platform/endian.h"
 
 CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                                CK_OBJECT_HANDLE object,
@@ -481,4 +482,25 @@ bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
     }
 
     return true;
+}
+
+void byteswap_buf(unsigned char *src, unsigned char *dest, size_t len)
+{
+#if BYTE_ORDER == LITTLE_ENDIAN
+    int s = 0;
+    int e = len - 1;
+    unsigned char sb;
+    unsigned char eb;
+
+    while (e >= s) {
+        sb = src[s];
+        eb = src[e];
+        dest[s] = eb;
+        dest[e] = sb;
+        s++;
+        e--;
+    }
+#else
+    memmove(dest, src, len);
+#endif
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,18 +5,22 @@ softokenpath=@SOFTOKENDIR@/@SOFTOKEN_SUBDIR@libsoftokn3.so
 libtoollibs=@abs_top_builddir@/src/.libs
 testsdir=@abs_top_builddir@/tests
 
-check_PROGRAMS = tsession
+check_PROGRAMS = tsession tgenkey
 
 tsession_SOURCES = tsession.c
 tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 tsession_LDADD = $(OPENSSL_LIBS)
+
+tgenkey_SOURCES = tgenkey.c
+tgenkey_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tgenkey_LDADD = $(OPENSSL_LIBS)
 
 dist_check_SCRIPTS = \
 	test.sh
 
 check_SCRIPTS = $(softokenpath)
 
-TESTS = $(dist_check_SCRIPTS)
+TESTS = $(dist_check_SCRIPTS) tgenkey
 
 TESTS_ENVIRONMENT =     \
 	OPENSSL_CONF="openssl.cnf" \

--- a/tests/tgenkey.c
+++ b/tests/tgenkey.c
@@ -1,0 +1,197 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/evp.h>
+#include <openssl/store.h>
+#include <openssl/rand.h>
+
+static void hexify(char *out, unsigned char *byte, size_t len)
+{
+    char c[2], s;
+
+    for (size_t i = 0; i < len; i++) {
+        out[i * 3] = '%';
+        c[0] = byte[i] >> 4;
+        c[1] = byte[i] & 0x0f;
+        for (int j = 0; j < 2; j++) {
+            if (c[j] < 0x0A) {
+                s = '0';
+            } else {
+                s = 'a' - 10;
+            }
+            out[i * 3 + 1 + j] = c[j] + s;
+        }
+    }
+    out[len * 3] = '\0';
+}
+
+static void check_keys(OSSL_STORE_CTX *store)
+{
+    OSSL_STORE_INFO *info;
+    EVP_PKEY *pubkey = NULL;
+    EVP_PKEY *privkey = NULL;
+
+    for (info = OSSL_STORE_load(store); info != NULL;
+         info = OSSL_STORE_load(store)) {
+        int type = OSSL_STORE_INFO_get_type(info);
+
+        switch (type) {
+        case OSSL_STORE_INFO_PUBKEY:
+            if (pubkey != NULL) {
+                fprintf(stderr, "Duplicate public key found!");
+                exit(EXIT_FAILURE);
+            }
+            pubkey = OSSL_STORE_INFO_get1_PUBKEY(info);
+            break;
+        case OSSL_STORE_INFO_PKEY:
+            if (privkey != NULL) {
+                fprintf(stderr, "Duplicate private key found!");
+                exit(EXIT_FAILURE);
+            }
+            privkey = OSSL_STORE_INFO_get1_PKEY(info);
+            break;
+        }
+    }
+
+    if (pubkey == NULL) {
+        fprintf(stderr, "Failed to load public key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (privkey == NULL) {
+        fprintf(stderr, "Failed to load private key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_free(privkey);
+    EVP_PKEY_free(pubkey);
+}
+
+static void gen_keys(const char *key_type, const char *label, unsigned char *id,
+                     const OSSL_PARAM *params)
+{
+    EVP_PKEY_CTX *ctx;
+    EVP_PKEY *key = NULL;
+    char idhex[16 * 3 + 1];
+    char *uri;
+    OSSL_STORE_CTX *store;
+    OSSL_STORE_SEARCH *search;
+    int ret;
+
+    ctx = EVP_PKEY_CTX_new_from_name(NULL, key_type, "provider=pkcs11");
+    if (ctx == NULL) {
+        fprintf(stderr, "Failed to init PKEY context\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = EVP_PKEY_keygen_init(ctx);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to init keygen\n");
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_CTX_set_params(ctx, params);
+
+    ret = EVP_PKEY_generate(ctx, &key);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to generate key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_free(key);
+    key = NULL;
+    EVP_PKEY_CTX_free(ctx);
+    ctx = NULL;
+
+    /* now try to search by id */
+    hexify(idhex, id, 16);
+    ret = asprintf(&uri, "pkcs11:id=%s", idhex);
+    if (ret == -1) {
+        fprintf(stderr, "Failed to allocate uri\n");
+        exit(EXIT_FAILURE);
+    }
+
+    store = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL);
+    if (store == NULL) {
+        fprintf(stderr, "Failed to open pkcs11 store\n");
+        exit(EXIT_FAILURE);
+    }
+
+    check_keys(store);
+
+    OSSL_STORE_close(store);
+
+    /* now make sure we can filter by label */
+    store = OSSL_STORE_open("pkcs11:", NULL, NULL, NULL, NULL);
+    if (store == NULL) {
+        fprintf(stderr, "Failed to open pkcs11 store\n");
+        exit(EXIT_FAILURE);
+    }
+
+    search = OSSL_STORE_SEARCH_by_alias(label);
+    if (search == NULL) {
+        fprintf(stderr, "Failed to create store search filter\n");
+        exit(EXIT_FAILURE);
+    }
+    ret = OSSL_STORE_find(store, search);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to set store search filter\n");
+        exit(EXIT_FAILURE);
+    }
+
+    check_keys(store);
+}
+
+int main(int argc, char *argv[])
+{
+    char *label;
+    unsigned char id[16];
+    size_t rsa_bits = 3072;
+    OSSL_PARAM params[4];
+    int ret;
+
+    /* RSA */
+    label = strdup("Test RSA gen");
+    if (!label) {
+        fprintf(stderr, "Failed to make label");
+        exit(EXIT_FAILURE);
+    }
+    ret = RAND_bytes(id, 16);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to set generate key id\n");
+        exit(EXIT_FAILURE);
+    }
+    params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_key_label", label, 0);
+    params[1] = OSSL_PARAM_construct_octet_string("pkcs11_key_id", id, 16);
+    params[2] = OSSL_PARAM_construct_size_t("rsa_keygen_bits", &rsa_bits);
+    params[3] = OSSL_PARAM_construct_end();
+
+    gen_keys("RSA", label, id, params);
+    free(label);
+
+    /* EC */
+    label = strdup("Test EC gen");
+    if (!label) {
+        fprintf(stderr, "Failed to make label");
+        exit(EXIT_FAILURE);
+    }
+    ret = RAND_bytes(id, 16);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to set generate key id\n");
+        exit(EXIT_FAILURE);
+    }
+    params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_key_label", label, 0);
+    params[1] = OSSL_PARAM_construct_octet_string("pkcs11_key_id", id, 16);
+    params[2] = OSSL_PARAM_construct_utf8_string("ec_paramgen_curve",
+                                                 (char *)"P-256", 0);
+    params[3] = OSSL_PARAM_construct_end();
+
+    gen_keys("EC", label, id, params);
+    free(label);
+
+    fprintf(stderr, "ALL A-OK!");
+    exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Try to implement RSA key generation function as best we can.

openssl genpkey assumes that you *always* have key data to return, which is obviously not the case when generateing a key on a token.

We provide a function to print the -text option, but errors are reported from the missing pem/der encoding functions although public and private keys are generated and stored in the DB.

A separate test binary checks that we can correctly generate keys and apply ID and Label to them.