### PR TITLE
Add support to expose digest mechanisms through the provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tests/openssl.cnf
 tests/openssl.cnf.softhsm
 tests/tmp.softhsm
 tests/tmp.softokn
+tests/tdigests
 tests/tsession
 tests/tgenkey
 tests/ttls

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ pkcs11_provider_la_SOURCES = \
 	asymmetric_cipher.c \
 	debug.c \
 	encoder.c \
+	digests.c \
 	exchange.c \
 	kdf.c \
 	keymgmt.c \

--- a/src/digests.c
+++ b/src/digests.c
@@ -1,0 +1,494 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include "provider.h"
+#include <string.h>
+
+/* General Digest Mapping functions */
+static struct {
+    CK_MECHANISM_TYPE digest;
+    size_t block_size;
+    size_t digest_size;
+    const char *names[5]; /* must give a size for initialization ... */
+} digest_map[] = {
+    { CKM_SHA_1,
+      64,
+      20,
+      { "SHA1", "SHA-1", "SSL3-SHA1", "1.3.14.3.2.26", NULL } },
+    { CKM_SHA224,
+      64,
+      28,
+      { "SHA2-224", "SHA-224", "SHA224", "2.16.840.1.101.3.4.2.4", NULL } },
+    { CKM_SHA256,
+      64,
+      32,
+      { "SHA2-256", "SHA-256", "SHA256", "2.16.840.1.101.3.4.2.1", NULL } },
+    { CKM_SHA384,
+      128,
+      48,
+      { "SHA2-384", "SHA-384", "SHA384", "2.16.840.1.101.3.4.2.2", NULL } },
+    { CKM_SHA512,
+      128,
+      64,
+      { "SHA2-512", "SHA-512", "SHA512", "2.16.840.1.101.3.4.2.3", NULL } },
+    { CKM_SHA512_224,
+      128,
+      28,
+      { "SHA2-512/224", "SHA-512/224", "SHA512-224", "2.16.840.1.101.3.4.2.5",
+        NULL } },
+    { CKM_SHA512_256,
+      128,
+      32,
+      { "SHA2-512/256", "SHA-512/256", "SHA512-256", "2.16.840.1.101.3.4.2.6",
+        NULL } },
+    { CKM_SHA3_224,
+      (1600 - 224 * 2) / 8,
+      28,
+      { "SHA3-224", "2.16.840.1.101.3.4.2.7", NULL } },
+    { CKM_SHA3_256,
+      (1600 - 256 * 2) / 8,
+      32,
+      { "SHA3-256", "2.16.840.1.101.3.4.2.8", NULL } },
+    { CKM_SHA3_384,
+      (1600 - 384 * 2) / 8,
+      48,
+      { "SHA3-384", "2.16.840.1.101.3.4.2.9", NULL } },
+    { CKM_SHA3_512,
+      (1600 - 512 * 2) / 8,
+      64,
+      { "SHA3-512", "2.16.840.1.101.3.4.2.10", NULL } },
+    { CK_UNAVAILABLE_INFORMATION, 0, 0, { NULL } },
+};
+
+CK_RV p11prov_digest_get_block_size(CK_MECHANISM_TYPE digest,
+                                    size_t *block_size)
+{
+    for (int i = 0; digest_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
+        if (digest_map[i].digest == digest) {
+            *block_size = digest_map[i].block_size;
+            return CKR_OK;
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV p11prov_digest_get_digest_size(CK_MECHANISM_TYPE digest,
+                                     size_t *digest_size)
+{
+    for (int i = 0; digest_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
+        if (digest_map[i].digest == digest) {
+            *digest_size = digest_map[i].digest_size;
+            return CKR_OK;
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV p11prov_digest_get_name(CK_MECHANISM_TYPE digest, const char **name)
+{
+    for (int i = 0; digest_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
+        if (digest_map[i].digest == digest) {
+            *name = digest_map[i].names[0];
+            return CKR_OK;
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+CK_RV p11prov_digest_get_by_name(const char *name, CK_MECHANISM_TYPE *digest)
+{
+    for (int i = 0; digest_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
+        for (int j = 0; digest_map[i].names[j] != NULL; j++) {
+            if (OPENSSL_strcasecmp(name, digest_map[i].names[j]) == 0) {
+                *digest = digest_map[i].digest;
+                return CKR_OK;
+            }
+        }
+    }
+    return CKR_MECHANISM_INVALID;
+}
+
+struct p11prov_digest_ctx {
+    P11PROV_CTX *provctx;
+    CK_MECHANISM_TYPE mechtype;
+
+    P11PROV_SESSION *session;
+};
+
+typedef struct p11prov_digest_ctx P11PROV_DIGEST_CTX;
+
+#define DISPATCH_DIGEST_NEWCTX_FN(mech, digest) \
+    static void *p11prov_##digest##_newctx(void *provctx) \
+    { \
+        P11PROV_DIGEST_CTX *dctx = OPENSSL_zalloc(sizeof(P11PROV_DIGEST_CTX)); \
+        if (dctx == NULL) { \
+            return NULL; \
+        } \
+        dctx->provctx = provctx; \
+        dctx->mechtype = mech; \
+        dctx->session = CK_INVALID_HANDLE; \
+        return dctx; \
+    }
+
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA_1, sha1);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA224, sha224);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA256, sha256);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA384, sha384);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA512, sha512);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA512_224, sha512_224);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA512_256, sha512_256);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA3_224, sha3_224);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA3_256, sha3_256);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA3_384, sha3_384);
+DISPATCH_DIGEST_NEWCTX_FN(CKM_SHA3_512, sha3_512);
+DISPATCH_DIGEST_COMMON_FN(dupctx);
+DISPATCH_DIGEST_COMMON_FN(freectx);
+DISPATCH_DIGEST_COMMON_FN(init);
+DISPATCH_DIGEST_COMMON_FN(update);
+DISPATCH_DIGEST_COMMON_FN(final);
+DISPATCH_DIGEST_COMMON_FN(gettable_params);
+
+static void *p11prov_digest_dupctx(void *ctx)
+{
+    P11PROV_DIGEST_CTX *dctx = (P11PROV_DIGEST_CTX *)ctx;
+    P11PROV_DIGEST_CTX *newctx;
+    CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
+    CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
+    CK_FUNCTION_LIST *f;
+    CK_BYTE_PTR state = NULL;
+    CK_ULONG state_len;
+    CK_RV ret;
+
+    P11PROV_debug("digest dupctx, ctx=%p", ctx);
+
+    if (dctx == NULL) {
+        return NULL;
+    }
+
+    newctx = OPENSSL_zalloc(sizeof(P11PROV_DIGEST_CTX));
+    if (dctx == NULL) {
+        return NULL;
+    }
+    newctx->provctx = dctx->provctx;
+    newctx->mechtype = dctx->mechtype;
+
+    if (dctx->session == NULL) {
+        goto done;
+    }
+
+    /* This is not really funny. OpenSSL by default assumes contexts with
+     * operations in flight can be easily duplicated, with all the
+     * cryptographic status and then both context can keep going
+     * independently. We'll try to save/restore state here, but on failure
+     * we just 'move' the the session to the new context and hope there is no
+     * need for the old context which will have no session and just return
+     * errors if an update is attempted. */
+
+    ret = p11prov_ctx_status(dctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
+    sess = p11prov_session_handle(dctx->session);
+
+    /* move old session to new context, we swap because often openssl continues
+     * on the duplicated context by default */
+    newctx->session = dctx->session;
+    dctx->session = NULL;
+
+    /* NOTE: most tokens will probably return errors trying to do this on digest
+     * sessions */
+
+    ret = f->C_GetOperationState(sess, NULL_PTR, &state_len);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret,
+                      "Error returned by C_GetOperationState");
+        goto done;
+    }
+    state = OPENSSL_malloc(state_len);
+    if (state == NULL) {
+        goto done;
+    }
+
+    ret = f->C_GetOperationState(sess, state, &state_len);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret,
+                      "Error returned by C_GetOperationState");
+        goto done;
+    }
+
+    /* FIXME: should probably cycle through slots and check if the slot,
+     * supports the mechtype via mechanism info requests */
+    ret = p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, NULL, NULL,
+                              false, false, &dctx->session);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Failed to open new session");
+        goto done;
+    }
+    sess = p11prov_session_handle(dctx->session);
+
+    ret = f->C_SetOperationState(sess, state, state_len, CK_INVALID_HANDLE,
+                                 CK_INVALID_HANDLE);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret,
+                      "Error returned by C_SetOperationState");
+        p11prov_session_free(dctx->session);
+        dctx->session = NULL;
+    }
+
+done:
+    OPENSSL_free(state);
+    return newctx;
+}
+
+static void p11prov_digest_freectx(void *ctx)
+{
+    P11PROV_DIGEST_CTX *dctx = (P11PROV_DIGEST_CTX *)ctx;
+
+    P11PROV_debug("digest freectx, ctx=%p", ctx);
+
+    if (!ctx) {
+        return;
+    }
+    p11prov_session_free(dctx->session);
+    OPENSSL_clear_free(dctx, sizeof(P11PROV_DIGEST_CTX));
+}
+
+static int p11prov_digest_init(void *ctx, const OSSL_PARAM params[])
+{
+    P11PROV_DIGEST_CTX *dctx = (P11PROV_DIGEST_CTX *)ctx;
+    CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
+    CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
+    CK_MECHANISM mechanism = { dctx->mechtype, NULL, 0 };
+    CK_FUNCTION_LIST *f;
+    CK_RV ret;
+
+    P11PROV_debug("digest init, ctx=%p", ctx);
+
+    if (ctx == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    ret = p11prov_ctx_status(dctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
+    /* FIXME: should probably cycle through slots and check if the slot,
+     * supports the mechtype via mechanism info requests */
+    ret = p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, NULL, NULL,
+                              false, false, &dctx->session);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Failed to open new session");
+        return RET_OSSL_ERR;
+    }
+    sess = p11prov_session_handle(dctx->session);
+
+    ret = f->C_DigestInit(sess, &mechanism);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Failed to initialize digest");
+        p11prov_session_free(dctx->session);
+        dctx->session = NULL;
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_OK;
+}
+
+static int p11prov_digest_update(void *ctx, const unsigned char *data,
+                                 size_t len)
+{
+    P11PROV_DIGEST_CTX *dctx = (P11PROV_DIGEST_CTX *)ctx;
+    CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
+    CK_FUNCTION_LIST *f;
+    CK_RV ret;
+
+    P11PROV_debug("digest update, ctx=%p", ctx);
+
+    if (ctx == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    if (len == 0) {
+        return RET_OSSL_OK;
+    }
+
+    ret = p11prov_ctx_status(dctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+    sess = p11prov_session_handle(dctx->session);
+
+    f->C_DigestUpdate(sess, (void *)data, len);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Failed to update digest");
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_OK;
+}
+
+static int p11prov_digest_final(void *ctx, unsigned char *out, size_t *size,
+                                size_t buf_size)
+{
+    P11PROV_DIGEST_CTX *dctx = (P11PROV_DIGEST_CTX *)ctx;
+    CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
+    CK_FUNCTION_LIST *f;
+    size_t digest_size;
+    CK_ULONG digest_len;
+    CK_RV ret;
+
+    P11PROV_debug("digest update, ctx=%p", ctx);
+
+    if (ctx == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    ret = p11prov_digest_get_digest_size(dctx->mechtype, &digest_size);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Unexpected get_digest_size error");
+        return RET_OSSL_ERR;
+    }
+
+    /* probing for buffer size to alloc */
+    if (buf_size == 0) {
+        *size = digest_size;
+        return RET_OSSL_OK;
+    } else if (buf_size < digest_size) {
+        P11PROV_raise(dctx->provctx, CKR_ARGUMENTS_BAD,
+                      "Digest output buffer too small %zd < %zd", buf_size,
+                      digest_size);
+        return RET_OSSL_OK;
+    }
+
+    digest_len = buf_size;
+
+    ret = p11prov_ctx_status(dctx->provctx, &f);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+    sess = p11prov_session_handle(dctx->session);
+
+    f->C_DigestFinal(sess, out, &digest_len);
+    if (ret != CKR_OK) {
+        P11PROV_raise(dctx->provctx, ret, "Failed to finalize digest");
+        return RET_OSSL_ERR;
+    }
+
+    *size = digest_len;
+    return RET_OSSL_OK;
+}
+
+static int p11prov_digest_get_params(CK_MECHANISM_TYPE digest,
+                                     OSSL_PARAM params[])
+{
+    OSSL_PARAM *p = NULL;
+    CK_RV ret;
+
+    P11PROV_debug("digest get params: digest=%ld, params=%p", digest, params);
+
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
+    if (p) {
+        size_t block_size;
+        ret = p11prov_digest_get_block_size(digest, &block_size);
+        if (ret != CKR_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+        ret = OSSL_PARAM_set_size_t(p, block_size);
+        if (ret != RET_OSSL_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return RET_OSSL_ERR;
+        }
+        P11PROV_debug("digest=%ld, block_size = %zd", digest, block_size);
+    }
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
+    if (p) {
+        size_t digest_size;
+        ret = p11prov_digest_get_digest_size(digest, &digest_size);
+        if (ret != CKR_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+        ret = OSSL_PARAM_set_size_t(p, digest_size);
+        if (ret != RET_OSSL_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return RET_OSSL_ERR;
+        }
+        P11PROV_debug("digest=%ld, digest_size = %zd", digest, digest_size);
+    }
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_XOF);
+    if (p) {
+        ret = OSSL_PARAM_set_int(p, 0);
+        if (ret != RET_OSSL_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return RET_OSSL_ERR;
+        }
+    }
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_ALGID_ABSENT);
+    if (p) {
+        ret = OSSL_PARAM_set_int(p, 1);
+        if (ret != RET_OSSL_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return RET_OSSL_ERR;
+        }
+    }
+    return RET_OSSL_OK;
+}
+
+#define DISPATCH_DIGEST_GET_PARAMS_FN(mech, digest) \
+    static int p11prov_##digest##_get_params(OSSL_PARAM params[]) \
+    { \
+        return p11prov_digest_get_params(mech, params); \
+    }
+
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA_1, sha1);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA224, sha224);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA256, sha256);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA384, sha384);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA512, sha512);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA512_224, sha512_224);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA512_256, sha512_256);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA3_224, sha3_224);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA3_256, sha3_256);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA3_384, sha3_384);
+DISPATCH_DIGEST_GET_PARAMS_FN(CKM_SHA3_512, sha3_512);
+
+static const OSSL_PARAM *p11prov_digest_gettable_params(void *provctx)
+{
+    P11PROV_debug("digest gettable params, ctx=%p", provctx);
+
+    static const OSSL_PARAM digest_params[] = {
+        OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_BLOCK_SIZE, NULL),
+        OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_SIZE, NULL),
+        OSSL_PARAM_int(OSSL_DIGEST_PARAM_XOF, NULL),
+        OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, NULL),
+        OSSL_PARAM_END,
+    };
+    return digest_params;
+}
+
+#define DISPATCH_FUNCTION_TABLE(digest) \
+    const OSSL_DISPATCH p11prov_##digest##_digest_functions[] = { \
+        DISPATCH_DIGEST_ELEM(digest, NEWCTX, newctx), \
+        DISPATCH_DIGEST_COMMON(DUPCTX, dupctx), \
+        DISPATCH_DIGEST_COMMON(FREECTX, freectx), \
+        DISPATCH_DIGEST_COMMON(INIT, init), \
+        DISPATCH_DIGEST_COMMON(UPDATE, update), \
+        DISPATCH_DIGEST_COMMON(FINAL, final), \
+        DISPATCH_DIGEST_ELEM(digest, GET_PARAMS, get_params), \
+        DISPATCH_DIGEST_COMMON(GETTABLE_PARAMS, gettable_params), \
+        { 0, NULL }, \
+    }
+
+DISPATCH_FUNCTION_TABLE(sha1);
+DISPATCH_FUNCTION_TABLE(sha224);
+DISPATCH_FUNCTION_TABLE(sha256);
+DISPATCH_FUNCTION_TABLE(sha384);
+DISPATCH_FUNCTION_TABLE(sha512);
+DISPATCH_FUNCTION_TABLE(sha512_224);
+DISPATCH_FUNCTION_TABLE(sha512_256);
+DISPATCH_FUNCTION_TABLE(sha3_224);
+DISPATCH_FUNCTION_TABLE(sha3_256);
+DISPATCH_FUNCTION_TABLE(sha3_384);
+DISPATCH_FUNCTION_TABLE(sha3_512);

