### PR TITLE
Add support for generating CSRs via openssl req command

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -45,15 +45,15 @@ static void print_data_buffer(BIO *out, CK_BYTE *buf, int len, int justify,
     }
 }
 
-DISPATCH_BASE_ENCODER_FN(rsa, newctx);
-DISPATCH_BASE_ENCODER_FN(rsa, freectx);
+DISPATCH_BASE_ENCODER_FN(newctx);
+DISPATCH_BASE_ENCODER_FN(freectx);
 DISPATCH_TEXT_ENCODER_FN(rsa, encode);
 
 struct p11prov_encoder_ctx {
     P11PROV_CTX *provctx;
 };
 
-static void *p11prov_rsa_encoder_newctx(void *provctx)
+static void *p11prov_encoder_newctx(void *provctx)
 {
     struct p11prov_encoder_ctx *ctx;
 
@@ -66,7 +66,7 @@ static void *p11prov_rsa_encoder_newctx(void *provctx)
     return ctx;
 }
 
-static void p11prov_rsa_encoder_freectx(void *ctx)
+static void p11prov_encoder_freectx(void *ctx)
 {
     OPENSSL_free(ctx);
 }
@@ -166,9 +166,9 @@ static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
 }
 
 const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[] = {
-    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
-    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
-    DISPATCH_BASE_ENCODER_ELEM(ENCODE, rsa, encode_text),
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
+    DISPATCH_TEXT_ENCODER_ELEM(ENCODE, rsa, encode_text),
     { 0, NULL },
 };
 
@@ -197,8 +197,8 @@ static int p11prov_rsa_encoder_pkcs1_der_encode(
 }
 
 const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[] = {
-    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
-    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
     DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, pkcs1, der, does_selection),
     DISPATCH_ENCODER_ELEM(ENCODE, rsa, pkcs1, der, encode),
     { 0, NULL },
