### PR TITLE
RFC: separate setup- and test-scripts

### DIFF
--- a/docs/README-ock.rst
+++ b/docs/README-ock.rst
@@ -1,0 +1,123 @@
+Opencryptoki
+============
+
+The PKCS#11 implementation `opencryptoki` can be used with the
+pkcs11-provider. This document describes a basic installation and setup for
+testing purposes with the pkcs11-provider.
+
+Installation as package
+=======================
+
+Install opencryptoki from the distribution's repository.
+
+RedHat/Fedora
+-------------
+
+Install the base packages (including depending packages):
+
+    sudo dnf install opencryptoki
+
+For the pkcs11-provider testing environment, the software token is required.
+Other token libraries can be installed as well.
+
+    sudo dnf install opencryptoki-swtok
+
+The location of the default configuration for opencryptoki is
+`/etc/opencryptoki/opencryptoki.conf`
+
+Debian/Ubuntu
+-------------
+
+Install the base packages (including depending packages):
+
+    sudo apt install opencryptoki
+
+The location of the default configuration for opencryptoki is
+`/etc/opencryptoki/opencryptoki.conf`
+
+Installation from source
+========================
+
+Get the source from github, build and install.
+		
+    git clone https://github.com/opencryptoki/opencryptoki.git
+    cd opencryptoki
+    ./bootstrap
+    ./configure
+    make
+    sudo make install
+    sudo ldconfig
+
+The location of the default configuration for opencryptoki is
+`/usr/local/etc/opencryptoki/opencryptoki.conf`
+
+Configuration
+=============
+
+For the pkcs11-provider tests, the default configuration should be
+sufficient. If the opencryptoki configuration has changed, please run the
+initialization script once.
+
+    sudo scripts/ock-once-swtok.sh
+
+The initialization script will only work with the swtok. If another token
+should be used, it must be initialized manually.
+
+The initialization script uses a default user pin. If another pin should be
+used, please specify it in the environment variable OCK_PIN.
+
+    sudo OCK_PIN=11223344 scripts/ock-once-swtok.sh
+
+Setup
+=====
+
+The pkcs11-provider tests require an openssl configuration and a set of keys
+in the token for testing purposes. The setup script will prepare all these.
+
+    export OPENSSL_CONF=tests/openssl.cnf
+    scripts/ock-setup.sh
+
+The setup script uses by default the swtok in slot 3. If another slot should
+be used, specify it in the environment variable OCK_SLOT.
+
+    OCK_SLOT=0 scripts/ock-setup.sh
+
+.. warning::
+
+     Attention: The setup script will remove all keys with label
+     `test_rsa2k` and `test_ec256` in the token!
+
+The setup script uses a default user pin. If another pin should be used,
+please specify it in the environment variable OCK_PIN. If a user pin has
+been used for the initialization script, the same should be used for the
+setup script.
+
+    OCK_PIN=11223344 scripts/ock-setup.sh
+
+Files
+-----
+
+The setup script will create a set of files in the temporary directory
+`tmp-ock`.
+
+- openssl.cnf: contains the openssl configuration for pkcs11-provider and
+  opencryptoki
+- pin.txt: contains the user pin
+- debugvars: exports environment variables for debugging
+- unsetvars: unsets environment variables (after debugging)
+
+Cleanup
+=======
+
+The test keys and the temporary directory can be removed with the cleanup
+script.
+
+    scripts/ock_cleanup.sh
+
+.. warning::
+
+     Attention: The cleanup script will remove all keys with label
+     `test_rsa2k` and `test_ec256` in the token!
+
+The cleanup script supports the same environment variables as the setup
+script.

