### PR TITLE
Add code that makes certs usable in OpenSSL

### DIFF
--- a/src/provider.h
+++ b/src/provider.h
@@ -474,7 +474,7 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                                unsigned long attrnums);
 
 #define MAX_PIN_LENGTH 32
-P11PROV_URI *p11prov_parse_uri(const char *uri);
+P11PROV_URI *p11prov_parse_uri(P11PROV_CTX *ctx, const char *uri);
 void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);

--- a/src/provider.h
+++ b/src/provider.h
@@ -490,6 +490,7 @@ bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
 CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
                              CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data);
 CK_RV p11prov_copy_attr(CK_ATTRIBUTE *dst, CK_ATTRIBUTE *src);
+bool p11prov_x509_names_are_equal(CK_ATTRIBUTE *a, CK_ATTRIBUTE *b);
 
 /* Sessions */
 CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,

--- a/src/store.c
+++ b/src/store.c
@@ -229,6 +229,20 @@ static int p11prov_store_load(void *pctx, OSSL_CALLBACK *object_cb,
                     continue;
                 }
             }
+            if (ctx->issuer.type == CKA_ISSUER) {
+                CK_ATTRIBUTE *issuer;
+
+                issuer = p11prov_obj_get_attr(obj, CKA_ISSUER);
+                if (!issuer) {
+                    /* no match, try next */
+                    continue;
+                }
+                /* TODO: X509_NAME caching for ctx->issuer ? */
+                if (!p11prov_x509_names_are_equal(&ctx->issuer, issuer)) {
+                    /* no match, try next */
+                    continue;
+                }
+            }
             break;
         case CKO_PUBLIC_KEY:
         case CKO_PRIVATE_KEY:

--- a/src/store.c
+++ b/src/store.c
@@ -149,7 +149,7 @@ static void *p11prov_store_open(void *pctx, const char *uri)
     }
     ctx->provctx = (P11PROV_CTX *)pctx;
 
-    ctx->parsed_uri = p11prov_parse_uri(uri);
+    ctx->parsed_uri = p11prov_parse_uri(ctx->provctx, uri);
     if (ctx->parsed_uri == NULL) {
         goto done;
     }

--- a/src/util.c
+++ b/src/util.c
@@ -240,7 +240,7 @@ done:
     return ret;
 }
 
