### PR TITLE
Add codespell to CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf-archive clang-format clang-tidy
+        sudo apt-get install -y autoconf-archive clang-format clang-tidy codespell
     - name: Install compiledb
       run: |
         sudo apt install python3-pip
@@ -40,3 +40,5 @@ jobs:
     - name: Show Style diff in case of failure
       if: failure()
       run: make check-style-show
+    - name: Check spelling
+      run: codespell --ignore-words-list="sorce" *.md Makefile.am configure.ac src tests -S src/oasis

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,7 +1,7 @@
 ## Build Prerequisites
 
 This package requires the following:
-- OpenSSL 3.0+ libraries and developement headers
+- OpenSSL 3.0+ libraries and development headers
 - autoconf-archives packages for some m4 macros
 - NSS softoken and development headers (for testing)
 - a C compiler that supports at least C11 semantics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Useful links to learn about these are:
 
 ### Reporting Bugs
 
-Before reporting bugs please insure that you have cecked the latest changes to
+Before reporting bugs please insure that you have checked the latest changes to
 see if a bug has already been reported and corrected. Peruse your distribution
 repositories and bug report system to find out if the bug has been reported
 there first.

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -537,7 +537,7 @@ const OSSL_DISPATCH p11prov_ecdh_exchange_functions[] = {
 
 /* unclear why OpenSSL makes KDFs go through a middle "exchange" layer
  * when there is a direct KDF facility. I can only assume this is
- * because for some reason they want the command line -derive comamnd
+ * because for some reason they want the command line -derive command
  * to be able to handle both key exchanges like ECDH and symmetric key
  * derivation done by KDFs via the -kdf <type> selector */
 DISPATCH_EXCHHKDF_FN(newctx);

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -325,7 +325,7 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
         P11PROV_debug("set salt (len:%lu)", hkdfctx->params.ulSaltLen);
     }
 
-    /* can be multiple paramaters, which wil be all concatenated */
+    /* can be multiple parameters, which will be all concatenated */
     for (p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO); p != NULL;
          p = OSSL_PARAM_locate_const(p + 1, OSSL_KDF_PARAM_INFO)) {
         uint8_t *ptr;

--- a/src/keys.c
+++ b/src/keys.c
@@ -557,7 +557,7 @@ again:
     case CKR_SESSION_HANDLE_INVALID:
         if (first_pass) {
             first_pass = false;
-            /* TODO: Explicilty mark handle invalid */
+            /* TODO: Explicitly mark handle invalid */
             p11prov_session_free(s);
             s = *session = NULL;
             goto again;

--- a/src/provider.c
+++ b/src/provider.c
@@ -854,7 +854,7 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
           C("The cryptographic operations state of the specified "
             "session cannot be saved") },
         { CKR_CRYPTOKI_NOT_INITIALIZED,
-          C("PKCS11 Module has not been intialized yet") },
+          C("PKCS11 Module has not been initialized yet") },
         { 0, NULL },
     };
 

--- a/src/session.c
+++ b/src/session.c
@@ -92,7 +92,7 @@ static void internal_session_close(P11PROV_SESSION *session)
                               "Failed to close session %lu", session->session);
             }
         }
-        /* regardless of the result the sesssion is gone */
+        /* regardless of the result the session is gone */
         if (session->pool) {
             (void)__atomic_fetch_sub(&session->pool->cur_sessions, 1,
                                      __ATOMIC_SEQ_CST);
@@ -527,7 +527,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                                          __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
         if (!ok) {
             P11PROV_raise(provctx, CKR_GENERAL_ERROR,
-                          "Unexpectd busy session while holding lock");
+                          "Unexpected busy session while holding lock");
             ret = CKR_GENERAL_ERROR;
         }
     }

--- a/src/signature.c
+++ b/src/signature.c
@@ -88,7 +88,7 @@ static void *p11prov_sig_dupctx(void *ctx)
         goto done;
     }
 
-    /* This is not really funny. OpenSSL by dfault asume contexts with
+    /* This is not really funny. OpenSSL by dfault assume contexts with
      * operations in flight can be easily duplicated, with all the
      * cryptographic status and then both context can keep going
      * independently. We'll try here, but on failure we just 'move' the

--- a/src/store.c
+++ b/src/store.c
@@ -93,7 +93,7 @@ P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj)
 
 /* Tokens return data in bigendian order, while openssl
  * wants it in host order, so we may need to fix the
- * endianess of the buffer.
+ * endianness of the buffer.
  * Src and Dest, can be the same area, but not partially
  * overlapping memory areas */
 

--- a/src/util.c
+++ b/src/util.c
@@ -65,7 +65,7 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     } else if (attrnums > 1
                && (ret == CKR_ATTRIBUTE_SENSITIVE
                    || ret == CKR_ATTRIBUTE_TYPE_INVALID)) {
-        P11PROV_debug("Quering attributes one by one");
+        P11PROV_debug("Querying attributes one by one");
         /* go one by one as this PKCS11 does not have some attributes
          * and does not handle it gracefully */
         for (size_t i = 0; i < attrnums; i++) {
@@ -225,7 +225,7 @@ static int get_pin_file(const char *str, size_t len, char **output,
     }
     BIO_free(fp);
 
-    /* files may contain newlines, remove any control chracter at the end */
+    /* files may contain newlines, remove any control character at the end */
     for (int i = ret - 1; i >= 0; i--) {
         if (pin[i] == '\n' || pin[i] == '\r') {
             pin[i] = '\0';
@@ -342,7 +342,7 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
                 goto done;
             }
         } else {
-            P11PROV_debug("Ignoring unkown pkcs11 URI attribute");
+            P11PROV_debug("Ignoring unknown pkcs11 URI attribute");
         }
 
         if (ptr) {

--- a/tests/README
+++ b/tests/README
@@ -5,7 +5,7 @@ uses NSS's softoken (chosen because it does not link openssl in it).
 
 copy it as openssl.cnf, set the correct cknfig dirs in.
 
-Initialize a token with and RSA keypair in tests/tokens
+Initialize a token with and RSA key pair in tests/tokens
 (or whatever you set in openssl.conf)
 $ certutil -d tests/tokens -G
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -306,7 +306,7 @@ pkeyutl -verify -inkey "${BASEURI}" -pubin
                 -in ${TMPDIR}/64krandom.bin
                 -rawin
                 -sigfile ${TMPDIR}/sha256-dgstsig.bin'
-title LINE "Re-verify using OpenSSL defult provider"
+title LINE "Re-verify using OpenSSL default provider"
 #(-pubin causes us to export a public key and OpenSSL to import it in the default provider)
 ossl '
 pkeyutl -verify -inkey "${PUBURI}"


### PR DESCRIPTION
Avoid retaining and introducing more spelling mistakes