--- a/docs/README-openssl.rst
+++ b/docs/README-openssl.rst
@@ -1,0 +1,66 @@
+OpenSSL
+=======
+
+The openssl test-suite performs operation with existing key-material in a
+PKCS#11 setup. All information between the PKCS#11 setup and the test-suite
+is contained in exported environment variables of the PKCS#11 setup.
+
+Usage
+=====
+
+Before running the openssl test-suite, the PKCS#11 environment must be
+set-up. This can be done manually or by executing the appropriate setup
+script.
+
+Example with opencryptoki:
+
+.. code-block::
+
+   # run the setup script for the PKCS#11 module
+   OPENSSL_CONF=tests/openssl.cnf scripts/ock-setup.sh
+
+   # export all variables of the setup script
+   source tmp-ock/debugvars
+
+   # run test-suite
+   tests/test-openssl.sh
+
+   # unset all variables (optional)
+   source tmp-ock/unsetvars
+
+Debugging
+=========
+
+All executed openssl commands are written as gdb commands to the
+`gdb_commands.txt` file in the temporary directory. It can be used for
+debugging sessions.
+
+Test-Suite API
+==============
+
+The Openssl test-suite script is based on environment variables. They
+contain setting and key references. The test-suite checks the environment
+variable with a key reference, before it executes the test. Tests for
+non-set or empty key references will be skipped.
+
+The following settings are mandatory:
+
+- TMPDIR: path to a temporary directory for the PKCS#11 module setup
+- OPENSSL_CONF: path to the openssl provider configuration
+- R64K: path to a file with 64k random data
+- R256: path to a file with 256bit random data (32 byte)
+- R512: path to a file with 512bit random data (64 byte)
+
+The following RSA key references are used:
+
+- BASEFILE: base path to a key file (without type suffix)
+- BASEURI: PKCS#11 URI to a key (no type)
+- PUBURI: PKCS#11 URI to a private key
+- PRIURI: PKCS#11 URI to a public key
+
+The following RSA key references are used:
+
+- ECBASEFILE: base path to a key file (without type suffix)
+- ECBASEURI: PKCS#11 URI to a key (no type)
+- ECPUBURI: PKCS#11 URI to a private key
+- ECPRIURI: PKCS#11 URI to a public key

--- a/scripts/ock-cleanup.sh
+++ b/scripts/ock-cleanup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+########### generic ###########
+title()
+{
+    case "$1" in
+    "SECTION")
+        shift 1
+        echo "########################################"
+        echo "## $*"
+        echo ""
+        ;;
+    "ENDSECTION")
+        echo ""
+        echo "                                      ##"
+        echo "########################################"
+        echo ""
+        ;;
+    "PARA")
+        shift 1
+        echo ""
+        echo "## $*"
+        ;;
+    "LINE")
+        shift 1
+        echo "$*"
+        ;;
+    *)
+        echo "$*"
+        ;;
+    esac
+}
+
+########### ock-specific ###########
+
+SLOT=${OCK_SLOT:-"3"}
+PIN=${OCK_PIN:-"12345678"}
+
+TMPDIR="tmp-ock"
+unset OPENSSL_CONF
+
+title SECTION "Cleanup (opencryptoki)"
+
+title PARA "Remove directories"
+rm -rf ${TMPDIR}
+
+title PARA "Clean keys"
+
+P11SAK=$(command -v p11sak)
+if [ -z "${P11SAK}" ]; then
+	title LINE "p11sak tool is required"
+	title ENDSECTION
+	exit 77
+fi
+P11SAK_ARGS="--slot ${SLOT} --pin ${PIN}"
+
+title LINE "remove rsa keys"
+LBL="ock_rsa2k"
+${P11SAK} remove-key rsa --label "${LBL}:prv" --force ${P11SAK_ARGS} > /dev/null || true
+${P11SAK} remove-key rsa --label "${LBL}:pub" --force ${P11SAK_ARGS} > /dev/null || true
+
+title LINE "remove ec keys"
+LBL="ock_ec256"
+${P11SAK} remove-key ec --label "${LBL}:prv" --force ${P11SAK_ARGS} > /dev/null || true
+${P11SAK} remove-key ec --label "${LBL}:pub" --force ${P11SAK_ARGS} > /dev/null || true
+
+title PARA "Show contents of token in slot ${SLOT}"
+${P11SAK} list-key all ${P11SAK_ARGS} | tail -n +2
+
+title ENDSECTION
+exit 0

