### PR TITLE
Small enhancements to encoder.c

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -117,19 +117,19 @@ static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
         return RET_OSSL_ERR;
     }
 
-    keysize = p11prov_obj_get_key_size(key);
+    keysize = p11prov_obj_get_key_bit_size(key);
 
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
         CK_OBJECT_CLASS class = p11prov_obj_get_class(key);
         if (class != CKO_PRIVATE_KEY) {
             return RET_OSSL_ERR;
         }
-        BIO_printf(out, "PKCS11 RSA Private Key (%lu bits)\n", keysize * 8);
+        BIO_printf(out, "PKCS11 RSA Private Key (%lu bits)\n", keysize);
         BIO_printf(out, "[Can't export and print private key data]\n");
     }
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        BIO_printf(out, "PKCS11 RSA Public Key (%lu bits)\n", keysize * 8);
+        BIO_printf(out, "PKCS11 RSA Public Key (%lu bits)\n", keysize);
         ret = p11prov_obj_export_public_rsa_key(
             key, p11prov_rsa_print_public_key, out);
         if (ret != RET_OSSL_OK) {
@@ -761,18 +761,18 @@ static int p11prov_ec_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
         return RET_OSSL_ERR;
     }
 
-    keysize = p11prov_obj_get_key_size(key);
+    keysize = p11prov_obj_get_key_bit_size(key);
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
         CK_OBJECT_CLASS class = p11prov_obj_get_class(key);
         if (class != CKO_PRIVATE_KEY) {
             return RET_OSSL_ERR;
         }
-        BIO_printf(out, "PKCS11 EC Private Key (%lu bits)\n", keysize * 8);
+        BIO_printf(out, "PKCS11 EC Private Key (%lu bits)\n", keysize);
         BIO_printf(out, "[Can't export and print private key data]\n");
     }
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
-        BIO_printf(out, "PKCS11 EC Public Key (%lu bits)\n", keysize * 8);
+        BIO_printf(out, "PKCS11 EC Public Key (%lu bits)\n", keysize);
         ret = p11prov_obj_export_public_ec_key(key, p11prov_ec_print_public_key,
                                                out);
         if (ret != RET_OSSL_OK) {

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -31,6 +31,7 @@ extern const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_spki_der_functions[];
+extern const OSSL_DISPATCH p11prov_ec_encoder_text_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_pem_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_spki_der_functions[];

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -31,6 +31,7 @@ extern const OSSL_DISPATCH p11prov_rsa_encoder_text_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_pkcs1_pem_functions[];
 extern const OSSL_DISPATCH p11prov_rsa_encoder_spki_der_functions[];
+extern const OSSL_DISPATCH p11prov_rsa_encoder_spki_pem_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_text_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_pkcs1_pem_functions[];

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -515,10 +515,15 @@ static int p11prov_rsa_export(void *keydata, int selection,
                               OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
     P11PROV_OBJ *key = (P11PROV_OBJ *)keydata;
+    P11PROV_CTX *ctx = p11prov_obj_get_prov_ctx(key);
 
     P11PROV_debug("rsa export %p", keydata);
 
     if (key == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    if (p11prov_ctx_allow_export(ctx) & DISALLOW_EXPORT_PUBLIC) {
         return RET_OSSL_ERR;
     }
 
@@ -930,10 +935,15 @@ static int p11prov_ec_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
                              void *cb_arg)
 {
     P11PROV_OBJ *key = (P11PROV_OBJ *)keydata;
+    P11PROV_CTX *ctx = p11prov_obj_get_prov_ctx(key);
 
     P11PROV_debug("ec export %p", keydata);
 
     if (key == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    if (p11prov_ctx_allow_export(ctx) & DISALLOW_EXPORT_PUBLIC) {
         return RET_OSSL_ERR;
     }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -166,6 +166,14 @@ P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
     return (P11PROV_OBJ *)reference;
 }
 
+P11PROV_CTX *p11prov_obj_get_prov_ctx(P11PROV_OBJ *obj)
+{
+    if (!obj) {
+        return NULL;
+    }
+    return obj->ctx;
+}
+
 #define BASE_KEY_ATTRS_NUM 3
 
 #define RSA_ATTRS_NUM (BASE_KEY_ATTRS_NUM + 2)
@@ -1102,10 +1110,6 @@ int p11prov_obj_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
         return RET_OSSL_ERR;
     }
 
-    if (p11prov_ctx_allow_export(obj->ctx) & DISALLOW_EXPORT_PUBLIC) {
-        return RET_OSSL_ERR;
-    }
-
     attrs[0].type = CKA_MODULUS;
     attrs[1].type = CKA_PUBLIC_EXPONENT;
 
@@ -1146,10 +1150,6 @@ int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     int ret;
 
     if (p11prov_obj_get_key_type(obj) != CKK_EC) {
-        return RET_OSSL_ERR;
-    }
-
-    if (p11prov_ctx_allow_export(obj->ctx) & DISALLOW_EXPORT_PUBLIC) {
         return RET_OSSL_ERR;
     }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -14,6 +14,7 @@ CK_OBJECT_HANDLE p11prov_obj_get_handle(P11PROV_OBJ *obj);
 CK_OBJECT_CLASS p11prov_obj_get_class(P11PROV_OBJ *obj);
 CK_ATTRIBUTE *p11prov_obj_get_attr(P11PROV_OBJ *obj, CK_ATTRIBUTE_TYPE type);
 CK_KEY_TYPE p11prov_obj_get_key_type(P11PROV_OBJ *obj);
+CK_ULONG p11prov_obj_get_key_bit_size(P11PROV_OBJ *obj);
 CK_ULONG p11prov_obj_get_key_size(P11PROV_OBJ *obj);
 void p11prov_obj_to_reference(P11PROV_OBJ *obj, void **reference,
                               size_t *reference_sz);

--- a/src/objects.h
+++ b/src/objects.h
@@ -19,6 +19,7 @@ void p11prov_obj_to_reference(P11PROV_OBJ *obj, void **reference,
                               size_t *reference_sz);
 P11PROV_OBJ *p11prov_obj_from_reference(const void *reference,
                                         size_t reference_sz);
+P11PROV_CTX *p11prov_obj_get_prov_ctx(P11PROV_OBJ *obj);
 
 typedef CK_RV (*store_obj_callback)(void *, P11PROV_OBJ *);
 CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,

--- a/src/provider.c
+++ b/src/provider.c
@@ -751,6 +751,8 @@ static int p11prov_operations_init(P11PROV_CTX *ctx)
     ADD_ALGO_EXT(RSA, encoder,
                  "provider=pkcs11,output=der,structure=SubjectPublicKeyInfo",
                  p11prov_rsa_encoder_spki_der_functions);
+    ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=text",
+                 p11prov_ec_encoder_text_functions);
     ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=der,structure=pkcs1",
                  p11prov_ec_encoder_pkcs1_der_functions);
     ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=pem,structure=pkcs1",