@@ -229,8 +229,8 @@ static int p11prov_rsa_encoder_pkcs1_pem_encode(
 }
 
 const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[] = {
-    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, rsa, newctx),
-    DISPATCH_BASE_ENCODER_ELEM(FREECTX, rsa, freectx),
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
     DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, pkcs1, pem, does_selection),
     DISPATCH_ENCODER_ELEM(ENCODE, rsa, pkcs1, pem, encode),
     { 0, NULL },

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -177,16 +177,15 @@ DISPATCH_ENCODER_FN(rsa, pkcs1, der, does_selection);
 static int p11prov_rsa_encoder_pkcs1_der_does_selection(void *inctx,
                                                         int selection)
 {
-    switch (selection) {
-    case OSSL_KEYMGMT_SELECT_PRIVATE_KEY:
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
         return RET_OSSL_ERR;
-    case OSSL_KEYMGMT_SELECT_PUBLIC_KEY:
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return RET_OSSL_ERR;
-    case OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS:
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
         return RET_OSSL_ERR;
     }
 
-    return RET_OSSL_ERR;
+    return RET_OSSL_OK;
 }
 
 static int p11prov_rsa_encoder_pkcs1_der_encode(
@@ -210,16 +209,15 @@ DISPATCH_ENCODER_FN(rsa, pkcs1, pem, does_selection);
 static int p11prov_rsa_encoder_pkcs1_pem_does_selection(void *inctx,
                                                         int selection)
 {
-    switch (selection) {
-    case OSSL_KEYMGMT_SELECT_PRIVATE_KEY:
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
         return RET_OSSL_ERR;
-    case OSSL_KEYMGMT_SELECT_PUBLIC_KEY:
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         return RET_OSSL_ERR;
-    case OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS:
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
         return RET_OSSL_ERR;
     }
 
-    return RET_OSSL_ERR;
+    return RET_OSSL_OK;
 }
 
 static int p11prov_rsa_encoder_pkcs1_pem_encode(

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -2,6 +2,8 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include "provider.h"
+#include <openssl/asn1t.h>
+#include <openssl/pem.h>
 #include <openssl/bio.h>
 
 static void print_data_buffer(BIO *out, CK_BYTE *buf, int len, int justify,
@@ -172,6 +174,145 @@ const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[] = {
     { 0, NULL },
 };
 
+/* Have to use OpenSSL nested ASN1 macros to build this, brace... */
+typedef struct {
+    ASN1_INTEGER *n;
+    ASN1_INTEGER *e;
+} P11PROV_RSA_PUBKEY;
+
+DECLARE_ASN1_FUNCTIONS(P11PROV_RSA_PUBKEY);
+IMPLEMENT_ASN1_FUNCTIONS(P11PROV_RSA_PUBKEY);
+
+ASN1_SEQUENCE(P11PROV_RSA_PUBKEY) = {
+    ASN1_SIMPLE(P11PROV_RSA_PUBKEY, n, ASN1_INTEGER),
+    ASN1_SIMPLE(P11PROV_RSA_PUBKEY, e, ASN1_INTEGER),
+} ASN1_SEQUENCE_END(P11PROV_RSA_PUBKEY)
+
+DECLARE_PEM_write_bio(P11PROV_RSA_PUBKEY, P11PROV_RSA_PUBKEY);
+IMPLEMENT_PEM_write_bio(P11PROV_RSA_PUBKEY, P11PROV_RSA_PUBKEY,
+                        PEM_STRING_RSA_PUBLIC, P11PROV_RSA_PUBKEY);
+
+static int p11prov_rsa_set_asn1key_data(const OSSL_PARAM *params, void *key)
+{
+    P11PROV_RSA_PUBKEY *asn1key = (P11PROV_RSA_PUBKEY *)key;
+    const OSSL_PARAM *p;
+    void *aret = NULL;
+    BIGNUM *n = NULL;
+    BIGNUM *e = NULL;
+    int ret;
+
+    /* Modulus */
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_N);
+    if (!p) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    ret = OSSL_PARAM_get_BN(p, &n);
+    if (ret != RET_OSSL_OK) {
+        goto done;
+    }
+
+    aret = BN_to_ASN1_INTEGER(n, asn1key->n);
+    if (!aret) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    /* Exponent */
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E);
+    if (!p) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    ret = OSSL_PARAM_get_BN(p, &e);
+    if (ret != RET_OSSL_OK) {
+        return ret;
+    }
+
+    aret = BN_to_ASN1_INTEGER(e, asn1key->e);
+    if (!aret) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    ret = RET_OSSL_OK;
+
+done:
+    BN_free(n);
+    BN_free(e);
+    return ret;
+}
+
+static P11PROV_RSA_PUBKEY *p11prov_rsa_pubkey_to_asn1(P11PROV_OBJ *obj)
+{
+    P11PROV_RSA_PUBKEY *asn1key;
+    int ret;
+
+    asn1key = P11PROV_RSA_PUBKEY_new();
+    if (!asn1key) {
+        return NULL;
+    }
+
+    ret = p11prov_object_export_public_rsa_key(
+        obj, p11prov_rsa_set_asn1key_data, asn1key);
+
+    if (ret != RET_OSSL_OK) {
+        P11PROV_RSA_PUBKEY_free(asn1key);
+        return NULL;
+    }
+
+    return asn1key;
+}
+
+static int p11prov_rsa_pubkey_to_der(P11PROV_OBJ *obj, unsigned char **der,
+                                     int *derlen)
+{
+    P11PROV_RSA_PUBKEY *asn1key;
+
+    asn1key = p11prov_rsa_pubkey_to_asn1(obj);
+    if (!asn1key) {
+        return RET_OSSL_ERR;
+    }
+
+    *derlen = i2d_P11PROV_RSA_PUBKEY(asn1key, der);
+    if (*derlen < 0) {
+        return RET_OSSL_ERR;
+    }
+    P11PROV_RSA_PUBKEY_free(asn1key);
+    return RET_OSSL_OK;
+}
+
+static X509_PUBKEY *p11prov_rsa_pubkey_to_x509(P11PROV_OBJ *obj)
+{
+    X509_PUBKEY *pubkey;
+    unsigned char *der = NULL;
+    int derlen = 0;
+    int ret;
+
+    ret = p11prov_rsa_pubkey_to_der(obj, &der, &derlen);
+    if (ret != RET_OSSL_OK) {
+        return NULL;
+    }
+
+    pubkey = X509_PUBKEY_new();
+    if (!pubkey) {
+        OPENSSL_free(der);
+        return NULL;
+    }
+
+    ret = X509_PUBKEY_set0_param(pubkey, OBJ_nid2obj(NID_rsaEncryption),
+                                 V_ASN1_NULL, NULL, der, derlen);
+    if (ret != RET_OSSL_OK) {
+        OPENSSL_free(der);
+        X509_PUBKEY_free(pubkey);
+        return NULL;
+    }
+
+    return pubkey;
+}
+
 DISPATCH_ENCODER_FN(rsa, pkcs1, der, does_selection);
 
 static int p11prov_rsa_encoder_pkcs1_der_does_selection(void *inctx,
@@ -233,5 +374,321 @@ const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[] = {
     DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
     DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, pkcs1, pem, does_selection),
     DISPATCH_ENCODER_ELEM(ENCODE, rsa, pkcs1, pem, encode),
+    { 0, NULL },
+};
+
+/* SubjectPublicKeyInfo DER Encode */
+DISPATCH_ENCODER_FN(rsa, spki, der, does_selection);
+
+static int p11prov_rsa_encoder_spki_der_does_selection(void *inctx,
+                                                       int selection)
+{
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
+        return RET_OSSL_OK;
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
+        return RET_OSSL_ERR;
+    }
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_rsa_encoder_spki_der_encode(void *inctx, OSSL_CORE_BIO *cbio,
+                                               const void *inkey,
+                                               const OSSL_PARAM key_abstract[],
+                                               int selection,
+                                               OSSL_PASSPHRASE_CALLBACK *cb,
+                                               void *cbarg)
+{
+    struct p11prov_encoder_ctx *ctx = (struct p11prov_encoder_ctx *)inctx;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)inkey;
+    CK_KEY_TYPE type;
+    X509_PUBKEY *pubkey = NULL;
+    P11PROV_KEY *key = NULL;
+    BIO *out = NULL;
+    int ret;
+
+    P11PROV_debug("RSA SubjectPublicKeyInfo DER Encoder");
+
+    /* we only return public key info */
+    if (!(selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)) {
+        return RET_OSSL_ERR;
+    }
+
+    key = p11prov_object_get_key(obj);
+    if (!key) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Object class");
+        return RET_OSSL_ERR;
+    }
+
+    type = p11prov_key_type(key);
+    if (type != CKK_RSA) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Key Type");
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    out = BIO_new_from_core_bio(p11prov_ctx_get_libctx(ctx->provctx), cbio);
+    if (!out) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Failed to init BIO");
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    pubkey = p11prov_rsa_pubkey_to_x509(obj);
+    if (!pubkey) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    ret = i2d_X509_PUBKEY_bio(out, pubkey);
+
+done:
+    X509_PUBKEY_free(pubkey);
+    p11prov_key_free(key);
+    BIO_free(out);
+    return ret;
+}
+
+const OSSL_DISPATCH p11prov_rsa_encoder_spki_der_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, rsa, spki, der, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, rsa, spki, der, encode),
+    { 0, NULL },
+};
+
+/* ECDSA */
+
+struct ecdsa_key_point {
+    ASN1_OBJECT *curve;
+    unsigned char *octet;
+    size_t octet_len;
+};
+
+static void ecdsa_key_point_free(struct ecdsa_key_point *k)
+{
+    if (k->curve) {
+        ASN1_OBJECT_free(k->curve);
+        k->curve = NULL;
+    }
+    if (k->octet) {
+        OPENSSL_free(k->octet);
+        k->octet = NULL;
+    }
+    k->octet_len = 0;
+}
+
+static int p11prov_ec_set_keypoint_data(const OSSL_PARAM *params, void *key)
+{
+    struct ecdsa_key_point *keypoint = (struct ecdsa_key_point *)key;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
+    if (!p) {
+        return RET_OSSL_ERR;
+    }
+    if (p->data_type != OSSL_PARAM_UTF8_STRING) {
+        return RET_OSSL_ERR;
+    }
+    keypoint->curve = OBJ_txt2obj(p->data, 0);
+    if (!keypoint->curve) {
+        return RET_OSSL_ERR;
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PUB_KEY);
+    if (!p) {
+        return RET_OSSL_ERR;
+    }
+    if (p->data_type != OSSL_PARAM_OCTET_STRING) {
+        return RET_OSSL_ERR;
+    }
+    keypoint->octet = OPENSSL_memdup(p->data, p->data_size);
+    if (!keypoint->octet) {
+        return RET_OSSL_ERR;
+    }
+    keypoint->octet_len = p->data_size;
+
+    return RET_OSSL_OK;
+}
+
+static X509_PUBKEY *p11prov_ec_pubkey_to_x509(P11PROV_OBJ *obj)
+{
+    struct ecdsa_key_point keypoint = { 0 };
+    X509_PUBKEY *pubkey;
+    int ret;
+
+    ret = p11prov_object_export_public_ec_key(obj, p11prov_ec_set_keypoint_data,
+                                              &keypoint);
+    if (ret != RET_OSSL_OK) {
+        ecdsa_key_point_free(&keypoint);
+        return NULL;
+    }
+
+    pubkey = X509_PUBKEY_new();
+    if (!pubkey) {
+        ecdsa_key_point_free(&keypoint);
+        return NULL;
+    }
+
+    ret = X509_PUBKEY_set0_param(pubkey, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),
+                                 V_ASN1_OBJECT, keypoint.curve, keypoint.octet,
+                                 keypoint.octet_len);
+    if (ret != RET_OSSL_OK) {
+        ecdsa_key_point_free(&keypoint);
+        X509_PUBKEY_free(pubkey);
+        return NULL;
+    }
+
+    return pubkey;
+}
+
+DISPATCH_ENCODER_FN(ec, pkcs1, der, does_selection);
+
+static int p11prov_ec_encoder_pkcs1_der_does_selection(void *inctx,
+                                                       int selection)
+{
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_ec_encoder_pkcs1_der_encode(void *inctx, OSSL_CORE_BIO *cbio,
+                                               const void *inkey,
+                                               const OSSL_PARAM key_abstract[],
+                                               int selection,
+                                               OSSL_PASSPHRASE_CALLBACK *cb,
+                                               void *cbarg)
+{
+    return RET_OSSL_ERR;
+}
+
+const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_der_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, ec, pkcs1, der, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, ec, pkcs1, der, encode),
+    { 0, NULL },
+};
+
+DISPATCH_ENCODER_FN(ec, pkcs1, pem, does_selection);
+
+static int p11prov_ec_encoder_pkcs1_pem_does_selection(void *inctx,
+                                                       int selection)
+{
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_ec_encoder_pkcs1_pem_encode(void *inctx, OSSL_CORE_BIO *cbio,
+                                               const void *inkey,
+                                               const OSSL_PARAM key_abstract[],
+                                               int selection,
+                                               OSSL_PASSPHRASE_CALLBACK *cb,
+                                               void *cbarg)
+{
+    return RET_OSSL_ERR;
+}
+
+const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_pem_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, ec, pkcs1, pem, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, ec, pkcs1, pem, encode),
+    { 0, NULL },
+};
+
+/* SubjectPublicKeyInfo DER Encode */
+DISPATCH_ENCODER_FN(ec, spki, der, does_selection);
+
+static int p11prov_ec_encoder_spki_der_does_selection(void *inctx,
+                                                      int selection)
+{
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+        return RET_OSSL_ERR;
+    } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
+        return RET_OSSL_OK;
+    } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) {
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_ERR;
+}
+
+static int p11prov_ec_encoder_spki_der_encode(void *inctx, OSSL_CORE_BIO *cbio,
+                                              const void *inkey,
+                                              const OSSL_PARAM key_abstract[],
+                                              int selection,
+                                              OSSL_PASSPHRASE_CALLBACK *cb,
+                                              void *cbarg)
+{
+    struct p11prov_encoder_ctx *ctx = (struct p11prov_encoder_ctx *)inctx;
+    P11PROV_OBJ *obj = (P11PROV_OBJ *)inkey;
+    CK_KEY_TYPE type;
+    X509_PUBKEY *pubkey = NULL;
+    P11PROV_KEY *key = NULL;
+    BIO *out = NULL;
+    int ret;
+
+    P11PROV_debug("EC SubjectPublicKeyInfo DER Encoder");
+
+    /* we only return public key info */
+    if (!(selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)) {
+        return RET_OSSL_ERR;
+    }
+
+    key = p11prov_object_get_key(obj);
+    if (!key) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Object class");
+        return RET_OSSL_ERR;
+    }
+
+    type = p11prov_key_type(key);
+    if (type != CKK_EC) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Invalid Key Type");
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    out = BIO_new_from_core_bio(p11prov_ctx_get_libctx(ctx->provctx), cbio);
+    if (!out) {
+        P11PROV_raise(ctx->provctx, CKR_GENERAL_ERROR, "Failed to init BIO");
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    pubkey = p11prov_ec_pubkey_to_x509(obj);
+    if (!pubkey) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    ret = i2d_X509_PUBKEY_bio(out, pubkey);
+
+done:
+    X509_PUBKEY_free(pubkey);
+    p11prov_key_free(key);
+    BIO_free(out);
+    return ret;
+}
+
+const OSSL_DISPATCH p11prov_ec_encoder_spki_der_functions[] = {
+    DISPATCH_BASE_ENCODER_ELEM(NEWCTX, newctx),
+    DISPATCH_BASE_ENCODER_ELEM(FREECTX, freectx),
+    DISPATCH_ENCODER_ELEM(DOES_SELECTION, ec, spki, der, does_selection),
+    DISPATCH_ENCODER_ELEM(ENCODE, ec, spki, der, encode),
     { 0, NULL },
 };

