### PR TITLE
Fix "tests" when built outside source directory

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,8 @@
 EXTRA_DIST = openssl.cnf.in
 
 libspath=@abs_top_builddir@/src/.libs
-testsdir=@abs_srcdir@
+testsblddir=@abs_top_builddir@/tests
+testssrcdir=@abs_srcdir@
 
 check_PROGRAMS = tsession tgenkey ttls tdigests
 
@@ -23,14 +24,16 @@ tdigests_LDADD = $(OPENSSL_LIBS)
 
 tmp.softokn:
 	LIBSPATH=$(libspath) \
-	TESTSDIR=$(testsdir) \
+	TESTSSRCDIR=$(testssrcdir) \
+	TESTBLDDIR=$(testsblddir) \
 	SOFTOKNPATH="$(SOFTOKENDIR)/$(SOFTOKEN_SUBDIR)" \
-	$(testsdir)/setup-softokn.sh > setup-softokn.log
+	$(testssrcdir)/setup-softokn.sh > setup-softokn.log
 tmp.softhsm:
 	LIBSPATH=$(libspath) \
-	TESTSDIR=$(testsdir) \
+	TESTSSRCDIR=$(testssrcdir) \
+	TESTBLDDIR=$(testsblddir) \
 	P11KITCLIENTPATH="$(P11KITCLIENTPATH)" \
-	$(testsdir)/setup-softhsm.sh > setup-softhsm.log
+	$(testssrcdir)/setup-softhsm.sh > setup-softhsm.log
 
 dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
@@ -54,7 +57,7 @@ $(TESTS): tmp.softokn tmp.softhsm
 
 TESTS_ENVIRONMENT =     \
 	LC_ALL="C"
-LOG_COMPILER = $(testsdir)/test-wrapper
+LOG_COMPILER = $(testssrcdir)/test-wrapper
 
 CLEANFILES = \
 	setup-*.log \

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -21,8 +21,8 @@ activate = 1
 
 [pkcs11_sect]
 module = @libtoollibs@/pkcs11.so
-pkcs11-module-init-args = configDir=@testsdir@/tmp.softokn/tokens
-pkcs11-module-token-pin = file:@testsdir@/pinfile.txt
+pkcs11-module-init-args = configDir=@testsblddir@/tmp.softokn/tokens
+pkcs11-module-token-pin = file:@testsblddir@/pinfile.txt
 #pkcs11-module-allow-export
 activate = 1
 

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 if ! command -v softhsm2-util &> /dev/null
 then
@@ -130,9 +130,10 @@ OPENSSL_CONF=${BASEDIR}/${TMPPDIR}/openssl.cnf
 
 title LINE "Generate openssl config file"
 sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
-    -e "s|@testsdir[@]|${BASEDIR}|g" \
+    -e "s|@testssrcdir[@]|${BASEDIR}|g" \
+    -e "s|@testsblddir@|${TESTBLDDIR}|g" \
     -e "/pkcs11-module-init-args/d" \
-    ${TESTSDIR}/openssl.cnf.in > ${OPENSSL_CONF}
+    ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
 
 title LINE "Export test variables to ${TMPPDIR}/testvars"
 cat >> ${TMPPDIR}/testvars <<DBGSCRIPT
@@ -142,12 +143,11 @@ export PKCS11_PROVIDER_MODULE=${P11LIB}
 export PKCS11_PROVIDER_DEBUG="file:${BASEDIR}/${TMPPDIR}/p11prov-debug.log"
 export OPENSSL_CONF="${OPENSSL_CONF}"
 export SOFTHSM2_CONF=${BASEDIR}/${TMPPDIR}/softhsm.conf
-export TESTSDIR="${TESTSDIR}"
+export TESTSSRCDIR="${TESTSSRCDIR}"
 
 export TOKDIR="${BASEDIR}/${TOKDIR}"
 export TMPPDIR="${BASEDIR}/${TMPPDIR}"
 export PINVALUE="${PINVALUE}"
-export PINFILE="${BASEDIR}/${PINFILE}"
 export SEEDFILE="${BASEDIR}/${TMPPDIR}/noisefile.bin"
 export RAND64FILE="${BASEDIR}/${TMPPDIR}/64krandom.bin"
 

--- a/tests/setup-softokn.sh
+++ b/tests/setup-softokn.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 if ! command -v certutil &> /dev/null
 then
@@ -146,20 +146,21 @@ OPENSSL_CONF=${BASEDIR}/${TMPPDIR}/openssl.cnf
 
 title LINE "Generate openssl config file"
 sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
