### PR TITLE
Rename the module binary to just pkcs11.so

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,32 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [fedora-gcc, fedora-clang, debian-clang, fedora-distcheck]
+        name: [fedora, debian]
+        compiler: [gcc, clang]
         token: [softokn, softhsm]
         include:
-          - name: fedora-gcc
+          - name: fedora
             container: fedora:latest
-            compiler: gcc
-            action: check
-          - name: fedora-clang
-            container: fedora:latest
-            compiler: clang
-            action: check
-          - name: debian-clang
+          - name: debian
             container: debian:sid
-            compiler: clang
-            action: check
-          - name: fedora-distcheck
-            container: fedora:latest
-            compiler: gcc
-            action: distcheck
     container: ${{ matrix.container }}
     steps:
     - name: Install Dependencies
       run: |
           if [ -f /etc/fedora-release ]; then
             dnf -y install git ${{ matrix.compiler }} automake libtool \
-              pkgconf-pkg-config autoconf-archive openssl-devel openssl xz
+              pkgconf-pkg-config autoconf-archive openssl-devel openssl
             if [ "${{ matrix.token }}" = "softokn" ]; then
               dnf -y install nss-softokn nss-tools nss-softokn-devel
             elif [ "${{ matrix.token }}" = "softhsm" ]; then
@@ -62,7 +51,7 @@ jobs:
         autoreconf -fiv
         CC=${{ matrix.compiler }} ./configure
     - name: Build and Test
-      run: make ${{ matrix.action }}
+      run: make check
     - uses: actions/upload-artifact@v3
       if: failure()
       with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -1,0 +1,50 @@
+name: Distribution checks
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  distcheck:
+    name: Test make distcheck and RPM Build
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [fedora, debian]
+        include:
+          - name: fedora
+            container: fedora:latest
+          - name: debian
+            container: debian:sid
+    container: ${{ matrix.container }}
+    steps:
+    - name: Install Dependencies
+      run: |
+          if [ -f /etc/fedora-release ]; then
+            dnf -y install git gcc automake libtool \
+              pkgconf-pkg-config autoconf-archive openssl-devel openssl xz \
+              nss-softokn nss-tools nss-softokn-devel \
+              softhsm opensc  p11-kit-devel p11-kit-server \
+              rpm-build nss-devel
+          elif [ -f /etc/debian_version ]; then
+            apt-get -q update
+            apt-get -yq install git gcc make automake \
+              libtool pkg-config autoconf-archive libssl-dev openssl xz-utils \
+              libnss3 libnss3-tools libnss3-dev \
+              softhsm opensc p11-kit libp11-kit-dev p11-kit-modules
+          fi
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Setup
+      run: |
+        autoreconf -fiv
+        ./configure
+    - name: Distcheck
+      run: make distcheck
+    - name: RPM Build
+      if: ${{ matrix.name == 'fedora' }}
+      run: |
+        mkdir -p rpmbuild/SOURCES
+        cp pkcs11-provider*tar.gz rpmbuild/SOURCES/
+        rpmbuild --define "_topdir $PWD/rpmbuild" -ba packaging/pkcs11-provider.spec

--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -41,8 +41,6 @@ autoreconf -fi
 
 %install
 %make_install
-mkdir %{buildroot}%{_libdir}/ossl-modules/
-ln -s ../pkcs11_provider.so %{buildroot}%{_libdir}/ossl-modules/pkcs11.so
 
 
 %check
@@ -53,7 +51,6 @@ make check || if [ $? -ne 0 ]; then cat tests/*.log; exit 1; fi;
 %files
 %license COPYING
 %doc README
-%{_libdir}/pkcs11_provider.so
 %{_libdir}/ossl-modules/pkcs11.so
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,11 +2,13 @@
 AM_CFLAGS = $(STD_CFLAGS)
 
 noinst_HEADERS = pkcs11.h provider.h
-lib_LTLIBRARIES = pkcs11_provider.la
+pkcs11_LTLIBRARIES = pkcs11.la
 
 SHARED_EXT=@SHARED_EXT@
 
-pkcs11_provider_la_SOURCES = \
+pkcs11dir = $(libdir)/ossl-modules
+
+pkcs11_la_SOURCES = \
 	asymmetric_cipher.c \
 	debug.c \
 	encoder.c \
@@ -30,10 +32,10 @@ pkcs11_provider_la_SOURCES = \
 	provider.exports \
 	$(NULL)
 
-pkcs11_provider_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS) -Wall -Werror
-pkcs11_provider_la_LIBADD = $(OPENSSL_LIBS)
+pkcs11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS) -Wall -Werror
+pkcs11_la_LIBADD = $(OPENSSL_LIBS)
 
-pkcs11_provider_la_LDFLAGS = \
+pkcs11_la_LDFLAGS = \
 	$(AM_LDFLAGS) -module \
 	-shared -shrext $(SHARED_EXT) \
 	-avoid-version \

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -20,7 +20,7 @@ activate = 1
 activate = 1
 
 [pkcs11_sect]
-module = @libtoollibs@/pkcs11_provider.so
+module = @libtoollibs@/pkcs11.so
 pkcs11-module-init-args = configDir=@testsdir@/tmp.softokn/tokens
 pkcs11-module-token-pin = file:@testsdir@/pinfile.txt
 #pkcs11-module-allow-export


### PR DESCRIPTION
It is a little bit silly to name a provider something-provider, and other openssl providers just use their name.so (for examnple tpm2.so), so let's do the same for the pkcs11 provider and install it propoerly under /libdir/ossl-modules/pkcs11.so as expected by openssl provider distribution standards.

Also add a dstribution check CI tests, that runs make distcheck and builds an rpm from the spec file