--- a/scripts/ock-once-swtok.sh
+++ b/scripts/ock-once-swtok.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+PIN=${OCK_PIN:-"12345678"}
+
+if id -u | grep -qw 0 && groups | grep -qwv pkcs11 ; then
+    echo "missing pkcs11 group membership"
+    exit 77
+fi
+
+if ! command -v pkcsslotd > /dev/null; then
+    echo "pkcsslotd is required"
+    exit 77
+fi
+
+for PREFIX in "/usr/local/" "/" "NA"; do
+    if [ "$PREFIX" = "NA" ]; then
+        echo "No ock configuration found or ock-swtok not configured"
+        exit 77
+    fi
+
+    OCK_CONF=${PREFIX}etc/opencryptoki/opencryptoki.conf
+    SLOT=$(grep -B2 "^stdll = libpkcs11_sw.so$" ${OCK_CONF} 2> /dev/null | grep -Po "slot \K[^\s]+")
+    test -n "${SLOT}" && break
+done
+
+if [ $(id -u) != "0" ]; then
+    echo "skip restart of pkcsslotd (require UID 0)"
+else
+    killall pkcsslotd > /dev/null 2>&1
+    pkcsslotd || exit 99
+fi
+
+PID=$(pidof pkcsslotd)
+if [ -z "${PID}" ]; then
+    echo "pkcsslotd not running"
+    exit 77
+fi
+
+echo "pkcsslotd running (PID: ${PID})"
+echo "configuration: ${OCK_CONF}"
+echo "swtok configured on slot ${SLOT}"
+
+if [ "$1" != "--batch" ]; then
+    echo    "*******************************************************************************"
+    echo    "*** This script may rename the swtok and may destroy existing key material in"
+    echo -n "*** this token. Please confirm to continue [y|N]: "
+    read CONFIRM
+    echo    "*******************************************************************************"
+
+    if [ "${CONFIRM}" != "y" -a "${CONFIRM}" != "Y" ]; then
+        echo "abort!"
+        exit 77
+    fi
+fi
+
+if ! $(pkcsconf -t -c ${SLOT} | grep -q "Flags: .*TOKEN_INITIALIZED.*"); then
+    echo "slot ${SLOT}: initialize token"
+    echo "test" | pkcsconf -c ${SLOT} -I -S "87654321" > /dev/null \
+    || exit 99
+fi
+
+if $(pkcsconf -t -c ${SLOT} | grep -q "Flags: .*SO_PIN_TO_BE_CHANGED.*"); then
+    echo "slot ${SLOT}: set new so-pin (76543210)"
+    pkcsconf -c ${SLOT} -P -S "87654321" -n "76543210" \
+    || exit 99
+fi
+
+if ! $(pkcsconf -t -c ${SLOT} | grep -q "Flags: .*USER_PIN_INITIALIZED.*"); then
+    echo "slot ${SLOT}: set new user-pin (${PIN})"
+    pkcsconf -c ${SLOT} -u -S "76543210" -n "${PIN}" \
+    || exit 99
+fi
+
+exit 0

