### PR TITLE
Fix detection of endianness

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -98,7 +98,7 @@ P11PROV_KEY *p11prov_object_get_key(P11PROV_OBJ *obj)
  * Src and Dest, can be the same area, but not partially
  * overlapping memory areas */
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
 #define WITH_FIXED_BUFFER(src, ptr) \
     unsigned char fix_##src[src->ulValueLen]; \
     byteswap_buf(src->pValue, fix_##src, src->ulValueLen); \

--- a/src/util.c
+++ b/src/util.c
@@ -501,7 +501,7 @@ bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
 
 void byteswap_buf(unsigned char *src, unsigned char *dest, size_t len)
 {
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
     int s = 0;
     int e = len - 1;
     unsigned char sb;


### PR DESCRIPTION
The non-underscored constants in `endian.h` only if the `__USE_MISC` is defined for some reason. This fixes the failing tests on s390x during the build in copr:
https://copr.fedorainfracloud.org/coprs/jjelen/pkcs11-provider/monitor/

Fixes #96