-    -e "s|@testsdir[@]|${BASEDIR}|g" \
-    ${TESTSDIR}/openssl.cnf.in > ${OPENSSL_CONF}
+    -e "s|@testssrcdir[@]|${BASEDIR}|g" \
+    -e "s|@testsblddir@|${TESTBLDDIR}|g" \
+    ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
 
 title LINE "Export tests variables to ${TMPPDIR}/testvars"
 cat > ${TMPPDIR}/testvars <<DBGSCRIPT
 export PKCS11_PROVIDER_DEBUG="file:${BASEDIR}/${TMPPDIR}/p11prov-debug.log"
 export PKCS11_PROVIDER_MODULE="${SOFTOKNPATH}/libsoftokn3.so"
 export OPENSSL_CONF="${OPENSSL_CONF}"
-export TESTSDIR="${TESTSDIR}"
+export TESTSSRCDIR="${TESTSSRCDIR}"
+export TESTBLDDIR="${TESTBLDDIR}"
 
 export TOKDIR="${BASEDIR}/${TOKDIR}"
 export TMPPDIR="${BASEDIR}/${TMPPDIR}"
 export PINVALUE="${PINVALUE}"
-export PINFILE="${BASEDIR}/${PINFILE}"
 export SEEDFILE="${BASEDIR}/${TMPPDIR}/noisefile.bin"
 export RAND64FILE="${BASEDIR}/${TMPPDIR}/64krandom.bin"
 

--- a/tests/softhsm-proxy.sh
+++ b/tests/softhsm-proxy.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 # p11-kit complains if there is not runtime directory
 if [ -z "$XDG_RUNTIME_DIR" ]; then

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 TSTOUT="${TMPPDIR}/testout"
 

--- a/tests/teccsha2
+++ b/tests/teccsha2
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 title PARA "DigestSign and DigestVerify with ECC"
 ossl '

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -2,10 +2,12 @@
 # Copyright (C) 2022 Simo sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-TEST_PARAMS=(${1//-/ })
+TEST_PATH=$(dirname ${1})
+BNAME=$(basename ${1})
 
-TEST_NAME=$(basename ${TEST_PARAMS[0]})
-TEST_PATH=$(dirname ${TEST_PARAMS[0]})
+TEST_PARAMS=(${BNAME//-/ })
+
+TEST_NAME=${TEST_PARAMS[0]}
 TOKEN_DRIVER=${TEST_PARAMS[1]}
 
 if [ -f "./tmp.${TOKEN_DRIVER}/testvars" ];  then
@@ -26,7 +28,7 @@ fi
 
 for option in "${TEST_PARAMS[@]}"; do
     if [[ "$option" == "proxy" ]]; then
-        COMMAND="${TESTSDIR}/softhsm-proxy.sh $COMMAND"
+        COMMAND="${TESTSSRCDIR}/softhsm-proxy.sh $COMMAND"
     fi
 done
 

--- a/tests/thkdf
+++ b/tests/thkdf
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 title PARA "HKDF Derivation"
 HKDF_HEX_SECRET=ffeeddccbbaa

--- a/tests/toaepsha2
+++ b/tests/toaepsha2
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 SECRETFILE=${TMPPDIR}/rsa-oaep-secret.txt
 echo "Super Secret" > ${SECRETFILE}

--- a/tests/trsapss
+++ b/tests/trsapss
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSDIR}/helpers.sh
+source ${TESTSSRCDIR}/helpers.sh
 
 title PARA "DigestSign and DigestVerify with RSA PSS"
 ossl '


### PR DESCRIPTION
The test now work when built in the source or some other directory and configured like ../pkcs11-provider/configure

Fixes: #109

Define "testblddir" and "TESTBLDDIR" to point to the build/test directory i.e. "@abs_top_builddir@/tests" and correct several places where original code made some assumptions that the source directory was the same as the build directory.

`tests/test-wrapper` was patched to allow a file path name to include "-" It would fail to run some of the tests because it would not find the command an options.

The export PINFILE="${BASEDIR}/${PINFILE}" work when basename was null as previously in code it was already defined as PINFILE="${PWD}/pinfile.txt"

 Changes to be committed:
	modified:   tests/Makefile.am
	modified:   tests/openssl.cnf.in
	modified:   tests/setup-softhsm.sh
	modified:   tests/setup-softokn.sh
	modified:   tests/test-wrapper