### PR TITLE
Add different ways for specifying PKCS#11 module to use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,13 @@ PKG_CHECK_MODULES(
 )
 AC_SUBST([SHARED_EXT], $(eval echo "${shrext_cmds}"))
 
+# Check whether we have a p11-kit to use as a default PKCS#11 module
+PKG_CHECK_EXISTS([p11-kit-1],
+                 [PKG_CHECK_VAR([DEFAULT_PKCS11_MODULE],
+                                [p11-kit-1],
+                                [proxy_module])],
+                 [AC_MSG_WARN([The P11-kit proxy is not available. No fallback PKCS11 module used.])])
+
 # Try nss-softoken first as used on Fedora,
 # fallback to "nss" as used on Debian
 PKG_CHECK_EXISTS(

--- a/src/provider.c
+++ b/src/provider.c
@@ -1064,6 +1064,16 @@ static int p11prov_module_init(P11PROV_CTX *ctx)
         ctx->module = OPENSSL_strdup(env_module);
     }
 
+    /* If the module is not specified in the configuration file, use the p11-kit proxy  */
+    if (ctx->module == NULL) {
+#ifdef DEFAULT_PKCS11_MODULE
+        ctx->module = OPENSSL_strdup(DEFAULT_PKCS11_MODULE);
+#else
+        P11PROV_raise(ctx, CKR_GENERAL_ERROR, "No PKCS#11 module specified.");
+        return -ENOENT;
+#endif
+    }
+
     P11PROV_debug("PKCS#11: Initializing the module: %s", ctx->module);
 
     dlerror();


### PR DESCRIPTION
Configuration of the provider through the openssl configuration file is cumbersome and it prevents also dynamically loading the provider (or makes it very complicated, see openssl/openssl#19496). Especially for testing, it would be very useful to have a way to pass environment variable with the testing pkcs11 module to use.

For generic use and integration in the consistent pkcs11 in os, the provider should try to pick up the default system pkcs11 module, which is in most of the cases p11-kit. This adds it as a default fallback option through `--with-default-pkcs11-module=yes`, which will ask p11-kit for this path through the pkg_config.

This also adds a implicit failure in case of no module was specified in any of the above means, which leads to dlopen call with NULL argument opening the calling so file, which does not have any `C_GetFunctionList`, leading to hard-to-parse errors like:

    prog: undefined symbol: C_GetFunctionList
