### PR TITLE
Fix uri matching logic

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -109,7 +109,7 @@ struct p11prov_uri {
     char *token;
     char *serial;
     CK_ATTRIBUTE id;
-    CK_ATTRIBUTE label;
+    CK_ATTRIBUTE label; /* object= part of URI */
     char *pin;
     CK_OBJECT_CLASS class;
 };
@@ -419,21 +419,27 @@ char *p11prov_uri_get_pin(P11PROV_URI *uri)
 
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token)
 {
+    /* The tokenifo fields have already trailing spacess trimmed and replaced
+     * with NULL byte */
     if (uri->model
-        && strncmp(uri->model, (const char *)token->model, 16) != 0) {
+        && strlen(uri->model) == strlen((const char *)token->model)
+        && strcmp(uri->model, (const char *)token->model) != 0) {
         return CKR_CANCEL;
     }
     if (uri->manufacturer
-        && strncmp(uri->manufacturer, (const char *)token->manufacturerID, 32)
+        && strlen(uri->manufacturer) == strlen((const char *)token->manufacturerID)
+        && strcmp(uri->manufacturer, (const char *)token->manufacturerID)
                != 0) {
         return CKR_CANCEL;
     }
     if (uri->token
-        && strncmp(uri->token, (const char *)token->label, 32) != 0) {
+        && strlen(uri->token) == strlen((const char *)token->label)
+        && strcmp(uri->token, (const char *)token->label) != 0) {
         return CKR_CANCEL;
     }
     if (uri->serial
-        && strncmp(uri->serial, (const char *)token->serialNumber, 16) != 0) {
+        && strlen(uri->serial) == strlen((const char *)token->serialNumber)
+        && strcmp(uri->serial, (const char *)token->serialNumber) != 0) {
         return CKR_CANCEL;
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -108,7 +108,6 @@ struct p11prov_uri {
     char *manufacturer;
     char *token;
     char *serial;
-    char *object;
     CK_ATTRIBUTE id;
     CK_ATTRIBUTE label;
     char *pin;


### PR DESCRIPTION
The URI matching assumes that all the tokeninfo fields are of fixed length. This is the case in the PKCS#11 layer, but the spaces are stripped with `trim()` in `provider.c:get_slots()`. The URI fields that are compared to them do not have fixed length as they are dynamically allocated so the matching should always fail (probably works because of custom openssl allocators stuff the memory with some more zeroes?).

This is removing the unused uri member, which was confusing while reading the code, and updates the matching to match as a C strings (with explicit length checks). I think this still can break in case of the field is full (without any space padding) though.

Fixes: #124