### PR TITLE
Wrap PKCS#11 interface calls

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ pkcs11_la_SOURCES = \
 	exchange.c \
 	kdf.c \
 	keymgmt.c \
+	interface.c \
 	oasis/pkcs11.h \
 	oasis/pkcs11f.h \
 	oasis/pkcs11t.h \

--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -116,7 +116,7 @@ static int p11prov_rsaenc_encrypt_init(void *ctx, void *provkey,
     P11PROV_debug("encrypt init (ctx=%p, key=%p, params=%p)", ctx, provkey,
                   params);
 
-    ret = p11prov_ctx_status(encctx->provctx, NULL);
+    ret = p11prov_ctx_status(encctx->provctx);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
@@ -134,7 +134,6 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
                                   size_t inlen)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
-    CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
     P11PROV_SESSION *session;
     CK_SESSION_HANDLE sess;
@@ -156,10 +155,6 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_OK;
     }
 
-    ret = p11prov_ctx_status(encctx->provctx, &f);
-    if (ret != CKR_OK) {
-        return RET_OSSL_ERR;
-    }
     slotid = p11prov_obj_get_slotid(encctx->key);
     if (slotid == CK_UNAVAILABLE_INFORMATION) {
         P11PROV_raise(encctx->provctx, CKR_SLOT_ID_INVALID,
@@ -188,9 +183,8 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
     sess = p11prov_session_handle(session);
 
-    ret = f->C_EncryptInit(sess, &mechanism, handle);
+    ret = p11prov_EncryptInit(encctx->provctx, sess, &mechanism, handle);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret, "Error returned by C_EncryptInit");
         if (ret == CKR_MECHANISM_INVALID
             || ret == CKR_MECHANISM_PARAM_INVALID) {
             ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
@@ -198,9 +192,9 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
         goto endsess;
     }
 
-    ret = f->C_Encrypt(sess, (void *)in, inlen, out, &out_size);
+    ret = p11prov_Encrypt(encctx->provctx, sess, (void *)in, inlen, out,
+                          &out_size);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret, "Error returned by C_Encrypt");
         goto endsess;
     }
 
@@ -222,7 +216,7 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
     P11PROV_debug("encrypt init (ctx=%p, key=%p, params=%p)", ctx, provkey,
                   params);
 
-    ret = p11prov_ctx_status(encctx->provctx, NULL);
+    ret = p11prov_ctx_status(encctx->provctx);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
@@ -244,7 +238,6 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
                                   size_t inlen)
 {
     struct p11prov_rsaenc_ctx *encctx = (struct p11prov_rsaenc_ctx *)ctx;
-    CK_FUNCTION_LIST *f;
     CK_MECHANISM mechanism;
     P11PROV_SESSION *session;
     CK_SESSION_HANDLE sess;
@@ -266,10 +259,6 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
         return RET_OSSL_OK;
     }
 
-    ret = p11prov_ctx_status(encctx->provctx, &f);
-    if (ret != CKR_OK) {
-        return RET_OSSL_ERR;
-    }
     slotid = p11prov_obj_get_slotid(encctx->key);
     if (slotid == CK_UNAVAILABLE_INFORMATION) {
         P11PROV_raise(encctx->provctx, CKR_SLOT_ID_INVALID,
@@ -298,9 +287,8 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     }
     sess = p11prov_session_handle(session);
 
-    ret = f->C_DecryptInit(sess, &mechanism, handle);
+    ret = p11prov_DecryptInit(encctx->provctx, sess, &mechanism, handle);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret, "Error returned by C_DecryptInit");
         if (ret == CKR_MECHANISM_INVALID
             || ret == CKR_MECHANISM_PARAM_INVALID) {
             ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
@@ -308,9 +296,9 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
         goto endsess;
     }
 
