### PR TITLE
Some code simpifications by generalizing helper functions

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -505,11 +505,10 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -523,9 +522,8 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        const char *digest = NULL;
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -338,10 +338,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
     if (p) {
-        char name[128] = { 0 };
-        char *str = name;
+        const char *name = NULL;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &str, sizeof(name));
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &name);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -368,11 +367,10 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -367,19 +367,15 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
     if (p) {
-        const char *digest = NULL;
+        const struct p11prov_digest *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
-        if (ret != RET_OSSL_OK) {
-            return ret;
-        }
-
-        rv = p11prov_digest_get_by_name(digest, &ecdhctx->digest);
+        rv = p11prov_digest_get_by_param(p, &digest);
         if (rv != CKR_OK) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
             return RET_OSSL_ERR;
         }
+        ecdhctx->digest = digest->digest;
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_OUTLEN);
@@ -456,14 +452,14 @@ static int p11prov_ecdh_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
     if (p) {
-        const char *digest;
+        const struct p11prov_digest *digest;
         CK_RV rv;
 
-        rv = p11prov_digest_get_name(ecdhctx->digest, &digest);
+        rv = p11prov_digest_get_by_mechanism(ecdhctx->digest, &digest);
         if (rv != CKR_OK) {
             return RET_OSSL_ERR;
         }
-        ret = OSSL_PARAM_set_utf8_string(p, digest);
+        ret = OSSL_PARAM_set_utf8_string(p, digest->names[0]);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -179,11 +179,10 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/provider.h
+++ b/src/provider.h
@@ -328,12 +328,19 @@ extern const OSSL_DISPATCH p11prov_sha3_512_digest_functions[];
 #define P11PROV_NAMES_SHA3_512 "SHA3-512:2.16.840.1.101.3.4.2.10"
 #define P11PROV_DESCS_SHA3_512 "PKCS11 SHA3-512 Implementation"
 
-CK_RV p11prov_digest_get_block_size(CK_MECHANISM_TYPE digest,
-                                    size_t *block_size);
-CK_RV p11prov_digest_get_digest_size(CK_MECHANISM_TYPE digest,
-                                     size_t *digest_size);
-CK_RV p11prov_digest_get_name(CK_MECHANISM_TYPE digest, const char **name);
-CK_RV p11prov_digest_get_by_name(const char *name, CK_MECHANISM_TYPE *digest);
+struct p11prov_digest {
+    CK_MECHANISM_TYPE digest;
+    size_t block_size;
+    size_t digest_size;
+    const char *names[5]; /* must give a size for initialization ... */
+};
+
+CK_RV p11prov_digest_get_by_mechanism(CK_MECHANISM_TYPE mech,
+                                      const struct p11prov_digest **digest);
+CK_RV p11prov_digest_get_by_name(const char *name,
+                                 const struct p11prov_digest **digest);
+CK_RV p11prov_digest_get_by_param(const OSSL_PARAM *p,
+                                  const struct p11prov_digest **digest);
 
 /* Utilities to fetch objects from tokens */
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -1120,11 +1120,10 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -1226,9 +1225,8 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_MGF1_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        const char *digest = NULL;
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -1564,11 +1562,10 @@ static int p11prov_ecdsa_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/signature.c
+++ b/src/signature.c
@@ -293,7 +293,7 @@ const unsigned char der_ecdsa_sha3_224[] = { DER_SEQ_ECDSA_SHA3_224 };
         .der_ecdsa_algorithm_id_len = sizeof(der_ecdsa_sha3_##bits), \
     }
 /* only the ones we can support */
-struct {
+struct p11prov_mech {
     CK_MECHANISM_TYPE digest;
     CK_MECHANISM_TYPE pkcs_mech;
     CK_MECHANISM_TYPE pkcs_pss;
@@ -318,26 +318,24 @@ struct {
     { CK_UNAVAILABLE_INFORMATION, 0, 0, 0, 0, 0, 0, 0, 0 },
 };
 
-static CK_RV p11prov_rsa_sig_algid(CK_MECHANISM_TYPE digest,
-                                   const unsigned char **algid, int *len)
+static CK_RV p11prov_mech_by_mechanism(CK_MECHANISM_TYPE mechanism,
+                                       const struct p11prov_mech **mech)
 {
     for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-        if (mech_map[i].digest == digest) {
-            *algid = mech_map[i].der_rsa_algorithm_id;
-            *len = mech_map[i].der_rsa_algorithm_id_len;
+        if (mech_map[i].digest == mechanism) {
+            *mech = &mech_map[i];
             return CKR_OK;
         }
     }
     return CKR_MECHANISM_INVALID;
 }
 
-static CK_RV p11prov_ecdsa_sig_algid(CK_MECHANISM_TYPE digest,
-                                     const unsigned char **algid, int *len)
+static CK_RV p11prov_mech_by_mgf(CK_RSA_PKCS_MGF_TYPE mgf,
+                                 const struct p11prov_mech **mech)
 {
     for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-        if (mech_map[i].digest == digest) {
-            *algid = mech_map[i].der_ecdsa_algorithm_id;
-            *len = mech_map[i].der_ecdsa_algorithm_id_len;
+        if (mech_map[i].mgf == mgf) {
+            *mech = &mech_map[i];
             return CKR_OK;
         }
     }
@@ -346,24 +344,27 @@ static CK_RV p11prov_ecdsa_sig_algid(CK_MECHANISM_TYPE digest,
 
 static const char *p11prov_sig_mgf_name(CK_RSA_PKCS_MGF_TYPE mgf)
 {
-    for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-        if (mech_map[i].mgf == mgf) {
-            const struct p11prov_digest *digest = NULL;
-            CK_RV rv;
+    const struct p11prov_mech *mech = NULL;
+    const struct p11prov_digest *digest = NULL;
+    CK_RV rv;
 
-            rv = p11prov_digest_get_by_mechanism(mech_map[i].digest, &digest);
-            if (rv != CKR_OK) {
-                return NULL;
-            }
-            return digest->names[0];
-        }
+    rv = p11prov_mech_by_mgf(mgf, &mech);
+    if (rv != CKR_OK) {
+        return NULL;
     }
-    return NULL;
+
+    rv = p11prov_digest_get_by_mechanism(mech->digest, &digest);
+    if (rv != CKR_OK) {
+        return NULL;
+    }
+
+    return digest->names[0];
 }
 
 static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char *digest_name)
 {
     const struct p11prov_digest *digest = NULL;
+    const struct p11prov_mech *mech = NULL;
     CK_RV rv;
 
     rv = p11prov_digest_get_by_name(digest_name, &digest);
@@ -371,12 +372,12 @@ static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char *digest_name)
         return CK_UNAVAILABLE_INFORMATION;
     }
 
-    for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-        if (mech_map[i].digest == digest->digest) {
-            return mech_map[i].mgf;
-        }
+    rv = p11prov_mech_by_mechanism(digest->digest, &mech);
+    if (rv != CKR_OK) {
+        return CK_UNAVAILABLE_INFORMATION;
     }
-    return CK_UNAVAILABLE_INFORMATION;
+
+    return mech->mgf;
 }
 
 static CK_RV p11prov_sig_pss_restrictions(P11PROV_SIG_CTX *sigctx,
@@ -414,6 +415,7 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
                                      CK_MECHANISM *mechanism)
 {
     P11PROV_SIG_CTX *sigctx = (P11PROV_SIG_CTX *)ctx;
+    const struct p11prov_mech *mech;
     int result = CKR_DATA_INVALID;
 
     mechanism->mechanism = sigctx->mechtype;
@@ -434,12 +436,9 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
 
     switch (sigctx->mechtype) {
     case CKM_RSA_PKCS:
-        for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-            if (sigctx->digest == mech_map[i].digest) {
-                mechanism->mechanism = mech_map[i].pkcs_mech;
-                result = CKR_OK;
-                break;
-            }
+        result = p11prov_mech_by_mechanism(sigctx->digest, &mech);
+        if (result == CKR_OK) {
+            mechanism->mechanism = mech->pkcs_mech;
         }
         break;
     case CKM_RSA_X_509:
@@ -447,24 +446,17 @@ static int p11prov_sig_set_mechanism(void *ctx, bool digest_sign,
     case CKM_RSA_PKCS_PSS:
         mechanism->pParameter = &sigctx->pss_params;
         mechanism->ulParameterLen = sizeof(sigctx->pss_params);
-        for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-            if (sigctx->digest == mech_map[i].digest) {
-                mechanism->mechanism = mech_map[i].pkcs_pss;
-                result = CKR_OK;
-                break;
-            }
-        }
+
+        result = p11prov_mech_by_mechanism(sigctx->digest, &mech);
         if (result == CKR_OK) {
+            mechanism->mechanism = mech->pkcs_pss;
             result = p11prov_sig_pss_restrictions(ctx, mechanism);
         }
         break;
     case CKM_ECDSA:
-        for (int i = 0; mech_map[i].digest != CK_UNAVAILABLE_INFORMATION; i++) {
-            if (sigctx->digest == mech_map[i].digest) {
-                mechanism->mechanism = mech_map[i].ecdsa_mech;
-                result = CKR_OK;
-                break;
-            }
+        result = p11prov_mech_by_mechanism(sigctx->digest, &mech);
+        if (result == CKR_OK) {
+            mechanism->mechanism = mech->ecdsa_mech;
         }
         break;
     }
@@ -1029,31 +1021,26 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p) {
-        const unsigned char *algid = NULL;
-        int len = 0;
+        const struct p11prov_mech *mech = NULL;
         CK_RV result;
 
         switch (sigctx->mechtype) {
         case CKM_RSA_PKCS:
-            result = p11prov_rsa_sig_algid(sigctx->digest, &algid, &len);
+            result = p11prov_mech_by_mechanism(sigctx->digest, &mech);
             if (result != CKR_OK) {
                 return RET_OSSL_ERR;
             }
+            ret = OSSL_PARAM_set_octet_string(p, mech->der_rsa_algorithm_id,
+                                              mech->der_rsa_algorithm_id_len);
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
             break;
         case CKM_RSA_X_509:
-            break;
+            return RET_OSSL_ERR;
         case CKM_RSA_PKCS_PSS:
             /* TODO */
-            break;
-        }
-
-        if (algid == NULL) {
             return RET_OSSL_ERR;
-        }
-
-        ret = OSSL_PARAM_set_octet_string(p, algid, len);
-        if (ret != RET_OSSL_OK) {
-            return ret;
         }
     }
 
@@ -1491,26 +1478,23 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p) {
-        const unsigned char *algid = NULL;
-        int len = 0;
+        const struct p11prov_mech *mech = NULL;
         CK_RV result;
 
         switch (sigctx->mechtype) {
         case CKM_ECDSA:
-            result = p11prov_ecdsa_sig_algid(sigctx->digest, &algid, &len);
+            result = p11prov_mech_by_mechanism(sigctx->digest, &mech);
             if (result != CKR_OK) {
                 return RET_OSSL_ERR;
             }
+            ret = OSSL_PARAM_set_octet_string(p, mech->der_ecdsa_algorithm_id,
+                                              mech->der_ecdsa_algorithm_id_len);
+            if (ret != RET_OSSL_OK) {
+                return ret;
+            }
             break;
-        }
-
-        if (algid == NULL) {
+        default:
             return RET_OSSL_ERR;
-        }
-
-        ret = OSSL_PARAM_set_octet_string(p, algid, len);
-        if (ret != RET_OSSL_OK) {
-            return ret;
         }
     }
 


### PR DESCRIPTION
- Use OSSL_PARAM_get_utf8_string_ptr() when possible
- Refactor accessing p11prov_digest_get_* API to return digest struct
- Add p11prov_mech_by_mechanism() helper and use it

```
$ git diff --stat main...HEAD
 src/asymmetric_cipher.c |  36 ++++++++--------
 src/digests.c           |  97 ++++++++++++++++++-------------------------
 src/exchange.c          |  22 ++++------
 src/kdf.c               |  37 ++++++-----------
 src/provider.h          |  19 ++++++---
 src/signature.c         | 210 ++++++++++++++++++++++++++++++++++++++++-----------------------------------------------------
 6 files changed, 180 insertions(+), 241 deletions(-)
```