--- a/scripts/ock-setup.sh
+++ b/scripts/ock-setup.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+
+########### generic ###########
+title()
+{
+    case "$1" in
+    "SECTION")
+        shift 1
+        echo "########################################"
+        echo "## $*"
+        echo ""
+        ;;
+    "ENDSECTION")
+        echo ""
+        echo "                                      ##"
+        echo "########################################"
+        echo ""
+        ;;
+    "PARA")
+        shift 1
+        echo ""
+        echo "## $*"
+        ;;
+    "LINE")
+        shift 1
+        echo "$*"
+        ;;
+    *)
+        echo "$*"
+        ;;
+    esac
+}
+
+########### ock-specific ###########
+
+SLOT=${OCK_SLOT:-"3"}
+PIN=${OCK_PIN:-"12345678"}
+
+BASEDIR=$(pwd)
+TMPDIR="tmp-ock"
+PINFILE=${BASEDIR}/${TMPDIR}/pin.txt
+
+title SECTION "Check & Configuration (opencryptoki)"
+title PARA "check ock tools and libraries"
+
+FAIL=0
+LIBOCK=$(/sbin/ldconfig -p | awk '/libopencryptoki.so.0/ {print $4}' | head -n 1)
+if [ -z "${LIBOCK}" ]; then
+    title LINE "libopencryptoki not installed"
+    FAIL=1
+fi
+
+if ! pidof pkcsslotd > /dev/null 2>&1 ; then
+    title LINE "pkcsslotd not running"
+    FAIL=1
+fi
+
+if ! groups | grep -qw pkcs11 ; then
+    title LINE "missing group membership"
+    FAIL=1
+fi
+
+PKCSCONF=$(command -v pkcsconf)
+if [ -z "${PKCSCONF}" ]; then
+    title LINE "pkcsconf tool is required"
+    FAIL=1
+fi
+
+P11SAK=$(command -v p11sak)
+if [ -z "${P11SAK}" ]; then
+    title LINE "p11sak tool is required"
+    FAIL=1
+fi
+
+if [ ${FAIL} -ne 0 ]; then
+    title LINE "skip (tools/libary missing)"
+    title ENDSECTION
+    exit 77
+fi
+
+title LINE "library path: ${LIBOCK}"
+title LINE "pkcsconf: ${PKCSCONF}"
+title LINE "p11sak: ${P11SAK}"
+title LINE "tools/library: ok"
+
+title PARA "check ock configuration"
+
+SLOT_CFG=$(pkcsconf -t -c ${SLOT})
+if [ $? != 0 ]; then
+    title LINE "[slot ${SLOT}]: token not working"
+    FAIL=1
+fi
+
+${PKCSCONF} -t -c ${SLOT} | grep "Flags:" | grep -qw "TOKEN_INITIALIZED"
+if [ $? != 0 ]; then
+    title LINE "[token/slot ${SLOT}]: token not initialized"
+    FAIL=1
+fi
+
+${PKCSCONF} -t -c ${SLOT} | grep "Flags:" | grep -qw "USER_PIN_INITIALIZED"
+if [ $? != 0 ]; then
+    title LINE "[token/slot ${SLOT}]: user-pin not initialized"
+    FAIL=1
+fi
+
+${PKCSCONF} -t -c ${SLOT} | grep "Flags:" | grep -qw "USER_PIN_TO_BE_CHANGED"
+if [ $? = 0 ]; then
+    title LINE "[token/slot ${SLOT}]: user-pin need to be changed"
+    FAIL=1
+fi
+
+if [ ${FAIL} -ne 0 ]; then
+    title LINE "skip (configuration problems)"
+    title ENDSECTION
+    exit 77
+fi
+
+OCK_VERSION=$(${PKCSCONF} -i -c ${SLOT} | grep -Po 'Library Version: \K[^ ]*')
+title LINE "library version: ${OCK_VERSION}"
+
+OCK_TOKEN=$(${PKCSCONF} -t -c ${SLOT} | grep -Po 'Label: \K[^ ]*')
+title LINE "token: ${OCK_TOKEN}"
+
+title LINE "configuration: ok"
+title ENDSECTION
+
+title SECTION "Setup"
+
+title PARA "Directories and files"
+title LINE "reset temporary directory"
+rm -rf ${TMPDIR}
+mkdir -p ${TMPDIR}
+
+echo ${PIN} > ${PINFILE}
+
+R64K=${TMPDIR}/r64k.bin
+dd if=/dev/urandom of=${R64K} bs=64K count=1 &> /dev/null
+
+R256=${TMPDIR}/r256.bin
+dd if=/dev/urandom of=${R256} bs=32 count=1 &>/dev/null
+
+R512=${TMPDIR}/r512.bin
+dd if=/dev/urandom of=${R512} bs=64 count=1 &>/dev/null
+
+title PARA "Openssl configuration (prepare)"
+if [ -z "${OPENSSL_CONF}" ]; then
+    title LINE "skip (OPENSSL_CONF must be set)"
+    title ENDSECTION
+    exit 77
+fi
+if [ ! -f "${OPENSSL_CONF}" ]; then
+    title LINE "skip (${OPENSSL_CONF} missing)"
+    title ENDSECTION
+    exit 77
+fi
+sed -e "s,^pkcs11-module-path = .*$,pkcs11-module-path = ${LIBOCK}," \
+    -e "/^pkcs11-module-init-args = .*$/d" \
+    -e "s,^pkcs11-module-token-pin = .*$,pkcs11-module-token-pin = file:${PINFILE}," \
+    ${OPENSSL_CONF} \
+> ${TMPDIR}/openssl.cnf
+unset OPENSSL_CONF
+title LINE "OPENSSL_CONF ${OPENSSL_CONF}"
+
+title PARA "generate test keys (rsa)"
+
+LBL="ock_rsa2k"
+P11SAK_ARGS="--slot ${SLOT} --pin ${PIN}"
+
+title LINE "clean-up"
+${P11SAK} remove-key rsa --label "${LBL}:prv" --force ${P11SAK_ARGS} > /dev/null || true
+${P11SAK} remove-key rsa --label "${LBL}:pub" --force ${P11SAK_ARGS} > /dev/null || true
+
+title LINE "generate key-pair"
+${P11SAK} generate-key rsa 2048 --attr "X:PSx" --label ${LBL} ${P11SAK_ARGS}
+
+title PARA "RSA PKCS11 URIs"
+BASEFILE="${TMPDIR}/${LBL}"
+BASEURI=""
+BASEURIWITHPIN=""
+PUBURI="pkcs11:object=${LBL}:pub;type=public"
+PRIURI="pkcs11:object=${LBL}:prv;type=private"
+title LINE "BASEFILE       ${BASEFILE}"
+title LINE "BASEURIWITHPIN ${BASEURIWITHPIN}"
+title LINE "BASEURI        ${BASEURI}"
+title LINE "PUBURI         ${PUBURI}"
+title LINE "PRIURI         ${PRIURI}"
+
+title PARA "generate test keys (ec)"
+LBL="ock_ec256"
+
+title LINE "clean-up"
+${P11SAK} remove-key ec --label "${LBL}:prv" --force ${P11SAK_ARGS} > /dev/null || true
+${P11SAK} remove-key ec --label "${LBL}:pub" --force ${P11SAK_ARGS} > /dev/null || true
+
+title LINE "generate key-pair"
+${P11SAK} generate-key ec prime256v1 --attr "X:PSx" --label ${LBL} ${P11SAK_ARGS}
+
+ECBASEFILE="${TMPDIR}/${LBL}"
+ECBASEURI=""
+ECPUBURI="pkcs11:object=${LBL}:pub;type=public"
+ECPRIURI="pkcs11:object=${LBL}:prv;type=private"
+
+title PARA "EC PKCS11 URIs"
+title LINE "ECBASEFILE      ${ECBASEFILE}"
+title LINE "ECBASEURI       ${ECBASEURI}"
+title LINE "ECPUBURI        ${ECPUBURI}"
+title LINE "ECPRIURI        ${ECPRIURI}"
+
+title PARA "Show contents of token in slot ${SLOT}"
+p11sak list-key all ${P11SAK_ARGS} | tail -n +2
+title LINE ""
+
+title PARA "openssl configuration (activate)"
+export OPENSSL_CONF="${TMPDIR}/openssl.cnf"
+title LINE "OPENSSL_CONF ${OPENSSL_CONF}"
+
+title PARA "Debug"
+title LINE "Export variables to ${TMPDIR}/debugvars for easy debugging"
+cat > ${TMPDIR}/debugvars << DBGSCRIPT
+# debug vars, just 'source ${TMPDIR}/debugvars'
+export TMPDIR="${BASEDIR}/${TMPDIR}"
+export OPENSSL_CONF="${BASEDIR}/${OPENSSL_CONF}"
+
+export PIN="${PIN}"
+export PINFILE="${PINFILE}"
+export R64K="${BASEDIR}/${R64K}"
+export R256="${BASEDIR}/${R256}"
+export R512="${BASEDIR}/${R512}"
+
+export BASEFILE="${BASEDIR}/${BASEFILE}"
+export BASEURIWITHPIN="${BASEURIWITHPIN}"
+export BASEURI="${BASEURI}"
+export PUBURI="${PUBURI}"
+export PRIURI="${PRIURI}"
+export ECBASEFILE="${BASEDIR}/${ECBASEFILE}"
+export ECBASEURI="${ECBASEURI}"
+export ECPUBURI="${ECPUBURI}"
+export ECPRIURI="${ECPRIURI}"
+DBGSCRIPT
+
+cat > ${TMPDIR}/unsetvars << UNSETSCRIPT
+# unset debug vars, just 'source ${TMPDIR}/debugvars'
+unset TMPDIR
+unset OPENSSL_CONF
+
+unset PIN
+unset PINFILE
+
+unset BASEFILE
+unset BASEURIWITHPIN
+unset BASEURI
+unset PUBURI
+unset PRIURI
+unset ECBASEFILE
+unset ECBASEURI
+unset ECPUBURI
+unset ECPRIURI
+UNSETSCRIPT
+
+title ENDSECTION
+
+exit 0