-    ret = f->C_Decrypt(sess, (void *)in, inlen, out, &out_size);
+    ret = p11prov_Decrypt(encctx->provctx, sess, (void *)in, inlen, out,
+                          &out_size);
     if (ret != CKR_OK) {
-        P11PROV_raise(encctx->provctx, ret, "Error returned by C_Decrypt");
         goto endsess;
     }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -87,16 +87,10 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
                              CK_MECHANISM_TYPE type)
 {
     CK_MECHANISM_INFO info = { 0 };
-    CK_FUNCTION_LIST *f;
     const char *mechname = "UNKNOWN";
     CK_RV ret;
 
     if (debug_lazy_init < 1) {
-        return;
-    }
-
-    ret = p11prov_ctx_status(ctx, &f);
-    if (ret != CKR_OK) {
         return;
     }
 
@@ -106,7 +100,7 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
         }
     }
 
-    ret = f->C_GetMechanismInfo(slotid, type, &info);
+    ret = p11prov_GetMechanismInfo(ctx, slotid, type, &info);
     if (ret != CKR_OK) {
         p11prov_debug("C_GetMechanismInfo for %s(%lu) failed %lu\n", mechname,
                       type, ret);

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -161,7 +161,7 @@ static int p11prov_ecdh_init(void *ctx, void *provkey,
         return RET_OSSL_ERR;
     }
 
-    ret = p11prov_ctx_status(ecdhctx->provctx, NULL);
+    ret = p11prov_ctx_status(ecdhctx->provctx);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }
@@ -591,7 +591,7 @@ static int p11prov_exch_hkdf_init(void *ctx, void *provkey,
         return RET_OSSL_ERR;
     }
 
-    ret = p11prov_ctx_status(hkdfctx->provctx, NULL);
+    ret = p11prov_ctx_status(hkdfctx->provctx);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }

--- a/src/interface.c
+++ b/src/interface.c
@@ -1,0 +1,348 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include "provider.h"
+#include <dlfcn.h>
+
+/* Wrapper Interface on top of PKCS#11 interfaces.
+ * This allows us to support multiple versions of PKCS#11 drivers
+ * at runtime by emulating or returning the proper error if a 3.0
+ * only function is used on a 2.40 token. */
+
+/* This structure is effectively equivalent to CK_FUNCTION_LIST_3_0
+ * however we list only the symbols we are actually using in the
+ * code plus flags */
+struct p11prov_interface {
+    CK_VERSION version;
+    CK_FLAGS flags;
+    CK_C_Initialize Initialize;
+    CK_C_Finalize Finalize;
+    CK_C_GetInfo GetInfo;
+    CK_C_GetFunctionList GetFunctionList;
+    CK_C_GetSlotList GetSlotList;
+    CK_C_GetSlotInfo GetSlotInfo;
+    CK_C_GetTokenInfo GetTokenInfo;
+    CK_C_GetMechanismList GetMechanismList;
+    CK_C_GetMechanismInfo GetMechanismInfo;
+    CK_C_OpenSession OpenSession;
+    CK_C_CloseSession CloseSession;
+    CK_C_GetSessionInfo GetSessionInfo;
+    CK_C_GetOperationState GetOperationState;
+    CK_C_SetOperationState SetOperationState;
+    CK_C_CreateObject CreateObject;
+    CK_C_Login Login;
+    CK_C_GetAttributeValue GetAttributeValue;
+    CK_C_SetAttributeValue SetAttributeValue;
+    CK_C_FindObjectsInit FindObjectsInit;
+    CK_C_FindObjects FindObjects;
+    CK_C_FindObjectsFinal FindObjectsFinal;
+    CK_C_EncryptInit EncryptInit;
+    CK_C_Encrypt Encrypt;
+    CK_C_DecryptInit DecryptInit;
+    CK_C_Decrypt Decrypt;
+    CK_C_DigestInit DigestInit;
+    CK_C_DigestUpdate DigestUpdate;
+    CK_C_DigestFinal DigestFinal;
+    CK_C_SignInit SignInit;
+    CK_C_Sign Sign;
+    CK_C_SignUpdate SignUpdate;
+    CK_C_SignFinal SignFinal;
+    CK_C_VerifyInit VerifyInit;
+    CK_C_Verify Verify;
+    CK_C_VerifyUpdate VerifyUpdate;
+    CK_C_VerifyFinal VerifyFinal;
+    CK_C_GenerateKeyPair GenerateKeyPair;
+    CK_C_DeriveKey DeriveKey;
+    CK_C_GenerateRandom GenerateRandom;
+    CK_C_GetInterface GetInterface;
+};
+
+#define IMPL_CALL_PROLOG(name) \
+    P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx); \
+    CK_RV ret; \
+    P11PROV_debug("Calling C_" #name)
+#define IMPL_CALL_EPILOG(name) \
+    if (ret != CKR_OK) { \
+        P11PROV_raise(ctx, ret, "Error returned by C_" #name); \
+    } \
+    return ret
+#define IMPL_INTERFACE_FN_1_ARG(name, t1, a1) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_2_ARG(name, t1, a1, t2, a2) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_3_ARG(name, t1, a1, t2, a2, t3, a3) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2, t3 a3) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2, a3); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_4_ARG(name, t1, a1, t2, a2, t3, a3, t4, a4) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2, t3 a3, t4 a4) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2, a3, a4); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_5_ARG(name, t1, a1, t2, a2, t3, a3, t4, a4, t5, a5) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2, t3 a3, t4 a4, t5 a5) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2, a3, a4, a5); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_6_ARG(name, t1, a1, t2, a2, t3, a3, t4, a4, t5, a5, \
+                                t6, a6) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2, t3 a3, t4 a4, t5 a5, \
+                         t6 a6) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2, a3, a4, a5, a6); \
+        IMPL_CALL_EPILOG(name); \
+    }
+#define IMPL_INTERFACE_FN_8_ARG(name, t1, a1, t2, a2, t3, a3, t4, a4, t5, a5, \
+                                t6, a6, t7, a7, t8, a8) \
+    CK_RV p11prov_##name(P11PROV_CTX *ctx, t1 a1, t2 a2, t3 a3, t4 a4, t5 a5, \
+                         t6 a6, t7 a7, t8 a8) \
+    { \
+        IMPL_CALL_PROLOG(name); \
+        ret = intf->name(a1, a2, a3, a4, a5, a6, a7, a8); \
+        IMPL_CALL_EPILOG(name); \
+    }
+
+IMPL_INTERFACE_FN_1_ARG(Initialize, CK_VOID_PTR, pInitArgs);
+IMPL_INTERFACE_FN_1_ARG(Finalize, CK_VOID_PTR, pReserved);
+IMPL_INTERFACE_FN_1_ARG(GetInfo, CK_INFO_PTR, pInfo);
+IMPL_INTERFACE_FN_4_ARG(GetInterface, CK_UTF8CHAR_PTR, pInterfaceName,
+                        CK_VERSION_PTR, pVersion, CK_INTERFACE_PTR_PTR,
+                        ppInterface, CK_FLAGS, flags);
+IMPL_INTERFACE_FN_1_ARG(GetFunctionList, CK_FUNCTION_LIST_PTR_PTR,
+                        ppFunctionList);
+IMPL_INTERFACE_FN_3_ARG(GetSlotList, CK_BBOOL, tokenPresent, CK_SLOT_ID_PTR,
+                        pSlotList, CK_ULONG_PTR, pulCount);
+IMPL_INTERFACE_FN_2_ARG(GetSlotInfo, CK_SLOT_ID, slotID, CK_SLOT_INFO_PTR,
+                        pInfo);
+IMPL_INTERFACE_FN_2_ARG(GetTokenInfo, CK_SLOT_ID, slotID, CK_TOKEN_INFO_PTR,
+                        pInfo);
+IMPL_INTERFACE_FN_3_ARG(GetMechanismList, CK_SLOT_ID, slotID,
+                        CK_MECHANISM_TYPE_PTR, pMechanismList, CK_ULONG_PTR,
+                        pulCount);
+
+IMPL_INTERFACE_FN_3_ARG(GetMechanismInfo, CK_SLOT_ID, slotID, CK_MECHANISM_TYPE,
+                        type, CK_MECHANISM_INFO_PTR, pInfo);
+IMPL_INTERFACE_FN_5_ARG(OpenSession, CK_SLOT_ID, slotID, CK_FLAGS, flags,
+                        CK_VOID_PTR, pApplication, CK_NOTIFY, Notify,
+                        CK_SESSION_HANDLE_PTR, phSession);
+IMPL_INTERFACE_FN_1_ARG(CloseSession, CK_SESSION_HANDLE, hSession);
+IMPL_INTERFACE_FN_2_ARG(GetSessionInfo, CK_SESSION_HANDLE, hSession,
+                        CK_SESSION_INFO_PTR, pInfo);
+IMPL_INTERFACE_FN_3_ARG(GetOperationState, CK_SESSION_HANDLE, hSession,
+                        CK_BYTE_PTR, pOperationState, CK_ULONG_PTR,
+                        pulOperationStateLen);
+IMPL_INTERFACE_FN_5_ARG(SetOperationState, CK_SESSION_HANDLE, hSession,
+                        CK_BYTE_PTR, pOperationState, CK_ULONG,
+                        ulOperationStateLen, CK_OBJECT_HANDLE, hEncryptionKey,
+                        CK_OBJECT_HANDLE, hAuthenticationKey);
+IMPL_INTERFACE_FN_4_ARG(Login, CK_SESSION_HANDLE, hSession, CK_USER_TYPE,
+                        userType, CK_UTF8CHAR_PTR, pPin, CK_ULONG, ulPinLen);
+IMPL_INTERFACE_FN_4_ARG(CreateObject, CK_SESSION_HANDLE, hSession,
+                        CK_ATTRIBUTE_PTR, pTemplate, CK_ULONG, ulCount,
+                        CK_OBJECT_HANDLE_PTR, phObject);
+IMPL_INTERFACE_FN_4_ARG(GetAttributeValue, CK_SESSION_HANDLE, hSession,
+                        CK_OBJECT_HANDLE, hObject, CK_ATTRIBUTE_PTR, pTemplate,
+                        CK_ULONG, ulCount);
+IMPL_INTERFACE_FN_4_ARG(SetAttributeValue, CK_SESSION_HANDLE, hSession,
+                        CK_OBJECT_HANDLE, hObject, CK_ATTRIBUTE_PTR, pTemplate,
+                        CK_ULONG, ulCount);
+IMPL_INTERFACE_FN_3_ARG(FindObjectsInit, CK_SESSION_HANDLE, hSession,
+                        CK_ATTRIBUTE_PTR, pTemplate, CK_ULONG, ulCount);
+IMPL_INTERFACE_FN_4_ARG(FindObjects, CK_SESSION_HANDLE, hSession,
+                        CK_OBJECT_HANDLE_PTR, phObject, CK_ULONG,
+                        ulMaxObjectCount, CK_ULONG_PTR, pulObjectCount);
+IMPL_INTERFACE_FN_1_ARG(FindObjectsFinal, CK_SESSION_HANDLE, hSession);
+
+IMPL_INTERFACE_FN_3_ARG(EncryptInit, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism, CK_OBJECT_HANDLE, hKey);
+IMPL_INTERFACE_FN_5_ARG(Encrypt, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pData, CK_ULONG, ulDataLen, CK_BYTE_PTR, pEncryptedData,
+                        CK_ULONG_PTR, pulEncryptedDataLen);
+IMPL_INTERFACE_FN_3_ARG(DecryptInit, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism, CK_OBJECT_HANDLE, hKey);
+IMPL_INTERFACE_FN_5_ARG(Decrypt, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pEncryptedData, CK_ULONG, ulEncryptedDataLen,
+                        CK_BYTE_PTR, pData, CK_ULONG_PTR, pulDataLen);
+IMPL_INTERFACE_FN_2_ARG(DigestInit, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism);
+IMPL_INTERFACE_FN_3_ARG(DigestUpdate, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pPart, CK_ULONG, ulPartLen);
+IMPL_INTERFACE_FN_3_ARG(DigestFinal, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pDigest, CK_ULONG_PTR, pulDigestLen);
+IMPL_INTERFACE_FN_3_ARG(SignInit, CK_SESSION_HANDLE, hSession, CK_MECHANISM_PTR,
+                        pMechanism, CK_OBJECT_HANDLE, hKey);
+IMPL_INTERFACE_FN_5_ARG(Sign, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR, pData,
+                        CK_ULONG, ulDataLen, CK_BYTE_PTR, pSignature,
+                        CK_ULONG_PTR, pulSignatureLen);
+IMPL_INTERFACE_FN_3_ARG(SignUpdate, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pPart, CK_ULONG, ulPartLen);
+IMPL_INTERFACE_FN_3_ARG(SignFinal, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pSignature, CK_ULONG_PTR, pulSignatureLen);
+IMPL_INTERFACE_FN_3_ARG(VerifyInit, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism, CK_OBJECT_HANDLE, hKey);
+IMPL_INTERFACE_FN_5_ARG(Verify, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR, pData,
+                        CK_ULONG, ulDataLen, CK_BYTE_PTR, pSignature, CK_ULONG,
+                        ulSignatureLen);
+IMPL_INTERFACE_FN_3_ARG(VerifyUpdate, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pPart, CK_ULONG, ulPartLen);
+IMPL_INTERFACE_FN_3_ARG(VerifyFinal, CK_SESSION_HANDLE, hSession, CK_BYTE_PTR,
+                        pSignature, CK_ULONG, ulSignatureLen);
+IMPL_INTERFACE_FN_8_ARG(GenerateKeyPair, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism, CK_ATTRIBUTE_PTR,
+                        pPublicKeyTemplate, CK_ULONG, ulPublicKeyAttributeCount,
+                        CK_ATTRIBUTE_PTR, pPrivateKeyTemplate, CK_ULONG,
+                        ulPrivateKeyAttributeCount, CK_OBJECT_HANDLE_PTR,
+                        phPublicKey, CK_OBJECT_HANDLE_PTR, phPrivateKey);
+IMPL_INTERFACE_FN_6_ARG(DeriveKey, CK_SESSION_HANDLE, hSession,
+                        CK_MECHANISM_PTR, pMechanism, CK_OBJECT_HANDLE,
+                        hBaseKey, CK_ATTRIBUTE_PTR, pTemplate, CK_ULONG,
+                        ulAttributeCount, CK_OBJECT_HANDLE_PTR, phKey);
+IMPL_INTERFACE_FN_3_ARG(GenerateRandom, CK_SESSION_HANDLE, hSession,
+                        CK_BYTE_PTR, RandomData, CK_ULONG, ulRandomLen);
+
+static CK_RV p11prov_NO_GetInterface(CK_UTF8CHAR_PTR pInterfaceName,
+                                     CK_VERSION_PTR pVersion,
+                                     CK_INTERFACE_PTR_PTR ppInterface,
+                                     CK_FLAGS flags)
+{
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+#define ASSIGN_FN(name) intf->name = list.fns->C_##name
+#define ASSIGN_FN_3_0(name) intf->name = list.fns_3_0->C_##name
+static void populate_interface(P11PROV_INTERFACE *intf, CK_INTERFACE *ck_intf)
+{
+    union {
+        CK_FUNCTION_LIST_PTR fns;
+        CK_FUNCTION_LIST_3_0_PTR fns_3_0;
+    } list;
+
+    list.fns = (CK_FUNCTION_LIST_PTR)ck_intf->pFunctionList;
+    P11PROV_debug("Populating Interfaces with '%s', version %d.%d\n",
+                  ck_intf->pInterfaceName, list.fns->version.major,
+                  list.fns->version.minor);
+
+    intf->version = list.fns->version;
+    intf->flags = ck_intf->flags;
+    ASSIGN_FN(Initialize);
+    ASSIGN_FN(Finalize);
+    ASSIGN_FN(GetInfo);
+    ASSIGN_FN(GetMechanismList);
+    ASSIGN_FN(GetFunctionList);
+    ASSIGN_FN(GetSlotList);
+    ASSIGN_FN(GetSlotInfo);
+    ASSIGN_FN(GetTokenInfo);
+    ASSIGN_FN(GetMechanismList);
+    ASSIGN_FN(GetMechanismInfo);
+    ASSIGN_FN(OpenSession);
+    ASSIGN_FN(CloseSession);
+    ASSIGN_FN(GetSessionInfo);
+    ASSIGN_FN(GetOperationState);
+    ASSIGN_FN(SetOperationState);
+    ASSIGN_FN(CreateObject);
+    ASSIGN_FN(Login);
+    ASSIGN_FN(GetAttributeValue);
+    ASSIGN_FN(SetAttributeValue);
+    ASSIGN_FN(FindObjectsInit);
+    ASSIGN_FN(FindObjects);
+    ASSIGN_FN(FindObjectsFinal);
+    ASSIGN_FN(EncryptInit);
+    ASSIGN_FN(Encrypt);
+    ASSIGN_FN(DecryptInit);
+    ASSIGN_FN(Decrypt);
+    ASSIGN_FN(DigestInit);
+    ASSIGN_FN(DigestUpdate);
+    ASSIGN_FN(DigestFinal);
+    ASSIGN_FN(SignInit);
+    ASSIGN_FN(Sign);
+    ASSIGN_FN(SignUpdate);
+    ASSIGN_FN(SignFinal);
+    ASSIGN_FN(VerifyInit);
+    ASSIGN_FN(Verify);
+    ASSIGN_FN(VerifyUpdate);
+    ASSIGN_FN(VerifyFinal);
+    ASSIGN_FN(GenerateKeyPair);
+    ASSIGN_FN(DeriveKey);
+    ASSIGN_FN(GenerateRandom);
+    ASSIGN_FN_3_0(GetInterface);
+}
+
+CK_RV p11prov_interface_init(void *dlhandle, P11PROV_INTERFACE **interface,
+                             CK_FLAGS *interface_flags)
+{
+    /* Try to get 3.0 interface by default */
+    P11PROV_INTERFACE *intf;
+    CK_VERSION version = { 3, 0 };
+    CK_INTERFACE *ck_interface;
+    CK_RV ret;
+
+    intf = OPENSSL_zalloc(sizeof(struct p11prov_interface));
+    if (!intf) {
+        return CKR_HOST_MEMORY;
+    }
+
+    ret = CKR_FUNCTION_NOT_SUPPORTED;
+    intf->GetInterface = dlsym(dlhandle, "C_GetInterface");
+    if (!intf->GetInterface) {
+        char *err = dlerror();
+        P11PROV_debug("dlsym() failed: %s", err);
+        intf->GetInterface = p11prov_NO_GetInterface;
+    }
+
+    ret = intf->GetInterface(NULL, &version, &ck_interface, 0);
+    if (ret != CKR_OK && ret != CKR_FUNCTION_NOT_SUPPORTED) {
+        /* retry without asking for specific version */
+        ret = intf->GetInterface(NULL, NULL, &ck_interface, 0);
+    }
+    if (ret == CKR_FUNCTION_NOT_SUPPORTED) {
+        /* assume fallback to 2.40 */
+        static CK_INTERFACE deflt = {
+            .pInterfaceName = (CK_UTF8CHAR_PTR) "Internal defaults",
+            .flags = 0,
+        };
+
+        intf->GetFunctionList = dlsym(dlhandle, "C_GetFunctionList");
+        if (intf->GetFunctionList) {
+            ret = intf->GetFunctionList(
+                (CK_FUNCTION_LIST_PTR_PTR)&deflt.pFunctionList);
+            if (ret == CKR_OK) {
+                ck_interface = &deflt;
+            }
+        } else {
+            char *err = dlerror();
+            P11PROV_debug("dlsym() failed: %s", err);
+            ret = CKR_GENERAL_ERROR;
+        }
+    }
+    if (ret == CKR_OK) {
+        populate_interface(intf, ck_interface);
+        *interface = intf;
+        *interface_flags = intf->flags;
+    } else {
+        OPENSSL_free(intf);
+    }
+    return ret;
+}
+
+void p11prov_interface_free(P11PROV_INTERFACE *interface)
+{
+    OPENSSL_free(interface);
+}

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -35,7 +35,7 @@ static void *p11prov_hkdf_newctx(void *provctx)
 
     P11PROV_debug("hkdf newctx");
 
-    ret = p11prov_ctx_status(ctx, NULL);
+    ret = p11prov_ctx_status(ctx);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }

