### PR TITLE
Skip slots that are not usable and check mechanism before selecting slot

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -178,8 +178,9 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_ERR;
     }
 
-    ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              false, false, &session);
+    ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL,
+                              mechanism.mechanism, NULL, NULL, false, false,
+                              &session);
     if (ret != CKR_OK) {
         P11PROV_raise(encctx->provctx, ret,
                       "Failed to open session on slot %lu", slotid);
@@ -287,8 +288,9 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_ERR;
     }
 
-    ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              true, false, &session);
+    ret = p11prov_get_session(encctx->provctx, &slotid, NULL, NULL,
+                              mechanism.mechanism, NULL, NULL, true, false,
+                              &session);
     if (ret != CKR_OK) {
         P11PROV_raise(encctx->provctx, ret,
                       "Failed to open session on slot %lu", slotid);

--- a/src/digests.c
+++ b/src/digests.c
@@ -218,10 +218,9 @@ static void *p11prov_digest_dupctx(void *ctx)
         goto done;
     }
 
-    /* FIXME: should probably cycle through slots and check if the slot,
-     * supports the mechtype via mechanism info requests */
-    ret = p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              false, false, &dctx->session);
+    ret =
+        p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, dctx->mechtype,
+                            NULL, NULL, false, false, &dctx->session);
     if (ret != CKR_OK) {
         P11PROV_raise(dctx->provctx, ret, "Failed to open new session");
         goto done;
@@ -275,10 +274,9 @@ static int p11prov_digest_init(void *ctx, const OSSL_PARAM params[])
         return RET_OSSL_ERR;
     }
 
-    /* FIXME: should probably cycle through slots and check if the slot,
-     * supports the mechtype via mechanism info requests */
-    ret = p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              false, false, &dctx->session);
+    ret =
+        p11prov_get_session(dctx->provctx, &slotid, NULL, NULL, dctx->mechtype,
+                            NULL, NULL, false, false, &dctx->session);
     if (ret != CKR_OK) {
         P11PROV_raise(dctx->provctx, ret, "Failed to open new session");
         return RET_OSSL_ERR;

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -251,9 +251,9 @@ static int p11prov_hkdf_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 
         /* Create Session  and key from key material */
         if (hkdfctx->session == NULL) {
-            ret =
-                p11prov_get_session(hkdfctx->provctx, &slotid, NULL, NULL, NULL,
-                                    NULL, false, false, &hkdfctx->session);
+            ret = p11prov_get_session(hkdfctx->provctx, &slotid, NULL, NULL,
+                                      hkdfctx->mechtype, NULL, NULL, false,
+                                      false, &hkdfctx->session);
             if (ret != CKR_OK) {
                 return RET_OSSL_ERR;
             }

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -303,8 +303,9 @@ static void *p11prov_common_gen(struct key_generator *ctx,
     }
 
     /* FIXME: how do we get a URI to select the right slot ? */
-    ret = p11prov_get_session(ctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              true, true, &session);
+    ret = p11prov_get_session(ctx->provctx, &slotid, NULL, NULL,
+                              ctx->mechanism.mechanism, NULL, NULL, true, true,
+                              &session);
     if (ret != CKR_OK) {
         return NULL;
     }

--- a/src/objects.c
+++ b/src/objects.c
@@ -633,7 +633,8 @@ static P11PROV_OBJ *find_associated_obj(P11PROV_CTX *provctx, P11PROV_OBJ *obj,
 
     slotid = p11prov_obj_get_slotid(obj);
 
-    ret = p11prov_get_session(provctx, &slotid, NULL, NULL, NULL, NULL, false,
+    ret = p11prov_get_session(provctx, &slotid, NULL, NULL,
+                              CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
                               false, &session);
     if (ret != CKR_OK) {
         goto done;
@@ -774,8 +775,9 @@ CK_RV p11prov_derive_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 
 again:
     if (!s) {
-        ret = p11prov_get_session(ctx, &slotid, NULL, NULL, NULL, NULL, false,
-                                  false, &s);
+        ret =
+            p11prov_get_session(ctx, &slotid, NULL, NULL, mechanism->mechanism,
+                                NULL, NULL, false, false, &s);
         if (ret != CKR_OK) {
             P11PROV_raise(ctx, ret, "Failed to open session on slot %lu",
                           slotid);
@@ -818,7 +820,8 @@ CK_RV p11prov_obj_set_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     CK_RV ret;
 
     if (!s) {
-        ret = p11prov_get_session(ctx, &slotid, NULL, NULL, NULL, NULL, false,
+        ret = p11prov_get_session(ctx, &slotid, NULL, NULL,
+                                  CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
                                   true, &s);
         if (ret != CKR_OK) {
             P11PROV_raise(ctx, ret, "Failed to open session on slot %lu",

--- a/src/provider.h
+++ b/src/provider.h
@@ -393,6 +393,7 @@ CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session);
 CK_SLOT_ID p11prov_session_slotid(P11PROV_SESSION *session);
 CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_SLOT_ID *next_slotid, P11PROV_URI *uri,
+                          CK_MECHANISM_TYPE mechtype,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -134,8 +134,9 @@ static void *p11prov_sig_dupctx(void *ctx)
             goto done;
         }
 
-        ret = p11prov_get_session(sigctx->provctx, &slotid, NULL, NULL, NULL,
-                                  NULL, reqlogin, false, &sigctx->session);
+        ret = p11prov_get_session(sigctx->provctx, &slotid, NULL, NULL,
+                                  sigctx->mechtype, NULL, NULL, reqlogin, false,
+                                  &sigctx->session);
         if (ret != CKR_OK) {
             P11PROV_raise(sigctx->provctx, ret,
                           "Failed to open session on slot %lu", slotid);
@@ -609,8 +610,9 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx, bool digest_op,
         reqlogin = true;
     }
 
-    ret = p11prov_get_session(sigctx->provctx, &slotid, NULL, NULL, NULL, NULL,
-                              reqlogin, false, &session);
+    ret = p11prov_get_session(sigctx->provctx, &slotid, NULL, NULL,
+                              mechanism.mechanism, NULL, NULL, reqlogin, false,
+                              &session);
     if (ret != CKR_OK) {
         P11PROV_raise(sigctx->provctx, ret,
                       "Failed to open session on slot %lu", slotid);

--- a/src/store.c
+++ b/src/store.c
@@ -98,9 +98,9 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
             ctx->session = CK_INVALID_HANDLE;
         }
 
-        ret =
-            p11prov_get_session(ctx->provctx, &slotid, &nextid, ctx->parsed_uri,
-                                pw_cb, pw_cbarg, false, false, &ctx->session);
+        ret = p11prov_get_session(ctx->provctx, &slotid, &nextid,
+                                  ctx->parsed_uri, CK_UNAVAILABLE_INFORMATION,
+                                  pw_cb, pw_cbarg, false, false, &ctx->session);
         if (ret != CKR_OK || ctx->session == CK_INVALID_HANDLE) {
             P11PROV_raise(ctx->provctx, ret,
                           "Failed to get session to load keys");


### PR DESCRIPTION
This PR handles optimizing iteration and usage of slots.
We skip completely slots that are at fault (can't fetch information) or where the token is not present.
We also now check that the token can handle the operation we are trying to perform at the time we request a session. This helps selecting the correct token on some operation when multiple tokens are available, and in general fails earlier if the token does not support the requested mechanism.

