### PR TITLE
Add RSA-PSS support

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -121,7 +121,7 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
         return RET_OSSL_ERR;
     }
 
-    encctx->key = p11prov_object_get_key(obj, 0);
+    encctx->key = p11prov_object_get_key(obj);
     if (encctx->key == NULL) {
         return RET_OSSL_ERR;
     }
@@ -226,8 +226,12 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
         return RET_OSSL_ERR;
     }
 
-    encctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
+    encctx->key = p11prov_object_get_key(obj);
     if (encctx->key == NULL) {
+        return RET_OSSL_ERR;
+    }
+    if (p11prov_key_class(encctx->key) != CKO_PRIVATE_KEY) {
+        P11PROV_raise(encctx->provctx, CKR_ARGUMENTS_BAD, "Invalid key class");
         return RET_OSSL_ERR;
     }
 

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -192,8 +192,13 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
     }
 
     p11prov_key_free(ecdhctx->key);
-    ecdhctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
+    ecdhctx->key = p11prov_object_get_key(obj);
     if (ecdhctx->key == NULL) {
+        P11PROV_raise(ecdhctx->provctx, CKR_ARGUMENTS_BAD, "Invalid object");
+        return RET_OSSL_ERR;
+    }
+    if (p11prov_key_class(ecdhctx->key) != CKO_PRIVATE_KEY) {
+        P11PROV_raise(ecdhctx->provctx, CKR_ARGUMENTS_BAD, "Invalid key class");
         return RET_OSSL_ERR;
     }
 
@@ -210,8 +215,13 @@ static int p11prov_ecdh_set_peer(void *ctx, void *provkey)
     }
 
     p11prov_key_free(ecdhctx->peer_key);
-    ecdhctx->peer_key = p11prov_object_get_key(obj, CKO_PUBLIC_KEY);
+    ecdhctx->peer_key = p11prov_object_get_key(obj);
     if (ecdhctx->peer_key == NULL) {
+        P11PROV_raise(ecdhctx->provctx, CKR_ARGUMENTS_BAD, "Invalid object");
+        return RET_OSSL_ERR;
+    }
+    if (p11prov_key_class(ecdhctx->peer_key) != CKO_PUBLIC_KEY) {
+        P11PROV_raise(ecdhctx->provctx, CKR_ARGUMENTS_BAD, "Invalid key class");
         return RET_OSSL_ERR;
     }
 
@@ -607,8 +617,15 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provobj,
 
     if (provobj != &p11prov_hkdf_static_ctx) {
         p11prov_key_free(hkdfctx->key);
-        hkdfctx->key = p11prov_object_get_key(obj, CKO_PRIVATE_KEY);
+        hkdfctx->key = p11prov_object_get_key(obj);
         if (hkdfctx->key == NULL) {
+            P11PROV_raise(hkdfctx->provctx, CKR_ARGUMENTS_BAD,
+                          "Invalid object");
+            return RET_OSSL_ERR;
+        }
+        if (p11prov_key_class(hkdfctx->key) != CKO_PRIVATE_KEY) {
+            P11PROV_raise(hkdfctx->provctx, CKR_ARGUMENTS_BAD,
+                          "Invalid key class");
             return RET_OSSL_ERR;
         }
     }

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -764,7 +764,7 @@ static void *p11prov_rsapss_gen(void *genctx, OSSL_CALLBACK *cb_fn,
     ret = p11prov_token_sup_attr(ctx->provctx, p11prov_key_slotid(key),
                                  GET_ATTR, CKA_ALLOWED_MECHANISMS,
                                  &token_supports_allowed_mechs);
-    if (ret != CKR_OK && ret != CKR_CANCEL) {
+    if (ret != CKR_OK) {
         P11PROV_raise(ctx->provctx, ret, "Failed to probe quirk");
         goto done;
     }

--- a/src/provider.h
+++ b/src/provider.h
@@ -4,6 +4,7 @@
 #ifndef _PROVIDER_H
 #define _PROVIDER_H
 
+#define _XOPEN_SOURCE 500
 #include "config.h"
 
 #include <stdbool.h>
@@ -82,6 +83,10 @@ CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_status(P11PROV_CTX *ctx, CK_FUNCTION_LIST **fns);
 int p11prov_ctx_get_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
+CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
+                            void **data, CK_ULONG *size);
+CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
+                            void *data, CK_ULONG size);
 
 /* Errors */
 void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
@@ -317,6 +322,10 @@ CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
 int p11prov_get_pin(const char *in, char **out);
 bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
                             uint64_t *start_time);
+#define GET_ATTR 0
+#define SET_ATTR 1
+CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
+                             CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data);
 
 /* Sessions */
 CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,

--- a/src/util.c
+++ b/src/util.c
@@ -1,7 +1,6 @@
 /* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
    SPDX-License-Identifier: Apache-2.0 */
 
-#define _XOPEN_SOURCE 500
 #include "provider.h"
 #include <string.h>
 #include <time.h>
@@ -503,4 +502,35 @@ void byteswap_buf(unsigned char *src, unsigned char *dest, size_t len)
 #else
     memmove(dest, src, len);
 #endif
+}
+
+CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
+                             CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data)
+{
+    CK_ULONG data_size = sizeof(CK_BBOOL);
+    void *data_ptr = &data;
+    char alloc_name[32];
+    const char *name;
+    int err;
+
+    switch (attr) {
+    case CKA_ALLOWED_MECHANISMS:
+        name = "sup_attr_CKA_ALLOWED_MECHANISMS";
+        break;
+    default:
+        err = snprintf(alloc_name, 32, "sup_attr_%016lx", attr);
+        if (err < 0 || err >= 32) {
+            return CKR_HOST_MEMORY;
+        }
+        name = alloc_name;
+    }
+
+    switch (action) {
+    case GET_ATTR:
+        return p11prov_ctx_get_quirk(ctx, id, name, data_ptr, &data_size);
+    case SET_ATTR:
+        return p11prov_ctx_set_quirk(ctx, id, name, data, data_size);
+    default:
+        return CKR_ARGUMENTS_BAD;
+    }
 }

--- a/src/util.c
+++ b/src/util.c
@@ -62,8 +62,9 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
         if (retrnums > 0) {
             ret = f->C_GetAttributeValue(sess, object, r, retrnums);
         }
-    } else if (ret == CKR_ATTRIBUTE_SENSITIVE
-               || ret == CKR_ATTRIBUTE_TYPE_INVALID) {
+    } else if (attrnums > 1
+               && (ret == CKR_ATTRIBUTE_SENSITIVE
+                   || ret == CKR_ATTRIBUTE_TYPE_INVALID)) {
         P11PROV_debug("Quering attributes one by one");
         /* go one by one as this PKCS11 does not have some attributes
          * and does not handle it gracefully */


### PR DESCRIPTION
Fixes #60 

Also fixes an off by one bug in the store.

- [x] partial restriction checks on parametrers that openssl expects
Not all parameters can be handled, and even those we can most tokens will not be able to for now.