--- a/src/provider.c
+++ b/src/provider.c
@@ -711,6 +711,16 @@ static int p11prov_operations_init(P11PROV_CTX *ctx)
                  p11prov_rsa_encoder_pkcs1_der_functions);
     ADD_ALGO_EXT(RSA, encoder, "provider=pkcs11,output=pem,structure=pkcs1",
                  p11prov_rsa_encoder_pkcs1_pem_functions);
+    ADD_ALGO_EXT(RSA, encoder,
+                 "provider=pkcs11,output=der,structure=SubjectPublicKeyInfo",
+                 p11prov_rsa_encoder_spki_der_functions);
+    ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=der,structure=pkcs1",
+                 p11prov_ec_encoder_pkcs1_der_functions);
+    ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=pem,structure=pkcs1",
+                 p11prov_ec_encoder_pkcs1_pem_functions);
+    ADD_ALGO_EXT(EC, encoder,
+                 "provider=pkcs11,output=der,structure=SubjectPublicKeyInfo",
+                 p11prov_ec_encoder_spki_der_functions);
     TERM_ALGO(encoder);
 
     return RET_OSSL_OK;

--- a/src/provider.h
+++ b/src/provider.h
@@ -250,12 +250,16 @@ extern const OSSL_DISPATCH p11prov_hkdf_kdf_functions[];
 /* Encoders */
 #define DISPATCH_TEXT_ENCODER_FN(type, name) \
     static OSSL_FUNC_encoder_##name##_fn p11prov_##type##_encoder_##name##_text
