### PR TITLE
Minor fixups found during code review and experiments

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -108,7 +108,6 @@ struct p11prov_uri {
     char *manufacturer;
     char *token;
     char *serial;
-    char *object;
     CK_ATTRIBUTE id;
     CK_ATTRIBUTE label;
     char *pin;

--- a/src/util.c
+++ b/src/util.c
@@ -333,7 +333,7 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
                 u->class = CKO_PUBLIC_KEY;
             } else if (len == 7 && strncmp(p, "private", 7) == 0) {
                 u->class = CKO_PRIVATE_KEY;
-            } else if (len == 7 && strncmp(p, "secret", 7) == 0) {
+            } else if (len == 6 && strncmp(p, "secret", 6) == 0) {
                 u->class = CKO_SECRET_KEY;
             } else {
                 P11PROV_debug("Unknown object type");


### PR DESCRIPTION
This was initially shared as part of #126 but submitting this separately as it was was not related to the login issues.

 * The unused struct member can be removed
 * The `object-type=secret` had wrong length
 * In `token_login()` delaying the session allocation simplifies the process and prevents log pollution in case the login is not needed.