--- a/src/provider.h
+++ b/src/provider.h
@@ -48,6 +48,7 @@
 #define P11PROV_PARAM_KEY_ID "pkcs11_key_id"
 
 typedef struct p11prov_ctx P11PROV_CTX;
+typedef struct p11prov_interface P11PROV_INTERFACE;
 typedef struct p11prov_uri P11PROV_URI;
 typedef struct p11prov_obj P11PROV_OBJ;
 typedef struct p11prov_session P11PROV_SESSION;
@@ -67,14 +68,120 @@ struct p11prov_slot {
 };
 
 /* Provider ctx */
+struct p11prov_interface *p11prov_ctx_get_interface(P11PROV_CTX *ctx);
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
-CK_RV p11prov_ctx_status(P11PROV_CTX *ctx, CK_FUNCTION_LIST **fns);
+CK_RV p11prov_ctx_status(P11PROV_CTX *ctx);
 int p11prov_ctx_get_slots(P11PROV_CTX *ctx, struct p11prov_slot **slots);
 CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void **data, CK_ULONG *size);
 CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void *data, CK_ULONG size);
+
+/* interface declarations for PKCS#11 wrapper functions */
+CK_RV p11prov_interface_init(void *dlhandle, P11PROV_INTERFACE **interface,
+                             CK_FLAGS *interface_flags);
+void p11prov_interface_free(P11PROV_INTERFACE *interface);
+CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs);
+CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved);
+CK_RV p11prov_GetInfo(P11PROV_CTX *ctx, CK_INFO_PTR pInfo);
+CK_RV p11prov_GetInterface(P11PROV_CTX *ctx, CK_UTF8CHAR_PTR pInterfaceName,
+                           CK_VERSION_PTR pVersion,
+                           CK_INTERFACE_PTR_PTR ppInterface, CK_FLAGS flags);
+CK_RV p11prov_GetFunctionList(P11PROV_CTX *ctx,
+                              CK_FUNCTION_LIST_PTR_PTR ppFunctionList);
+CK_RV p11prov_GetSlotList(P11PROV_CTX *ctx, CK_BBOOL tokenPresent,
+                          CK_SLOT_ID_PTR pSlotList, CK_ULONG_PTR pulCount);
+CK_RV p11prov_GetSlotInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
+                          CK_SLOT_INFO_PTR pInfo);
+CK_RV p11prov_GetTokenInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
+                           CK_TOKEN_INFO_PTR pInfo);
+CK_RV p11prov_GetMechanismList(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
+                               CK_MECHANISM_TYPE_PTR pMechanismList,
+                               CK_ULONG_PTR pulCount);
+
+CK_RV p11prov_GetMechanismInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
+                               CK_MECHANISM_TYPE type,
+                               CK_MECHANISM_INFO_PTR pInfo);
+CK_RV p11prov_OpenSession(P11PROV_CTX *ctx, CK_SLOT_ID slotID, CK_FLAGS flags,
+                          CK_VOID_PTR pApplication, CK_NOTIFY Notify,
+                          CK_SESSION_HANDLE_PTR phSession);
+CK_RV p11prov_CloseSession(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession);
+CK_RV p11prov_GetSessionInfo(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                             CK_SESSION_INFO_PTR pInfo);
+CK_RV p11prov_GetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                                CK_BYTE_PTR pOperationState,
+                                CK_ULONG_PTR pulOperationStateLen);
+CK_RV p11prov_SetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                                CK_BYTE_PTR pOperationState,
+                                CK_ULONG ulOperationStateLen,
+                                CK_OBJECT_HANDLE hEncryptionKey,
+                                CK_OBJECT_HANDLE hAuthenticationKey);
+CK_RV p11prov_Login(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                    CK_USER_TYPE userType, CK_UTF8CHAR_PTR pPin,
+                    CK_ULONG ulPinLen);
+CK_RV p11prov_CreateObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                           CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
+                           CK_OBJECT_HANDLE_PTR phObject);
+CK_RV p11prov_GetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                                CK_OBJECT_HANDLE hObject,
+                                CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);
+CK_RV p11prov_SetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                                CK_OBJECT_HANDLE hObject,
+                                CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);
+CK_RV p11prov_FindObjectsInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                              CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);
+CK_RV p11prov_FindObjects(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                          CK_OBJECT_HANDLE_PTR phObject,
+                          CK_ULONG ulMaxObjectCount,
+                          CK_ULONG_PTR pulObjectCount);
+CK_RV p11prov_FindObjectsFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession);
+CK_RV p11prov_EncryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                          CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
+CK_RV p11prov_Encrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                      CK_BYTE_PTR pData, CK_ULONG ulDataLen,
+                      CK_BYTE_PTR pEncryptedData,
+                      CK_ULONG_PTR pulEncryptedDataLen);
+CK_RV p11prov_DecryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                          CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
+CK_RV p11prov_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                      CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen,
+                      CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen);
+CK_RV p11prov_DigestInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                         CK_MECHANISM_PTR pMechanism);
+CK_RV p11prov_DigestUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                           CK_BYTE_PTR pPart, CK_ULONG ulPartLen);
+CK_RV p11prov_DigestFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                          CK_BYTE_PTR pDigest, CK_ULONG_PTR pulDigestLen);
+CK_RV p11prov_SignInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                       CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
+CK_RV p11prov_Sign(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                   CK_BYTE_PTR pData, CK_ULONG ulDataLen,
+                   CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen);
+CK_RV p11prov_SignUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                         CK_BYTE_PTR pPart, CK_ULONG ulPartLen);
+CK_RV p11prov_SignFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                        CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen);
+CK_RV p11prov_VerifyInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                         CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey);
+CK_RV p11prov_Verify(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                     CK_BYTE_PTR pData, CK_ULONG ulDataLen,
+                     CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen);
+CK_RV p11prov_VerifyUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                           CK_BYTE_PTR pPart, CK_ULONG ulPartLen);
+CK_RV p11prov_VerifyFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                          CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen);
+CK_RV p11prov_GenerateKeyPair(
+    P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
+    CK_ATTRIBUTE_PTR pPublicKeyTemplate, CK_ULONG ulPublicKeyAttributeCount,
+    CK_ATTRIBUTE_PTR pPrivateKeyTemplate, CK_ULONG ulPrivateKeyAttributeCount,
+    CK_OBJECT_HANDLE_PTR phPublicKey, CK_OBJECT_HANDLE_PTR phPrivateKey);
+CK_RV p11prov_DeriveKey(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                        CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hBaseKey,
+                        CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulAttributeCount,
+                        CK_OBJECT_HANDLE_PTR phKey);
+CK_RV p11prov_GenerateRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                             CK_BYTE_PTR RandomData, CK_ULONG ulRandomLen);
 
 #define ALLOW_EXPORT_PUBLIC 0
 #define DISALLOW_EXPORT_PUBLIC 1


### PR DESCRIPTION
This allows us a few things:
- Support multiple PKCS#11 version drivers
- Add automatic debugging/tracing and error reporting for each PKCS#11 function called
- Gain information on whether the token is modern enough to support forking processes

Additionally this allowed to remove a lot of cruft and some odd calls to p11prov_ctx_status() making some code a lot more readable.