--- a/tests/test-openssl.sh
+++ b/tests/test-openssl.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+########### generic ###########
+title() {
+    case "$1" in
+    "SECTION")
+        shift 1
+        echo "########################################"
+        echo "## $*"
+        echo ""
+        ;;
+    "ENDSECTION")
+        echo ""
+        echo "                                      ##"
+        echo "########################################"
+        echo ""
+        ;;
+    "PARA")
+        shift 1
+        echo ""
+        echo "## $*"
+        ;;
+    "LINE")
+        shift 1
+        echo "$*"
+        ;;
+    *)
+        echo "$*"
+        ;;
+    esac
+}
+
+ossl() {
+    echo r $* >> ${GDB_CMDS}
+
+    echo openssl $*
+
+    eval openssl $1
+    return $?
+}
+
+skip() {
+    title LINE "skip"
+    return 77
+}
+
+log_test_result() {
+    local rc=$1
+    local name=$2
+    local subn=$3
+    local mesg=$4
+
+    case "${rc}" in
+    "0")
+        echo "* TESTCASE ${name} ${subn} PASS ${mesg}" >> ${RESULTLOG}
+        ;;
+    "77")
+        echo "* TESTCASE ${name} ${subn} SKIP ${mesg}" >> ${RESULTLOG}
+        ;;
+    *)
+        echo "* TESTCASE ${name} ${subn} FAIL ${mesg}" >> ${RESULTLOG}
+        ;;
+    esac
+}
+
+########### openssl-specific ###########
+
+if [ -z "${TMPDIR}" -o \
+     ! -d "${TMPDIR}" -o \
+     -z "${OPENSSL_CONF}" ]; then
+     echo "skip (requirements missing)"
+     exit 77
+fi
+
+GDB_CMDS=${TMPDIR}/gdb_commands.txt
+> ${GDB_CMDS}
+RESULTLOG=${TMPDIR}/result.log
+> ${RESULTLOG}
+
+title PARA "RSA key export"
+
+title LINE "export public key to file"
+if [ -n "${PUBURI}" ]; then
+    ossl '
+    pkey -in ${PUBURI} -pubin -pubout -out ${BASEFILE}.pub'
+else
+    skip
+fi
+log_test_result $? "RSA" "key-export" "export public key to file"
+
+title LINE "export private key to file (failure expected)"
+if [ -n "${PRIURI}" ]; then
+    ! ossl '
+    pkey -in ${PRIURI} -out ${BASEFILE}.pem' 2> /dev/null
+else
+    skip
+fi
+log_test_result $? "RSA" "key-export" "export private key to file (failure expected)"
+
+title PARA "RSA en-/decrypt data"
+
+echo "secret test" > ${TMPDIR}/secret.txt
+
+title LINE "encrypt data with public key (file)"
+if [ -f "${BASEFILE}.pub" ]; then
+    ossl '
+    pkeyutl -encrypt
+            -inkey "${BASEFILE}.pub"
+            -pubin
+            -pkeyopt pad-mode:oaep
+            -pkeyopt digest:sha256
+            -pkeyopt mgf1-digest:sha256
+            -in ${TMPDIR}/secret.txt
+            -out ${TMPDIR}/secret.txt.enc'
+else
+    skip
+fi
+log_test_result $? "RSA" "encrypt" "encrypt data (file)"
+
+title LINE "decrypt data with private key"
+if [ -n "${PRIURI}" ]; then
+    ossl '
+    pkeyutl -decrypt
+            -inkey "${PRIURI}"
+            -pkeyopt pad-mode:oaep
+            -pkeyopt digest:sha256
+            -pkeyopt mgf1-digest:sha256
+            -in ${TMPDIR}/secret.txt.enc
+            -out ${TMPDIR}/secret.txt.dec'
+else
+    skip
+fi
+log_test_result $? "RSA" "decrypt" "decrypt data data (URI)"
+
+diff -q ${TMPDIR}/secret.txt ${TMPDIR}/secret.txt.dec
+log_test_result $? "RSA" "en-decrypt" "compare original and decrypted text"
+
+title PARA "RSA sign/verify data"
+
+title LINE "sign data with private key"
+if [ -n "${PRIURI}" ]; then
+    ossl '
+    pkeyutl -sign -digest sha256
+            -inkey ${PRIURI}
+            -in ${R64K} -rawin
+            -out ${R64K}_rsa.sig'
+else
+    skip
+fi
+log_test_result $? "RSA" "sign" "sign data (URI)"
+
+title LINE "verify signature with public key (URI)"
+if [ -n "${PUBURI}" ]; then
+    ossl '
+    pkeyutl -verify -digest sha256
+            -inkey ${PUBURI} -pubin
+            -in ${R64K} -rawin
+            -sigfile ${R64K}_rsa.sig'
+else
+    skip
+fi
+log_test_result $? "RSA" "verify" "verify data (URI)"
+
+title LINE "verify signature with public key (file)"
+if [ -f "${BASEFILE}.pub" ]; then
+    ossl '
+    pkeyutl -verify -digest sha256
+            -inkey ${BASEFILE}.pub -pubin
+            -in ${R64K} -rawin
+            -sigfile ${R64K}_rsa.sig'
+else
+    skip
+fi
+log_test_result $? "RSA" "verify" "verify data (URI)"
+
+title PARA "EC key export"
+
+title LINE "export public key to file"
+if [ -n "${ECPUBURI}" ]; then
+    ossl '
+    pkey -in ${ECPUBURI} -pubin -pubout -out ${ECBASEFILE}.pub'
+else
+    skip
+fi
+log_test_result $? "EC" "key-export" "export public key to file"
+
+title LINE "export private key to file (failure expected)"
+if [ -n "${PRIURI}" ]; then
+    ! ossl '
+    pkey -in ${ECPRIURI} -out ${ECBASEFILE}.pem' 2> /dev/null
+else
+    skip
+fi
+log_test_result $? "EC" "key-export" "export private key to file (failure expected)"
+
+title PARA "EC sign/verify data (ECDSA)"
+
+title LINE "sign data with private key"
+if [ -n "${ECPRIURI}" ]; then
+    ossl '
+    pkeyutl -sign -digest sha256
+            -inkey ${ECPRIURI}
+            -in ${R64K} -rawin
+            -out ${R64K}_ec.sig'
+else
+    skip
+fi
+log_test_result $? "EC" "sign" "sign data (URI)"
+
+title LINE "verify signature with public key (URI)"
+if [ -n "${ECPUBURI}" ]; then
+    ossl '
+    pkeyutl -verify -digest sha256
+            -inkey ${ECPUBURI} -pubin
+            -in ${R64K} -rawin
+            -sigfile ${R64K}_ec.sig'
+else
+    skip
+fi
+log_test_result $? "EC" "verify" "verify data (URI)"
+
+title LINE "verify signature with public key (file)"
+if [ -f "${ECBASEFILE}.pub" ]; then
+    ossl '
+    pkeyutl -verify -digest sha256
+            -inkey ${ECBASEFILE}.pub -pubin
+            -in ${R64K} -rawin
+            -sigfile ${R64K}_ec.sig'
+else
+    skip
+fi
+log_test_result $? "EC" "verify" "verify data (file)"
+
+cat ${RESULTLOG}
+echo done


### PR DESCRIPTION
This series contains a first shot of an separate approach for setup- and test-scripts. The idea is, to execute a setup-script upfront, which covers all the PKCS#11-module specific handling. The main test scripts only does the provider tests by executing openssl commands. This series should also cover some documentation about how to setup opencryptoki, an alternative PKCS#11 module to NSS. 

Although we're not yet there, the long-term goal is to integrate these scripts in some kind of automated testing like make check or the github CI.

I would like to start a discussion about the way to structure the tests. Should we continue this way?