--- a/src/provider.h
+++ b/src/provider.h
@@ -278,6 +278,63 @@ extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_pem_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_spki_der_functions[];
 
+/* Digests */
+#define DISPATCH_DIGEST_COMMON_FN(name) \
+    DECL_DISPATCH_FUNC(digest, p11prov_digest, name)
+#define DISPATCH_DIGEST_COMMON(NAME, name) \
+    { \
+        OSSL_FUNC_DIGEST_##NAME, (void (*)(void))p11prov_digest_##name \
+    }
+#define DISPATCH_DIGEST_FN(type, name) \
+    DECL_DISPATCH_FUNC(digest, p11prov_##type, name)
+#define DISPATCH_DIGEST_ELEM(digest, NAME, name) \
+    { \
+        OSSL_FUNC_DIGEST_##NAME, (void (*)(void))p11prov_##digest##_##name \
+    }
+extern const OSSL_DISPATCH p11prov_sha1_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha224_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha256_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha384_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha512_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha512_224_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha512_256_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha3_224_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha3_256_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha3_384_digest_functions[];
+extern const OSSL_DISPATCH p11prov_sha3_512_digest_functions[];
+
+#define P11PROV_NAMES_SHA1 "SHA1:SHA-1:SSL3-SHA1:1.3.14.3.2.26"
+#define P11PROV_DESCS_SHA1 "PKCS11 SHA1 Implementation"
+#define P11PROV_NAMES_SHA2_224 "SHA2-224:SHA-224:SHA224:2.16.840.1.101.3.4.2.4"
+#define P11PROV_DESCS_SHA2_224 "PKCS11 SHA2-224 Implementation"
+#define P11PROV_NAMES_SHA2_256 "SHA2-256:SHA-256:SHA256:2.16.840.1.101.3.4.2.1"
+#define P11PROV_DESCS_SHA2_256 "PKCS11 SHA2-256 Implementation"
+#define P11PROV_NAMES_SHA2_384 "SHA2-384:SHA-384:SHA384:2.16.840.1.101.3.4.2.2"
+#define P11PROV_DESCS_SHA2_384 "PKCS11 SHA2-384 Implementation"
+#define P11PROV_NAMES_SHA2_512 "SHA2-512:SHA-512:SHA512:2.16.840.1.101.3.4.2.3"
+#define P11PROV_DESCS_SHA2_512 "PKCS11 SHA2-512 Implementation"
+#define P11PROV_NAMES_SHA2_512_224 \
+    "SHA2-512/224:SHA-512/224:SHA512-224:2.16.840.1.101.3.4.2.5"
+#define P11PROV_DESCS_SHA2_512_224 "PKCS11 SHA2-512/224 Implementation"
+#define P11PROV_NAMES_SHA2_512_256 \
+    "SHA2-512/256:SHA-512/256:SHA512-256:2.16.840.1.101.3.4.2.6"
+#define P11PROV_DESCS_SHA2_512_256 "PKCS11 SHA2-512/224 Implementation"
+#define P11PROV_NAMES_SHA3_224 "SHA3-224:2.16.840.1.101.3.4.2.7"
+#define P11PROV_DESCS_SHA3_224 "PKCS11 SHA3-224 Implementation"
+#define P11PROV_NAMES_SHA3_256 "SHA3-256:2.16.840.1.101.3.4.2.8"
+#define P11PROV_DESCS_SHA3_256 "PKCS11 SHA3-256 Implementation"
+#define P11PROV_NAMES_SHA3_384 "SHA3-384:2.16.840.1.101.3.4.2.9"
+#define P11PROV_DESCS_SHA3_384 "PKCS11 SHA3-384 Implementation"
+#define P11PROV_NAMES_SHA3_512 "SHA3-512:2.16.840.1.101.3.4.2.10"
+#define P11PROV_DESCS_SHA3_512 "PKCS11 SHA3-512 Implementation"
+
+CK_RV p11prov_digest_get_block_size(CK_MECHANISM_TYPE digest,
+                                    size_t *block_size);
+CK_RV p11prov_digest_get_digest_size(CK_MECHANISM_TYPE digest,
+                                     size_t *digest_size);
+CK_RV p11prov_digest_get_name(CK_MECHANISM_TYPE digest, const char **name);
+CK_RV p11prov_digest_get_by_name(const char *name, CK_MECHANISM_TYPE *digest);
+
 /* Utilities to fetch objects from tokens */
 
 struct fetch_attrs {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ noinst_DATA = openssl.cnf
 libtoollibs=@abs_top_builddir@/src/.libs
 testsdir=@abs_top_builddir@/tests
 
-check_PROGRAMS = tsession tgenkey ttls
+check_PROGRAMS = tsession tgenkey ttls tdigests
 
 tsession_SOURCES = tsession.c
 tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -18,9 +18,15 @@ ttls_SOURCES = ttls.c
 ttls_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 ttls_LDADD = $(OPENSSL_LIBS)
 
+tdigests_SOURCES = tdigests.c
+tdigests_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tdigests_LDADD = $(OPENSSL_LIBS)
+
 dist_check_SCRIPTS = \
 	test-genkey-softhsm.sh \
 	test-genkey-softokn.sh \
+	test-digests-softhsm.sh \
+	test-digests-softokn.sh \
 	test-softhsm.sh \
 	test-softokn.sh
 

--- a/tests/tdigests.c
+++ b/tests/tdigests.c
@@ -1,0 +1,83 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+
+#define EXIT_TEST_SKIPPED 77
+
+int main(int argc, char *argv[])
+{
+    unsigned char osslout[EVP_MAX_MD_SIZE];
+    unsigned char pk11out[EVP_MAX_MD_SIZE];
+    unsigned int ossllen;
+    unsigned int pk11len;
+    bool pk11_tested = false;
+    const char *propq = "provider=pkcs11";
+    const char *digests[] = { "sha1",       "sha224",   "sha256",
+                              "sha384",     "sha512",   "sha512-224",
+                              "sha512-256", "sha3-224", "sha3-256",
+                              "sha3-384",   "sha3-512", NULL };
+    const char *data = "Digest This!";
+    int ret;
+
+    for (int i = 0; digests[i] != NULL; i++) {
+        const char *digest = digests[i];
+        const OSSL_PROVIDER *pk11prov;
+        const char *provname;
+        EVP_MD *osslmd;
+        EVP_MD *pk11md;
+
+        osslmd = EVP_MD_fetch(NULL, digest, NULL);
+        if (!osslmd) {
+            fprintf(stderr, "%s: Failed to fetch openssl EVP_MD\n", digest);
+            exit(EXIT_FAILURE);
+        }
+        pk11md = EVP_MD_fetch(NULL, digest, propq);
+        if (!pk11md) {
+            fprintf(stderr, "%s: Unsupported by pkcs11 token\n", digest);
+            continue;
+        }
+        pk11prov = EVP_MD_get0_provider(pk11md);
+        provname = OSSL_PROVIDER_get0_name(pk11prov);
+
+        if (strcmp(provname, "pkcs11") != 0) {
+            fprintf(stderr, "%s: Not a pkcs11 method, provider=%s\n", digest,
+                    provname);
+            continue;
+        }
+
+        ret = EVP_Digest(data, sizeof(data), osslout, &ossllen, osslmd, NULL);
+        if (ret != 1) {
+            fprintf(stderr, "%s: Failed to generate openssl digest\n", digest);
+            exit(EXIT_FAILURE);
+        }
+
+        ret = EVP_Digest(data, sizeof(data), pk11out, &pk11len, pk11md, NULL);
+        if (ret != 1) {
+            fprintf(stderr, "%s: Failed to generate pkcs11 digest\n", digest);
+            exit(EXIT_FAILURE);
+        }
+
+        if (ossllen != pk11len || memcmp(osslout, pk11out, ossllen) != 0) {
+            fprintf(stderr, "%s: Digests do not match!\n", digest);
+            exit(EXIT_FAILURE);
+        }
+
+        pk11_tested = true;
+
+        EVP_MD_free(osslmd);
+        EVP_MD_free(pk11md);
+    }
+
+    if (!pk11_tested) {
+        fprintf(stderr, "No digest available for testing pkcs11 provider\n");
+        exit(EXIT_TEST_SKIPPED);
+    }
+
+    exit(EXIT_SUCCESS);
+}

--- a/tests/test-digests-softhsm.sh
+++ b/tests/test-digests-softhsm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+SOURCE_PATH=${SOURCE_PATH:-..}
+
+TEST_SETUP_SKIP_KEYS=1
+# TODO for some reason the EC key generation does not work through the p11-kit proxy
+TEST_SETUP_USE_PROXY=1
+source $SOURCE_PATH/tests/setup-softhsm.sh
+./tdigests

--- a/tests/test-digests-softokn.sh
+++ b/tests/test-digests-softokn.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+SOURCE_PATH=${SOURCE_PATH:-..}
+
+TEST_SETUP_SKIP_KEYS=1
+source $SOURCE_PATH/tests/setup-softokn.sh
+./tdigests

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -255,4 +255,19 @@ if [ "$TEST_ECC_SHA2" = "1" ]; then
     req -new -batch -key "${ECPRIURI}" -out ${TMPPDIR}/ecdsa_csr.pem'
 fi
 
+title PARA "Test Digests"
+# Due to what seems a bug (https://github.com/openssl/openssl/issues/19662)
+# inOpenSSL 3.x, using openssl dgst is not very useful, so we just test one
+# common digest and defer to a custom test for digests until we have a fix.
+dgst="sha256"
+ossl 'dgst -${dgst} -out ${TMPPDIR}/dgst-${dgst}.ossl.txt ${TMPPDIR}/64krandom.bin'
+ossl 'dgst -${dgst} -provider=pkcs11 -propquery "provider=pkcs11" -out ${TMPPDIR}/dgst-${dgst}.prov.txt ${TMPPDIR}/64krandom.bin'
+OSSL_DGST=`cat ${TMPPDIR}/dgst-${dgst}.ossl.txt | cut -d= -f2`
+PROV_DGST=`cat ${TMPPDIR}/dgst-${dgst}.prov.txt | cut -d= -f2`
+if [ "${OSSL_DGST}" != "${PROV_DGST}" ]; then
+    echo "${dgst} digest produced with provider does not match openssl produced one"
+    echo "${PROV_DGST} != ${OSSL_DGST}"
+    exit 1
+fi
+
 exit 0


### PR DESCRIPTION
Add the digest provider functions.
Refactor code to use helpers from digest.c so all places use a single mapping function that will be easier to keep up to date.
Add tests.