### PR TITLE
Add basic support to load certificates from tokens

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,10 +16,10 @@ pkcs11_la_SOURCES = \
 	exchange.c \
 	kdf.c \
 	keymgmt.c \
-	keys.c \
 	oasis/pkcs11.h \
 	oasis/pkcs11f.h \
 	oasis/pkcs11t.h \
+	objects.c \
 	pkcs11.h \
 	platform/endian.h \
 	provider.h \

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -8,7 +8,7 @@
 struct p11prov_kdf_ctx {
     P11PROV_CTX *provctx;
 
-    P11PROV_KEY *key;
+    P11PROV_OBJ *key;
 
     CK_MECHANISM_TYPE mechtype;
 
@@ -70,7 +70,7 @@ static void p11prov_hkdf_reset(void *ctx)
     P11PROV_debug("hkdf reset (ctx:%p)", ctx);
 
     /* free all allocated resources */
-    p11prov_key_free(hkdfctx->key);
+    p11prov_obj_free(hkdfctx->key);
     if (hkdfctx->session) {
         p11prov_session_free(hkdfctx->session);
         hkdfctx->session = NULL;
@@ -128,7 +128,7 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     mechanism.pParameter = &hkdfctx->params;
     mechanism.ulParameterLen = sizeof(hkdfctx->params);
 
-    pkey_handle = p11prov_key_handle(hkdfctx->key);
+    pkey_handle = p11prov_obj_get_handle(hkdfctx->key);
     if (pkey_handle == CK_INVALID_HANDLE) {
         P11PROV_raise(hkdfctx->provctx, CKR_KEY_HANDLE_INVALID,
                       "Provided key has invalid handle");
@@ -140,7 +140,7 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
         hkdfctx->params.ulSaltType = CKF_HKDF_SALT_NULL;
     }
 
-    slotid = p11prov_key_slotid(hkdfctx->key);
+    slotid = p11prov_obj_get_slotid(hkdfctx->key);
     if (slotid == CK_UNAVAILABLE_INFORMATION) {
         P11PROV_raise(hkdfctx->provctx, CKR_SLOT_ID_INVALID,
                       "Provided key has invalid slot");

--- a/src/provider.h
+++ b/src/provider.h
@@ -145,12 +145,12 @@ void p11prov_obj_to_reference(P11PROV_OBJ *obj, void **reference,
 P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
                                         size_t reference_sz);
 
-typedef CK_RV (*store_key_callback)(void *, P11PROV_OBJ *);
+typedef CK_RV (*store_obj_callback)(void *, P11PROV_OBJ *);
 CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                               CK_OBJECT_HANDLE handle, P11PROV_OBJ **object);
-CK_RV find_keys(P11PROV_CTX *provctx, P11PROV_SESSION *session,
-                CK_SLOT_ID slotid, P11PROV_URI *uri, store_key_callback cb,
-                void *cb_ctx);
+CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
+                       CK_SLOT_ID slotid, P11PROV_URI *uri,
+                       store_obj_callback cb, void *cb_ctx);
 P11PROV_OBJ *find_associated_key(P11PROV_CTX *provctx, P11PROV_OBJ *key,
                                  CK_OBJECT_CLASS class);
 P11PROV_OBJ *p11prov_create_secret_key(P11PROV_CTX *provctx,

--- a/src/provider.h
+++ b/src/provider.h
@@ -379,7 +379,7 @@ void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri);
-char *p11prov_uri_get_object(P11PROV_URI *uri);
+char *p11prov_uri_get_serial(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
 int p11prov_get_pin(const char *in, char **out);

--- a/src/session.c
+++ b/src/session.c
@@ -353,6 +353,11 @@ CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session)
     return session->session;
 }
 
+CK_SLOT_ID p11prov_session_slotid(P11PROV_SESSION *session)
+{
+    return session->slotid;
+}
+
 static CK_RV token_login(P11PROV_CTX *provctx, struct p11prov_slot *slot,
                          P11PROV_URI *uri, OSSL_PASSPHRASE_CALLBACK *pw_cb,
                          void *pw_cbarg)

--- a/src/store.c
+++ b/src/store.c
@@ -113,8 +113,8 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
             return;
         }
 
-        ret = find_keys(ctx->provctx, ctx->session, slotid, ctx->parsed_uri,
-                        p11prov_store_ctx_add_obj, ctx);
+        ret = p11prov_obj_find(ctx->provctx, ctx->session, slotid,
+                               ctx->parsed_uri, p11prov_store_ctx_add_obj, ctx);
         if (ret != CKR_OK) {
             P11PROV_raise(ctx->provctx, ret,
                           "Failed to load keys from slot (%ld)", slotid);

--- a/src/util.c
+++ b/src/util.c
@@ -296,7 +296,7 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
         } else if (strncmp(p, "serial=", 7) == 0) {
             p += 7;
             len -= 7;
-            ptr = (unsigned char **)&u->object;
+            ptr = (unsigned char **)&u->serial;
         } else if (strncmp(p, "id=", 3) == 0) {
             p += 3;
             len -= 3;
@@ -386,7 +386,6 @@ void p11prov_uri_free(P11PROV_URI *uri)
     OPENSSL_free(uri->manufacturer);
     OPENSSL_free(uri->token);
     OPENSSL_free(uri->serial);
-    OPENSSL_free(uri->object);
     OPENSSL_free(uri->id.pValue);
     if (uri->pin) {
         OPENSSL_clear_free(uri->pin, strlen(uri->pin));
@@ -409,9 +408,9 @@ CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri)
     return uri->label;
 }
 
-char *p11prov_uri_get_object(P11PROV_URI *uri)
+char *p11prov_uri_get_serial(P11PROV_URI *uri)
 {
-    return uri->object;
+    return uri->serial;
 }
 
 char *p11prov_uri_get_pin(P11PROV_URI *uri)


### PR DESCRIPTION
This PR refactors how objects are stored.

In particular it merges the P11PROV_KEY structure into P11PROV_OBJ and adds support for representing both keys and certificates from a single object.

All code from keys.c and some from store.c is moved to objects.c 