-P11PROV_URI *p11prov_parse_uri(const char *uri)
+P11PROV_URI *p11prov_parse_uri(P11PROV_CTX *ctx, const char *uri)
 {
     struct p11prov_uri *u;
     const char *p, *end;
@@ -331,7 +331,8 @@ P11PROV_URI *p11prov_parse_uri(const char *uri)
             } else if (len == 6 && strncmp(p, "secret", 6) == 0) {
                 u->class = CKO_SECRET_KEY;
             } else {
-                P11PROV_debug("Unknown object type");
+                P11PROV_raise(ctx, CKR_ARGUMENTS_BAD,
+                              "Unknown object type [%#s]", p, len);
                 ret = EINVAL;
                 goto done;
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,10 +37,11 @@ tmp.softhsm:
 
 dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
-	test-wrapper tbasic teccsha2 thkdf toaepsha2 trsapss
+	test-wrapper tbasic tcerts teccsha2 thkdf toaepsha2 trsapss
 
 test_LIST = \
 	basic-softokn basic-softhsm-proxy \
+	certs-softokn \
 	eccsha2-softokn \
 	oaepsha2-softokn \
 	hkdf-softokn \

--- a/tests/setup-softokn.sh
+++ b/tests/setup-softokn.sh
@@ -53,16 +53,17 @@ CERTSCRIPT
 
 # RSA
 TSTCRT="${TMPPDIR}/testcert"
+TSTCRTN="testCert"
 title LINE  "Creating Certificate request for 'My Test Cert'"
 certutil -R -s "CN=My Test Cert, O=PKCS11 Provider" -o ${TSTCRT}.req \
             -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
 let "SERIAL+=1"
 certutil -C -m ${SERIAL} -i ${TSTCRT}.req -o ${TSTCRT}.crt -c selfCA \
             -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n testCert -i ${TSTCRT}.crt -t "u,u,u" -d ${TOKDIR} \
+certutil -A -n ${TSTCRTN} -i ${TSTCRT}.crt -t "u,u,u" -d ${TOKDIR} \
             -f ${PINFILE} >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep 'testCert'| cut -b 15-54`
+KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${TSTCRTN}"| cut -b 15-54`
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
     line=`echo "${KEYID:$i:2}"`
@@ -73,26 +74,29 @@ BASEURIWITHPIN="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
 BASEURI="pkcs11:id=${URIKEYID}"
 PUBURI="pkcs11:type=public;id=${URIKEYID}"
 PRIURI="pkcs11:type=private;id=${URIKEYID}"
+CRTURI="pkcs11:type=cert;object=${TSTCRTN}"
 
 title LINE "RSA PKCS11 URIS"
 echo "${BASEURIWITHPIN}"
 echo "${BASEURI}"
 echo "${PUBURI}"
 echo "${PRIURI}"
+echo "${CRTURI}"
 echo ""
 
 # ECC
 ECCRT="${TMPPDIR}/eccert"
+ECCRTN="ecCert"
 title LINE  "Creating Certificate request for 'My EC Cert'"
 certutil -R -s "CN=My EC Cert, O=PKCS11 Provider" -k ec -q nistp256 \
             -o ${ECCRT}.req -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
 let "SERIAL+=1"
 certutil -C -m ${SERIAL} -i ${ECCRT}.req -o ${ECCRT}.crt -c selfCA \
             -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n ecCert -i ${ECCRT}.crt -t "u,u,u" \
+certutil -A -n ${ECCRTN} -i ${ECCRT}.crt -t "u,u,u" \
             -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep 'ecCert'| cut -b 15-54`
+KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${ECCRTN}"| cut -b 15-54`
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
     line=`echo "${KEYID:$i:2}"`
@@ -102,19 +106,21 @@ done
 ECBASEURI="pkcs11:id=${URIKEYID}"
 ECPUBURI="pkcs11:type=public;id=${URIKEYID}"
 ECPRIURI="pkcs11:type=private;id=${URIKEYID}"
+ECCRTURI="pkcs11:type=cert;object=${ECCRTN}"
 
 title LINE  "Creating Certificate request for 'My Peer EC Cert'"
 ECPEERCRT="${TMPPDIR}/ecpeercert"
+ECPEERCRTN="ecPeerCert"
 certutil -R -s "CN=My Peer EC Cert, O=PKCS11 Provider" \
             -k ec -q nistp256 -o ${ECPEERCRT}.req \
             -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
 let "SERIAL+=1"
 certutil -C -m ${SERIAL} -i ${ECPEERCRT}.req -o ${ECPEERCRT}.crt \
             -c selfCA -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n ecPeerCert -i ${ECPEERCRT}.crt -t "u,u,u" \
+certutil -A -n ${ECPEERCRTN} -i ${ECPEERCRT}.crt -t "u,u,u" \
             -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep 'ecPeerCert'| cut -b 15-54`
+KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${ECPEERCRTN}"| cut -b 15-54`
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
     line=`echo "${KEYID:$i:2}"`
@@ -124,14 +130,17 @@ done
 ECPEERBASEURI="pkcs11:id=${URIKEYID}"
 ECPEERPUBURI="pkcs11:type=public;id=${URIKEYID}"
 ECPEERPRIURI="pkcs11:type=private;id=${URIKEYID}"
+ECPEERCRTURI="pkcs11:type=cert;object=${ECPEERCRTN}"
 
 title LINE "EC PKCS11 URIS"
 echo "${ECBASEURI}"
 echo "${ECPUBURI}"
 echo "${ECPRIURI}"
+echo "${ECCRTURI}"
 echo "${ECPEERBASEURI}"
 echo "${ECPEERPUBURI}"
 echo "${ECPEERPRIURI}"
+echo "${ECPEERCRTURI}"
 echo ""
 
 title PARA "Show contents of softoken"
@@ -168,12 +177,15 @@ export BASEURIWITHPIN="${BASEURIWITHPIN}"
 export BASEURI="${BASEURI}"
 export PUBURI="${PUBURI}"
 export PRIURI="${PRIURI}"
+export CRTURI="${CRTURI}"
 export ECBASEURI="${ECBASEURI}"
 export ECPUBURI="${ECPUBURI}"
 export ECPRIURI="${ECPRIURI}"
+export ECCRTURI="${ECCRTURI}"
 export ECPEERBASEURI="${ECPEERBASEURI}"
 export ECPEERPUBURI="${ECPEERPUBURI}"
 export ECPEERPRIURI="${ECPEERPRIURI}"
+export ECPEERCRTURI="${ECPEERCRTURI}"
 DBGSCRIPT
 gen_unsetvars
 

--- a/tests/tcerts
+++ b/tests/tcerts
@@ -24,4 +24,22 @@ if [[ ! ${DATA} =~ ${CHECK} ]]; then
     exit 1
 fi
 
+title PARA "Use storeutl command to match specific certs via params"
+
+SUBJECTS=("/O=PKCS11 Provider/CN=My Test Cert"
+          "/O=PKCS11 Provider/CN=My EC Cert"
+          "/O=PKCS11 Provider/CN=My Peer EC Cert"
+          "/CN=Issuer")
+
+for subj in "${SUBJECTS[@]}"; do
+ossl '
+storeutl -certs -subject "${subj}"
+                -out ${TMPPDIR}/storeutl-crt-subj.txt
+                pkcs11:type=cert'
+DATA=$(cat ${TMPPDIR}/storeutl-crt-subj.txt)
+if [[ ! ${DATA} =~ "Total found: 1" ]]; then
+    echo "Cert not found matching by subject=${subj}"
+fi
+done
+
 exit 0

--- a/tests/tcerts
+++ b/tests/tcerts
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source ${TESTSSRCDIR}/helpers.sh
+
+title PARA "Check we can fetch certifiatce objects"
+
+ossl '
+x509 -in ${CRTURI} -subject -out ${TMPPDIR}/crt-subj.txt'
+DATA=$(cat ${TMPPDIR}/crt-subj.txt)
+CHECK="subject=O = PKCS11 Provider, CN = My Test Cert"
+if [[ ! ${DATA} =~ ${CHECK} ]]; then
+    echo "Cert not found looking for ${CHECK}"
+    exit 1
+fi
+
+ossl '
+x509 -in ${ECCRTURI} -subject -out ${TMPPDIR}/eccrt-subj.txt'
+DATA=$(cat ${TMPPDIR}/eccrt-subj.txt)
+CHECK="subject=O = PKCS11 Provider, CN = My EC Cert"
+if [[ ! ${DATA} =~ ${CHECK} ]]; then
+    echo "Cert not found looking for ${CHECK}"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
A previous PR added code to allow loading certs.

This brings that work forward by correctly wiring the store api to return the cert objects to OpenSSL.

It can be exercised via the openssl storeutl command.