### PR TITLE
Avoid leaving behind a freed pointer

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -242,6 +242,7 @@ static void store_load(struct p11prov_store_ctx *ctx,
 
         if (ctx->session != NULL) {
             p11prov_session_free(ctx->session);
+            ctx->session = CK_INVALID_HANDLE;
         }
 
         ret =


### PR DESCRIPTION
This does not lead to a crash because sessions are cached and reused, but can cause issues (beyond nasty "possible double free" messages), as it may free a session reused by another thread while it is in use.

Related #66 