--- a/src/provider.c
+++ b/src/provider.c
@@ -751,6 +751,9 @@ static int p11prov_operations_init(P11PROV_CTX *ctx)
     ADD_ALGO_EXT(RSA, encoder,
                  "provider=pkcs11,output=der,structure=SubjectPublicKeyInfo",
                  p11prov_rsa_encoder_spki_der_functions);
+    ADD_ALGO_EXT(RSA, encoder,
+                 "provider=pkcs11,output=pem,structure=SubjectPublicKeyInfo",
+                 p11prov_rsa_encoder_spki_pem_functions);
     ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=text",
                  p11prov_ec_encoder_text_functions);
     ADD_ALGO_EXT(EC, encoder, "provider=pkcs11,output=der,structure=pkcs1",

--- a/src/store.c
+++ b/src/store.c
@@ -376,23 +376,10 @@ static int p11prov_store_export_object(void *loaderctx, const void *reference,
                                        size_t reference_sz,
                                        OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    P11PROV_OBJ *obj = NULL;
-
     P11PROV_debug("store (%p) export object %p, %zu", loaderctx, reference,
                   reference_sz);
 
-    /* the contents of the reference is the address to our object */
-    obj = p11prov_obj_from_reference(reference, reference_sz);
-    if (!obj) {
-        return RET_OSSL_ERR;
-    }
-
-    /* we can only export public bits, so that's all we do */
-    if (p11prov_obj_get_class(obj) != CKO_PUBLIC_KEY) {
-        return RET_OSSL_ERR;
-    }
-
-    return p11prov_obj_export_public_rsa_key(obj, cb_fn, cb_arg);
+    return RET_OSSL_ERR;
 }
 
 static const OSSL_PARAM *p11prov_store_settable_ctx_params(void *provctx)

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -40,9 +40,17 @@ cleanup_server()
 
 ossl()
 {
-    echo "# r "$* >> ${TMPPDIR}/gdb-commands.txt
-    echo openssl $*
-    eval openssl $1
+    local __output=$2
+    echo "# r "$1 >> ${TMPPDIR}/gdb-commands.txt
+    echo openssl $1
+    __out=$(eval openssl $1)
+    __res=$?
+    if [[ "$__output" ]]; then
+        eval $__output="'$__out'"
+    else
+        echo $__out
+    fi
+    return $__res
 }
 
 gen_unsetvars() {

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -12,6 +12,9 @@ title LINE "Export Public key to a file (pub-uri)"
 ossl 'pkey -in $PUBURI -pubin -pubout -out ${TSTOUT}.pub'
 title LINE "Export Public key to a file (with pin)"
 ossl 'pkey -in $BASEURIWITHPIN -pubin -pubout -out ${TSTOUT}.pub'
+title LINE "Print Public key from private"
+ossl 'pkey -in $PRIURI -pubout -text' output
+echo $output | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1
 
 title PARA "Export Public check error"
 FAIL=0
@@ -24,6 +27,9 @@ fi
 
 title PARA "Export EC Public key to a file"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ecout.pub'
+title LINE "Print EC Public key from private"
+ossl 'pkey -in $ECPRIURI -pubout -text' output
+echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1
 
 title PARA "Raw Sign check error"
 dd if=/dev/urandom of=${TMPPDIR}/64Brandom.bin bs=64 count=1 >/dev/null 2>&1

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -14,7 +14,15 @@ title LINE "Export Public key to a file (with pin)"
 ossl 'pkey -in $BASEURIWITHPIN -pubin -pubout -out ${TSTOUT}.pub'
 title LINE "Print Public key from private"
 ossl 'pkey -in $PRIURI -pubout -text' output
-echo $output | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1
+FAIL=0
+echo $output | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
+if [ $FAIL -eq 1 ]; then
+    echo "Pkcs11 encoder function failed"
+    echo
+    echo "Original command output:"
+    echo "$output"
+    echo
+fi
 
 title PARA "Export Public check error"
 FAIL=0
@@ -29,7 +37,15 @@ title PARA "Export EC Public key to a file"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ecout.pub'
 title LINE "Print EC Public key from private"
 ossl 'pkey -in $ECPRIURI -pubout -text' output
-echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1
+FAIL=0
+echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
+if [ $FAIL -eq 1 ]; then
+    echo "Pkcs11 encoder function failed"
+    echo
+    echo "Original command output:"
+    echo "$output"
+    echo
+fi
 
 title PARA "Raw Sign check error"
 dd if=/dev/urandom of=${TMPPDIR}/64Brandom.bin bs=64 count=1 >/dev/null 2>&1
@@ -126,13 +142,26 @@ pkeyutl -decrypt -inkey "${PRIURI}"
 diff ${SECRETFILE} ${SECRETFILE}.dec
 
 title PARA "Test Disallow Public Export"
-FAIL=0
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
 sed "s/#pkcs11-module-allow-export/pkcs11-module-allow-export = 1/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.noexport
 OPENSSL_CONF=${OPENSSL_CONF}.noexport
-ossl 'pkey -in $BASEURI -pubin -pubout -out ${TSTOUT}.pub.fail' || FAIL=1
-if [ $FAIL -eq 0 ]; then
-    echo "pkcs11 export should have failed, but actually succeeded"
+ossl 'pkey -in $PUBURI -pubin -pubout -text' output
+FAIL=0
+echo "$output" | grep "^PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
+if [ $FAIL -neq 0 ]; then
+    echo "$output" | grep "PUBLIC KEY" > /dev/null 2>&1 || FAIL=2
+fi
+if [ $FAIL -eq 1 ]; then
+    echo "pkcs11 pem export failed"
+fi
+if [ $FAIL -eq 2 ]; then
+    echo "pkcs11 pem export succeeded but internal encoder was not used"
+fi
+if [ $FAIL -neq 0 ]; then
+    echo
+    echo "Original command output:"
+    echo "$output"
+    echo
     exit 1
 fi
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}


### PR DESCRIPTION
- Streamlines rsa public key printing
- Allow to print public key data from private keys
- Add EC public key printing.
- Match printing style from OpenSSL's existing text encoders