### PR TITLE
Add fallback to cert to get public key attributes

### DIFF
--- a/src/provider.h
+++ b/src/provider.h
@@ -151,8 +151,6 @@ CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,
 CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
                        CK_SLOT_ID slotid, P11PROV_URI *uri,
                        store_obj_callback cb, void *cb_ctx);
-P11PROV_OBJ *find_associated_key(P11PROV_CTX *provctx, P11PROV_OBJ *key,
-                                 CK_OBJECT_CLASS class);
 P11PROV_OBJ *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        P11PROV_SESSION *session,
                                        bool session_key, unsigned char *secret,
@@ -384,6 +382,7 @@ bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
 #define SET_ATTR 1
 CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
                              CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data);
+CK_RV p11prov_copy_attr(CK_ATTRIBUTE *dst, CK_ATTRIBUTE *src);
 
 /* Sessions */
 CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,

--- a/src/util.c
+++ b/src/util.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <time.h>
 #include "platform/endian.h"
+#include <openssl/bn.h>
 
 CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                                CK_OBJECT_HANDLE object,
@@ -548,4 +549,19 @@ CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
     default:
         return CKR_ARGUMENTS_BAD;
     }
+}
+
+CK_RV p11prov_copy_attr(CK_ATTRIBUTE *dst, CK_ATTRIBUTE *src)
+{
+    if (src->ulValueLen) {
+        dst->pValue = OPENSSL_malloc(src->ulValueLen);
+        if (!dst->pValue) {
+            return CKR_HOST_MEMORY;
+        }
+        memcpy(dst->pValue, src->pValue, src->ulValueLen);
+        dst->ulValueLen = src->ulValueLen;
+    }
+    dst->type = src->type;
+
+    return CKR_OK;
 }


### PR DESCRIPTION
Allow the code to try not only to find an associated public key, but to also fallback further to try to find a certificate object and extract the public key attributes from that object.

Fixes #127