### PR TITLE
Improve public key export

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -976,9 +976,13 @@ static int p11prov_ec_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
         return RET_OSSL_ERR;
     }
 
-    /* TODO */
+    /* if anything else is asked for we can't provide it, so be strict */
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+        return RET_OSSL_ERR;
+    }
 
-    return RET_OSSL_ERR;
+    /* this will return the public EC_POINT as well as DOMAIN_PARAMTERS */
+    return p11prov_object_export_public_ec_key(obj, cb_fn, cb_arg);
 }
 
 static const OSSL_PARAM p11prov_ec_key_types[] = {

--- a/src/provider.h
+++ b/src/provider.h
@@ -168,6 +168,8 @@ P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
                                         size_t reference_sz);
 int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                          void *cb_arg);
+int p11prov_object_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
+                                        void *cb_arg);
 P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj);
 
 /* dispatching */

--- a/src/provider.h
+++ b/src/provider.h
@@ -27,6 +27,7 @@
 #define P11PROV_PKCS11_MODULE_PATH "pkcs11-module-path"
 #define P11PROV_PKCS11_MODULE_INIT_ARGS "pkcs11-module-init-args"
 #define P11PROV_PKCS11_MODULE_TOKEN_PIN "pkcs11-module-token-pin"
+#define P11PROV_PKCS11_MODULE_ALLOW_EXPORT "pkcs11-module-allow-export"
 
 #define P11PROV_DEFAULT_PROPERTIES "provider=pkcs11"
 #define P11PROV_NAMES_RSA "RSA:rsaEncryption:1.2.840.113549.1.1.1"
@@ -75,6 +76,10 @@ CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void **data, CK_ULONG *size);
 CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void *data, CK_ULONG size);
+
+#define ALLOW_EXPORT_PUBLIC 0
+#define DISALLOW_EXPORT_PUBLIC 1
+int p11prov_ctx_allow_export(P11PROV_CTX *ctx);
 
 /* Errors */
 void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,

--- a/src/store.c
+++ b/src/store.c
@@ -123,6 +123,10 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
         return RET_OSSL_ERR;
     }
 
+    if (p11prov_ctx_allow_export(obj->ctx) & DISALLOW_EXPORT_PUBLIC) {
+        return RET_OSSL_ERR;
+    }
+
     n = p11prov_key_attr(obj->data.key, CKA_MODULUS);
     if (n == NULL) {
         return RET_OSSL_ERR;

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -24,4 +24,5 @@ module = @libtoollibs@/pkcs11_provider.so
 pkcs11-module-path = @softokenpath@
 pkcs11-module-init-args = configDir=@testsdir@/tokens
 pkcs11-module-token-pin = file:@testsdir@/tokens/pinfile.txt
+#pkcs11-module-allow-export
 activate = 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -222,7 +222,7 @@ if [ $FAIL -eq 0 ]; then
 fi
 
 title PARA "Export EC Public key to a file"
-#ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${ECCRT}.pub'
+ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${ECCRT}.pub'
 
 title PARA "Raw Sign check error"
 dd if=/dev/urandom of=${TMPPDIR}/64Brandom.bin bs=64 count=1 >/dev/null 2>&1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -189,6 +189,8 @@ export ECPUBURI="${ECPUBURI}"
 export ECPRIURI="${ECPRIURI}"
 DBGSCRIPT
 
+    OPENSSL_CONF="${BASEDIR}/openssl.cnf"
+
     title ENDSECTION
 }
 
@@ -415,5 +417,18 @@ diff ${TMPPDIR}/hkdf2-out-pkcs11.bin ${TMPPDIR}/hkdf2-out.bin
 
 title PARA "Test session support"
 BASEURI="${BASEURI}" ./tsession
+
+title PARA "Test Disallow Public Export"
+FAIL=0
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed "s/#pkcs11-module-allow-export/pkcs11-module-allow-export = 1/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.noexport
+OPENSSL_CONF=${OPENSSL_CONF}.noexport
+ossl 'pkey -in $BASEURI -pubin -pubout -out ${TSTCRT}.pub.fail' || FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "pkcs11 export should have failed, but actually succeeded"
+    exit 1
+fi
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+rm -f ${OPENSSL_CONF}.noexport
 
 exit 0


### PR DESCRIPTION
Add function to allow exporting EC public keys.

Add option to deny exporting public keys so processing stays on the token.

Fixes #69