-#define DISPATCH_BASE_ENCODER_FN(type, name) \
-    DECL_DISPATCH_FUNC(encoder, p11prov_##type##_encoder, name)
-#define DISPATCH_BASE_ENCODER_ELEM(NAME, type, name) \
+#define DISPATCH_TEXT_ENCODER_ELEM(NAME, type, name) \
     { \
         OSSL_FUNC_ENCODER_##NAME, \
             (void (*)(void))p11prov_##type##_encoder_##name \
+    }
+#define DISPATCH_BASE_ENCODER_FN(name) \
+    DECL_DISPATCH_FUNC(encoder, p11prov_encoder, name)
+#define DISPATCH_BASE_ENCODER_ELEM(NAME, name) \
+    { \
+        OSSL_FUNC_ENCODER_##NAME, (void (*)(void))p11prov_encoder_##name \
     }
 #define DISPATCH_ENCODER_FN(type, structure, format, name) \
     DECL_DISPATCH_FUNC(encoder, \

--- a/src/provider.h
+++ b/src/provider.h
@@ -147,6 +147,8 @@ P11PROV_KEY *p11prov_object_handle_to_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 CK_RV find_keys(P11PROV_CTX *provctx, P11PROV_SESSION *session,
                 CK_SLOT_ID slotid, P11PROV_URI *uri, store_key_callback cb,
                 void *cb_ctx);
+P11PROV_KEY *find_associated_key(P11PROV_CTX *provctx, P11PROV_KEY *key,
+                                 CK_OBJECT_CLASS class);
 P11PROV_KEY *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        P11PROV_SESSION *session,
                                        bool session_key, unsigned char *secret,

--- a/src/provider.h
+++ b/src/provider.h
@@ -273,6 +273,10 @@ extern const OSSL_DISPATCH p11prov_hkdf_kdf_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[];
+extern const OSSL_DISPATCH p11prov_rsa_encoder_spki_der_functions[];
+extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_der_functions[];
+extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_pem_functions[];
+extern const OSSL_DISPATCH p11prov_ec_encoder_spki_der_functions[];
 
 /* Utilities to fetch objects from tokens */
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -1525,7 +1525,7 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
         }
     }
 
-    return RET_OSSL_ERR;
+    return RET_OSSL_OK;
 }
 
 static int p11prov_ecdsa_set_ctx_params(void *ctx, const OSSL_PARAM params[])

--- a/src/signature.c
+++ b/src/signature.c
@@ -630,17 +630,17 @@ static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     int result = RET_OSSL_ERR;
     CK_RV ret;
 
-    if (!sigctx->session) {
-        return RET_OSSL_ERR;
-    }
-    sess = p11prov_session_handle(sigctx->session);
-
     if (sig == NULL) {
         if (sigctx->operation == CKF_VERIFY) {
             return RET_OSSL_ERR;
         }
         return p11prov_sig_get_sig_size(sigctx, siglen);
     }
