### PR TITLE
Fedora package and requirements clarifications

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -20,6 +20,7 @@ Files: **/Makefile.am
        tests/openssl.cnf.in
        .clang-format
        .clang-format-ignore
+       packaging/pkcs11-provider.spec
 Copyright: (C) 2022 Simo Sorce <simo@redhat.com>
 License: Apache-2.0
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,8 +2,9 @@
 
 This package requires the following:
 - OpenSSL 3.0+ libraries and development headers
-- autoconf-archives packages for some m4 macros
-- NSS softoken and development headers (for testing)
+- OpenSSL tools (for testing)
+- autoconf-archive packages for some m4 macros
+- NSS softoken, tools and development headers (for testing)
 - a C compiler that supports at least C11 semantics
 
 The usual command to build are:

--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -1,0 +1,58 @@
+Name:          pkcs11-provider
+Version:       0.1
+Release:       1%{dist}
+Summary:       A PKCS#11 provider for OpenSSL 3.0+
+License:       Apache-2.0
+URL:           https://github.com/latchset/pkcs11-provider
+Source:        pkcs11-provider-%{version}.tar.gz
+
+BuildRequires: openssl-devel >= 3.0.5
+BuildRequires: gcc
+BuildRequires: autoconf-archive
+BuildRequires: automake
+BuildRequires: libtool
+# for tests
+BuildRequires: nss-devel
+BuildRequires: nss-softokn
+BuildRequires: nss-tools
+BuildRequires: openssl
+
+
+%description
+This is an Openssl 3.x provider to access Hardware or Software Tokens using
+the PKCS#11 Cryptographic Token Interface.
+This code targets version 3.0 of the interface but should be backwards
+compatible to previous versions as well.
+
+
+%prep
+%autosetup -p1
+
+
+%build
+autoreconf -fi
+%configure
+%make_build
+
+
+%install
+%make_install
+mkdir %{buildroot}%{_libdir}/ossl-modules/
+ln -s ../pkcs11_provider.so %{buildroot}%{_libdir}/ossl-modules/pkcs11.so
+
+
+%check
+# do not run them in parrallel with %{?_smp_mflags}
+make check || if [ $? -ne 0 ]; then cat tests/*.log; exit 1; fi;
+
+
+%files
+%license COPYING
+%doc README
+%{_libdir}/pkcs11_provider.so
+%{_libdir}/ossl-modules/pkcs11.so
+
+
+%changelog
+* Mon Oct 24 2022 Jakub Jelen <jjelen@redhat.com> - 0.1-1
++ Initial Fedora release


### PR DESCRIPTION
While getting familiar with this package, I prepared a spec file and build the packages in copr:

https://copr.fedorainfracloud.org/coprs/jjelen/pkcs11-provider/monitor/

From here, it should be easy to integrate the packit to automate the builds.

The tests now fail on s390x on signature verification test on all Fedora versions, but I was not able to investigate this further yet:

```
## Sign and Verify with provided Hash and RSA
openssl dgst -sha256 -binary -out ${TMPPDIR}/sha256.bin ${SEEDFILE}
openssl pkeyutl -sign -inkey "${PRIURI}" -in ${TMPPDIR}/sha256.bin -out ${TMPPDIR}/sha256-sig.bin
openssl pkeyutl -verify -inkey "${PUBURI}" -pubin -in ${TMPPDIR}/sha256.bin -sigfile ${TMPPDIR}/sha256-sig.bin
000003FFB0772720:error:0200008A:rsa routines:RSA_padding_check_PKCS1_type_1:invalid padding:crypto/rsa/rsa_pk1.c:75:
000003FFB0772720:error:02000072:rsa routines:rsa_ossl_public_decrypt:padding check failed:crypto/rsa/rsa_ossl.c:599:
Signature Verification Failure
FAIL test.sh (exit status: 1)
```
If anyone has some ideas where to look, feel free to point me in the right direction or fix that. Otherwise I will open an issue later.