### PR TITLE
Use OSSL_PARAM_get_utf8_string_ptr() when possible

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -505,11 +505,10 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -523,9 +522,8 @@ static int p11prov_rsaenc_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        const char *digest = NULL;
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -338,10 +338,9 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_TYPE);
     if (p) {
-        char name[128] = { 0 };
-        char *str = name;
+        const char *name = NULL;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &str, sizeof(name));
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &name);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -368,11 +367,10 @@ static int p11prov_ecdh_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_EXCHANGE_PARAM_KDF_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -179,11 +179,10 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }

--- a/src/signature.c
+++ b/src/signature.c
@@ -1120,11 +1120,10 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -1226,9 +1225,8 @@ static int p11prov_rsasig_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_MGF1_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        const char *digest = NULL;
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }
@@ -1564,11 +1562,10 @@ static int p11prov_ecdsa_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
     if (p) {
-        char digest[256];
-        char *ptr = digest;
+        const char *digest = NULL;
         CK_RV rv;
 
-        ret = OSSL_PARAM_get_utf8_string(p, &ptr, 256);
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
         if (ret != RET_OSSL_OK) {
             return ret;
         }


### PR DESCRIPTION
OSSL_PARAM_get_utf8_string_ptr() returns pointer to the data of OSSL_PARAM data and does not copy or allocate memory.

Prefer its usage when it makes sense.