+
+    if (!sigctx->session) {
+        return RET_OSSL_ERR;
+    }
+    sess = p11prov_session_handle(sigctx->session);
 
     ret = p11prov_ctx_status(sigctx->provctx, &f);
     if (ret != CKR_OK) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -171,13 +171,116 @@ static void p11prov_sig_freectx(void *ctx)
     OPENSSL_clear_free(sigctx, sizeof(P11PROV_SIG_CTX));
 }
 
+#define DER_SEQUENCE 0x30
+#define DER_OBJECT 0x06
+#define DER_NULL 0x05, 0x00
+
+#define DER_RSAID_SEQ_LEN 0x0D
+#define DER_RSAID_LEN 0x09
+/* 1.2.840.113549.1.1 */
+#define DER_RSADSI_PKCS1 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01
+
+#define DER_SEQ_RSA_SHA512 \
+    DER_SEQUENCE, DER_RSAID_SEQ_LEN, DER_OBJECT, DER_RSAID_LEN, \
+        DER_RSADSI_PKCS1, 0x0D, DER_NULL
+const unsigned char der_rsa_sha512[] = { DER_SEQ_RSA_SHA512 };
+#define DER_SEQ_RSA_SHA384 \
+    DER_SEQUENCE, DER_RSAID_SEQ_LEN, DER_OBJECT, DER_RSAID_LEN, \
+        DER_RSADSI_PKCS1, 0x0C, DER_NULL
+const unsigned char der_rsa_sha384[] = { DER_SEQ_RSA_SHA384 };
+#define DER_SEQ_RSA_SHA256 \
+    DER_SEQUENCE, DER_RSAID_SEQ_LEN, DER_OBJECT, DER_RSAID_LEN, \
+        DER_RSADSI_PKCS1, 0x0B, DER_NULL
+const unsigned char der_rsa_sha256[] = { DER_SEQ_RSA_SHA256 };
+#define DER_SEQ_RSA_SHA224 \
+    DER_SEQUENCE, DER_RSAID_SEQ_LEN, DER_OBJECT, DER_RSAID_LEN, \
+        DER_RSADSI_PKCS1, 0x0E, DER_NULL
+const unsigned char der_rsa_sha224[] = { DER_SEQ_RSA_SHA224 };
+#define DER_SEQ_RSA_SHA1 \
+    DER_SEQUENCE, DER_RSAID_SEQ_LEN, DER_OBJECT, DER_RSAID_LEN, \
+        DER_RSADSI_PKCS1, 0x05, DER_NULL
+const unsigned char der_rsa_sha1[] = { DER_SEQ_RSA_SHA1 };
+
+#define DER_ECSHA1_SEQ_LEN 0x09
+#define DER_ECSHA1_LEN 0x07
+/* 1.2.840.10045.4 */
+#define DER_ANSIX962_SIG 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04
+
+#define DER_ECSHA2_SEQ_LEN 0x10
+#define DER_ECSHA2_LEN 0x08
+/* 1.2.840.10045.4.3 */
+#define DER_ANSIX962_SHA2_SIG DER_ANSIX962_SIG, 0x03
+
+#define DER_SEQ_ECDSA_SHA224 \
+    DER_SEQUENCE, DER_ECSHA1_SEQ_LEN, DER_OBJECT, DER_ECSHA1_LEN, \
+        DER_ANSIX962_SHA2_SIG, 0x01
+const unsigned char der_ecdsa_sha224[] = { DER_SEQ_ECDSA_SHA224 };
+#define DER_SEQ_ECDSA_SHA256 \
+    DER_SEQUENCE, DER_ECSHA1_SEQ_LEN, DER_OBJECT, DER_ECSHA1_LEN, \
+        DER_ANSIX962_SHA2_SIG, 0x02
+const unsigned char der_ecdsa_sha256[] = { DER_SEQ_ECDSA_SHA256 };
+#define DER_SEQ_ECDSA_SHA384 \
+    DER_SEQUENCE, DER_ECSHA1_SEQ_LEN, DER_OBJECT, DER_ECSHA1_LEN, \
+        DER_ANSIX962_SHA2_SIG, 0x03
+const unsigned char der_ecdsa_sha384[] = { DER_SEQ_ECDSA_SHA384 };
+#define DER_SEQ_ECDSA_SHA512 \
+    DER_SEQUENCE, DER_ECSHA1_SEQ_LEN, DER_OBJECT, DER_ECSHA1_LEN, \
+        DER_ANSIX962_SHA2_SIG, 0x04
+const unsigned char der_ecdsa_sha512[] = { DER_SEQ_ECDSA_SHA512 };
+#define DER_SEQ_ECDSA_SHA1 \
+    DER_SEQUENCE, DER_ECSHA1_SEQ_LEN, DER_OBJECT, DER_ECSHA1_LEN, \
+        DER_ANSIX962_SIG, 0x01
+const unsigned char der_ecdsa_sha1[] = { DER_SEQ_ECDSA_SHA1 };
+
+#define DER_NISTID_SEQ_LEN 0x0D
+#define DER_NISTID_LEN 0x09
+/* 2.16.840.1.101.3.4.3 */
+#define DER_NIST_SIGALGS 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03
+
+#define DER_SEQ_RSA_SHA3_512 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x10, DER_NULL
+const unsigned char der_rsa_sha3_512[] = { DER_SEQ_RSA_SHA3_512 };
+#define DER_SEQ_RSA_SHA3_384 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0F, DER_NULL
+const unsigned char der_rsa_sha3_384[] = { DER_SEQ_RSA_SHA3_384 };
+#define DER_SEQ_RSA_SHA3_256 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0E, DER_NULL
+const unsigned char der_rsa_sha3_256[] = { DER_SEQ_RSA_SHA3_256 };
+#define DER_SEQ_RSA_SHA3_224 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0D, DER_NULL
+const unsigned char der_rsa_sha3_224[] = { DER_SEQ_RSA_SHA3_224 };
+
+#define DER_SEQ_ECDSA_SHA3_512 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0C, DER_NULL
+const unsigned char der_ecdsa_sha3_512[] = { DER_SEQ_ECDSA_SHA3_512 };
+#define DER_SEQ_ECDSA_SHA3_384 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0B, DER_NULL
+const unsigned char der_ecdsa_sha3_384[] = { DER_SEQ_ECDSA_SHA3_384 };
+#define DER_SEQ_ECDSA_SHA3_256 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x0A, DER_NULL
+const unsigned char der_ecdsa_sha3_256[] = { DER_SEQ_ECDSA_SHA3_256 };
+#define DER_SEQ_ECDSA_SHA3_224 \
+    DER_SEQUENCE, DER_NISTID_SEQ_LEN, DER_OBJECT, DER_NISTID_LEN, \
+        DER_NIST_SIGALGS, 0x09, DER_NULL
+const unsigned char der_ecdsa_sha3_224[] = { DER_SEQ_ECDSA_SHA3_224 };
+
 #define DM_ELEM_SHA(bits) \
     { \
         .name = "SHA" #bits, .digest = CKM_SHA##bits, \
         .pkcs_mech = CKM_SHA##bits##_RSA_PKCS, \
         .pkcs_pss = CKM_SHA##bits##_RSA_PKCS_PSS, \
         .ecdsa_mech = CKM_ECDSA_SHA##bits, .mgf = CKG_MGF1_SHA##bits, \
-        .digest_size = bits / 8 \
+        .digest_size = bits / 8, .der_rsa_algorithm_id = der_rsa_sha##bits, \
+        .der_rsa_algorithm_id_len = sizeof(der_rsa_sha##bits), \
+        .der_ecdsa_algorithm_id = der_ecdsa_sha##bits, \
+        .der_ecdsa_algorithm_id_len = sizeof(der_ecdsa_sha##bits), \
     }
 #define DM_ELEM_SHA3(bits) \
     { \
@@ -185,7 +288,10 @@ static void p11prov_sig_freectx(void *ctx)
         .pkcs_mech = CKM_SHA3_##bits##_RSA_PKCS, \
         .pkcs_pss = CKM_SHA3_##bits##_RSA_PKCS_PSS, \
         .ecdsa_mech = CKM_ECDSA_SHA3_##bits, .mgf = CKG_MGF1_SHA3_##bits, \
-        .digest_size = bits / 8 \
+        .digest_size = bits / 8, .der_rsa_algorithm_id = der_rsa_sha3_##bits, \
+        .der_rsa_algorithm_id_len = sizeof(der_rsa_sha3_##bits), \
+        .der_ecdsa_algorithm_id = der_ecdsa_sha3_##bits, \
+        .der_ecdsa_algorithm_id_len = sizeof(der_ecdsa_sha3_##bits), \
     }
 /* only the ones we can support */
 static struct {
@@ -196,6 +302,10 @@ static struct {
     CK_MECHANISM_TYPE ecdsa_mech;
     CK_RSA_PKCS_MGF_TYPE mgf;
     int digest_size;
+    const unsigned char *der_rsa_algorithm_id;
+    int der_rsa_algorithm_id_len;
+    const unsigned char *der_ecdsa_algorithm_id;
+    int der_ecdsa_algorithm_id_len;
 } digest_map[] = {
     DM_ELEM_SHA3(256),
     DM_ELEM_SHA3(512),
@@ -206,9 +316,46 @@ static struct {
     DM_ELEM_SHA(384),
     DM_ELEM_SHA(224),
     { "SHA1", CKM_SHA_1, CKM_SHA1_RSA_PKCS, CKM_SHA1_RSA_PKCS_PSS,
-      CKM_ECDSA_SHA1, CKG_MGF1_SHA1, 20 },
-    { NULL, 0, 0, 0, 0, 0, 0 },
+      CKM_ECDSA_SHA1, CKG_MGF1_SHA1, 20, der_rsa_sha1, sizeof(der_rsa_sha1),
+      der_ecdsa_sha1, sizeof(der_ecdsa_sha1) },
+    { NULL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 };
+
+static CK_RV p11prov_rsa_sig_algid(CK_MECHANISM_TYPE digest,
+                                   const unsigned char **algid, int *len)
+{
+    for (int i = 0; digest_map[i].name != NULL; i++) {
+        if (digest_map[i].digest == digest) {
+            *algid = digest_map[i].der_rsa_algorithm_id;
+            *len = digest_map[i].der_rsa_algorithm_id_len;
+            return CKR_OK;
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+static CK_RV p11prov_ecdsa_sig_algid(CK_MECHANISM_TYPE digest,
+                                     const unsigned char **algid, int *len)
+{
+    for (int i = 0; digest_map[i].name != NULL; i++) {
+        if (digest_map[i].digest == digest) {
+            *algid = digest_map[i].der_ecdsa_algorithm_id;
+            *len = digest_map[i].der_ecdsa_algorithm_id_len;
+            return CKR_OK;
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+static int p11prov_sig_digest_size(CK_MECHANISM_TYPE digest)
+{
+    for (int i = 0; digest_map[i].name != NULL; i++) {
+        if (digest_map[i].digest == digest) {
+            return digest_map[i].digest_size;
+        }
+    }
+    return 0;
+}
 
 static const char *p11prov_sig_digest_name(CK_MECHANISM_TYPE digest)
 {
@@ -891,6 +1038,36 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
         return RET_OSSL_OK;
     }
 
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
+    if (p) {
+        const unsigned char *algid = NULL;
+        int len = 0;
+        CK_RV result;
+
+        switch (sigctx->mechtype) {
+        case CKM_RSA_PKCS:
+            result = p11prov_rsa_sig_algid(sigctx->digest, &algid, &len);
+            if (result != CKR_OK) {
+                return RET_OSSL_ERR;
+            }
+            break;
+        case CKM_RSA_X_509:
+            break;
+        case CKM_RSA_PKCS_PSS:
+            /* TODO */
+            break;
+        }
+
+        if (algid == NULL) {
+            return RET_OSSL_ERR;
+        }
+
+        ret = OSSL_PARAM_set_octet_string(p, algid, len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
         const char *digest = p11prov_sig_digest_name(sigctx->digest);
@@ -1064,6 +1241,7 @@ static const OSSL_PARAM *p11prov_rsasig_gettable_ctx_params(void *ctx,
                                                             void *prov)
 {
     static const OSSL_PARAM params[] = {
+        OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
@@ -1304,6 +1482,40 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     P11PROV_debug("ecdsa get ctx params (ctx=%p, params=%p)", ctx, params);
 
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
+    if (p) {
+        const unsigned char *algid = NULL;
+        int len = 0;
+        CK_RV result;
+
+        switch (sigctx->mechtype) {
+        case CKM_ECDSA:
+            result = p11prov_ecdsa_sig_algid(sigctx->digest, &algid, &len);
+            if (result != CKR_OK) {
+                return RET_OSSL_ERR;
+            }
+            break;
+        }
+
+        if (algid == NULL) {
+            return RET_OSSL_ERR;
+        }
+
+        ret = OSSL_PARAM_set_octet_string(p, algid, len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_SIZE);
+    if (p) {
+        size_t digest_size = p11prov_sig_digest_size(sigctx->digest);
+        ret = OSSL_PARAM_set_size_t(p, digest_size);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
+
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
         const char *digest = p11prov_sig_digest_name(sigctx->digest);
@@ -1351,9 +1563,8 @@ static const OSSL_PARAM *p11prov_ecdsa_gettable_ctx_params(void *ctx,
                                                            void *prov)
 {
     static const OSSL_PARAM params[] = {
-        /*
         OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
-         */
+        OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
         OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
         OSSL_PARAM_END,
     };

--- a/src/store.c
+++ b/src/store.c
@@ -109,16 +109,11 @@ P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj)
 int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                          void *cb_arg)
 {
+    P11PROV_KEY *pubkey = NULL;
     OSSL_PARAM params[3];
     CK_ATTRIBUTE *n, *e;
     unsigned char *val;
-
-    switch (obj->class) {
-    case CKO_PUBLIC_KEY:
-        break;
-    default:
-        return RET_OSSL_ERR;
-    }
+    int ret;
 
     if (p11prov_key_type(obj->data.key) != CKK_RSA) {
         return RET_OSSL_ERR;
@@ -129,18 +124,29 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     }
 
     n = p11prov_key_attr(obj->data.key, CKA_MODULUS);
-    if (n == NULL) {
-        return RET_OSSL_ERR;
+    e = p11prov_key_attr(obj->data.key, CKA_PUBLIC_EXPONENT);
+    if (!n || !e) {
+        if (obj->class == CKO_PRIVATE_KEY) {
+            /* try to find the associated public key */
+            pubkey =
+                find_associated_key(obj->ctx, obj->data.key, CKO_PUBLIC_KEY);
+            if (!pubkey) {
+                return RET_OSSL_ERR;
+            }
+            n = p11prov_key_attr(pubkey, CKA_MODULUS);
+            e = p11prov_key_attr(pubkey, CKA_PUBLIC_EXPONENT);
+            if (!n || !e) {
+                p11prov_key_free(pubkey);
+                return RET_OSSL_ERR;
+            }
+        } else {
+            return RET_OSSL_ERR;
+        }
     }
 
     WITH_FIXED_BUFFER(n, val);
     params[0] =
         OSSL_PARAM_construct_BN(OSSL_PKEY_PARAM_RSA_N, val, n->ulValueLen);
-
-    e = p11prov_key_attr(obj->data.key, CKA_PUBLIC_EXPONENT);
-    if (e == NULL) {
-        return RET_OSSL_ERR;
-    }
 
     WITH_FIXED_BUFFER(e, val);
     params[1] =
@@ -148,23 +154,24 @@ int p11prov_object_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
 
     params[2] = OSSL_PARAM_construct_end();
 
-    return cb_fn(params, cb_arg);
+    ret = cb_fn(params, cb_arg);
+
+    p11prov_key_free(pubkey);
+    return ret;
 }
 
 int p11prov_object_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                         void *cb_arg)
 {
+    P11PROV_KEY *pubkey = NULL;
     OSSL_PARAM params[3];
     CK_ATTRIBUTE *ec_params, *ec_point;
     ASN1_OCTET_STRING *octet = NULL;
+    EC_GROUP *group = NULL;
+    const unsigned char *val;
+    const char *curve_name;
+    int curve_nid;
     int ret;
-
-    switch (obj->class) {
-    case CKO_PUBLIC_KEY:
-        break;
-    default:
-        return RET_OSSL_ERR;
-    }
 
     if (p11prov_key_type(obj->data.key) != CKK_EC) {
         return RET_OSSL_ERR;
@@ -175,56 +182,68 @@ int p11prov_object_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     }
 
     ec_params = p11prov_key_attr(obj->data.key, CKA_EC_PARAMS);
-    if (ec_params == NULL) {
-        return RET_OSSL_ERR;
-    } else {
-        EC_GROUP *group;
-        const char *curve_name;
-        int curve_nid;
-
-        group =
-            d2i_ECPKParameters(NULL, (const unsigned char **)&ec_params->pValue,
-                               ec_params->ulValueLen);
-        if (group == NULL) {
-            return RET_OSSL_ERR;
-        }
-
-        curve_nid = EC_GROUP_get_curve_name(group);
-        if (curve_nid == NID_undef) {
-            EC_GROUP_free(group);
-            return RET_OSSL_ERR;
-        }
-        curve_name = OSSL_EC_curve_nid2name(curve_nid);
-        if (curve_name == NULL) {
-            EC_GROUP_free(group);
-            return RET_OSSL_ERR;
-        }
-        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
-                                                     (char *)curve_name, 0);
-        EC_GROUP_free(group);
-    }
-
     ec_point = p11prov_key_attr(obj->data.key, CKA_EC_POINT);
-    if (ec_point == NULL) {
-        return RET_OSSL_ERR;
-    } else {
-        octet = d2i_ASN1_OCTET_STRING(NULL,
-                                      (const unsigned char **)&ec_point->pValue,
-                                      ec_point->ulValueLen);
-        if (octet == NULL) {
+    if (!ec_params || !ec_point) {
+        if (obj->class == CKO_PRIVATE_KEY) {
+            /* try to find the associated public key */
+            pubkey =
+                find_associated_key(obj->ctx, obj->data.key, CKO_PUBLIC_KEY);
+            if (!pubkey) {
+                return RET_OSSL_ERR;
+            }
+            ec_params = p11prov_key_attr(pubkey, CKA_EC_PARAMS);
+            ec_point = p11prov_key_attr(pubkey, CKA_EC_POINT);
+            if (!ec_params || !ec_point) {
+                p11prov_key_free(pubkey);
+                return RET_OSSL_ERR;
+            }
+        } else {
             return RET_OSSL_ERR;
         }
-        params[1] = OSSL_PARAM_construct_octet_string(
-            OSSL_PKEY_PARAM_PUB_KEY, octet->data, octet->length);
     }
+
+    /* in d2i functions 'in' is overwritten to return the remainder of the
+     * buffer after parsing, so we always need to avoid passing in our pointer
+     * folders, to avoid having them clobbered */
+    val = ec_params->pValue;
+    group = d2i_ECPKParameters(NULL, (const unsigned char **)&val,
+                               ec_params->ulValueLen);
+    if (group == NULL) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    curve_nid = EC_GROUP_get_curve_name(group);
+    if (curve_nid == NID_undef) {
+        EC_GROUP_free(group);
+        return RET_OSSL_ERR;
+    }
+    curve_name = OSSL_EC_curve_nid2name(curve_nid);
+    if (curve_name == NULL) {
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
+                                                 (char *)curve_name, 0);
+
+    val = ec_point->pValue;
+    octet = d2i_ASN1_OCTET_STRING(NULL, (const unsigned char **)&val,
+                                  ec_point->ulValueLen);
+    if (octet == NULL) {
+        return RET_OSSL_ERR;
+    }
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+                                                  octet->data, octet->length);
 
     params[2] = OSSL_PARAM_construct_end();
 
     ret = cb_fn(params, cb_arg);
 
+done:
     /* must be freed after callback */
     ASN1_OCTET_STRING_free(octet);
-
+    p11prov_key_free(pubkey);
+    EC_GROUP_free(group);
     return ret;
 }
 
@@ -548,6 +567,10 @@ static int p11prov_store_export_object(void *loaderctx, const void *reference,
     }
 
     /* we can only export public bits, so that's all we do */
+    if (obj->class != CKO_PUBLIC_KEY) {
+        return RET_OSSL_ERR;
+    }
+
     return p11prov_object_export_public_rsa_key(obj, cb_fn, cb_arg);
 }
 

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -26,3 +26,58 @@ pkcs11-module-init-args = configDir=@testsdir@/tokens
 pkcs11-module-token-pin = file:@testsdir@/tokens/pinfile.txt
 #pkcs11-module-allow-export
 activate = 1
+
+####################################################################
+[ req ]
+default_bits		= 2048
+default_md		= sha256
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+string_mask = utf8only
+req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= US
+countryName_min			= 2
+countryName_max			= 2
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= New York
+localityName			= Locality Name (eg, city)
+localityName_default		= New York
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= PKCS11 Provider
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= Testing Harness
+commonName			= Common Name (eg, your name or your server\'s hostname)
+commonName_max			= 64
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+unstructuredName		= An optional company name
+
+[ v3_req ]
+# Extensions to add to a certificate request
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+# Extensions for a typical CA
+# PKIX recommendation.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical,CA:true
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+# Include email address in subject alt name: another PKIX recommendation
+subjectAltName=email:copy
+# Copy issuer details
+issuerAltName=issuer:copy

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -431,4 +431,10 @@ fi
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 rm -f ${OPENSSL_CONF}.noexport
 
+title PARA "Test CSR generation from private keys"
+ossl '
+req -new -batch -key "${PRIURI}" -out ${TMPPDIR}/rsa_csr.pem'
+ossl '
+req -new -batch -key "${ECPRIURI}" -out ${TMPPDIR}/ecdsa_csr.pem'
+
 exit 0


### PR DESCRIPTION
This required several changes
- Some fixes to signature code
- Add ability to return DER formatted algorithm-id to be included in CSR
- Add support for encoding SubjectPublicKeyInfo in DER format to be included in CSR
- Ability to fetch the corresponding public key when we need to export public attributes and are given a private key
- Other general fixes

Fixes #88 