### PR TITLE
uri: fix key references by label

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -321,7 +321,7 @@ CK_RV find_keys(P11PROV_CTX *provctx, P11PROV_SESSION *session,
     CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
     CK_OBJECT_CLASS class = p11prov_uri_get_class(uri);
     CK_ATTRIBUTE id = p11prov_uri_get_id(uri);
-    char *label = p11prov_uri_get_object(uri);
+    CK_ATTRIBUTE label = p11prov_uri_get_label(uri);
     CK_ATTRIBUTE template[3] = { 0 };
     CK_ULONG tsize = 0;
     CK_ULONG objcount = 0;
@@ -348,8 +348,8 @@ CK_RV find_keys(P11PROV_CTX *provctx, P11PROV_SESSION *session,
         template[tsize] = id;
         tsize++;
     }
-    if (label) {
-        CKATTR_ASSIGN_ALL(template[tsize], CKA_LABEL, label, strlen(label));
+    if (label.type == CKA_LABEL) {
+        template[tsize] = label;
         tsize++;
     }
 

--- a/src/provider.h
+++ b/src/provider.h
@@ -302,6 +302,7 @@ P11PROV_URI *p11prov_parse_uri(const char *uri);
 void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
+CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri);
 char *p11prov_uri_get_object(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);

--- a/src/util.c
+++ b/src/util.c
@@ -110,6 +110,7 @@ struct p11prov_uri {
     char *serial;
     char *object;
     CK_ATTRIBUTE id;
+    CK_ATTRIBUTE label;
     char *pin;
     CK_OBJECT_CLASS class;
 };
@@ -268,7 +269,7 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
         unsigned char **ptr;
         size_t *ptrlen;
         size_t len;
-        bool id_fill = false;
+        bool id_fill = false, label_fill = false;
 
         end = strpbrk(p, ";?&");
         if (end) {
@@ -301,6 +302,11 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
             len -= 3;
             ptr = (unsigned char **)&u->id.pValue;
             id_fill = true;
+        } else if (strncmp(p, "object=", 7) == 0) {
+            p += 7;
+            len -= 7;
+            ptr = (unsigned char **)&u->label.pValue;
+            label_fill = true;
         } else if (strncmp(p, "pin-value=", 10) == 0) {
             p += 10;
             len -= 10;
@@ -348,6 +354,10 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
                 u->id.type = CKA_ID;
                 u->id.ulValueLen = outlen;
             }
+            if (label_fill) {
+                u->label.type = CKA_LABEL;
+                u->label.ulValueLen = outlen;
+            }
         }
 
         if (end) {
@@ -392,6 +402,11 @@ CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri)
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri)
 {
     return uri->id;
+}
+
+CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri)
+{
+    return uri->label;
 }
 
 char *p11prov_uri_get_object(P11PROV_URI *uri)


### PR DESCRIPTION
The key objects can also be referenced by label. According to RFC 7512 the "object=<value>" is related to the label attribute of the key object. Introduce a label attribute to the URI struct and use it to find the key objects.

Signed-off-by: Holger Dengler <dengler@linux.ibm.com>