### PR TITLE
Caching of keys in session objects and refactoring of session management

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -202,7 +202,7 @@ static int p11prov_rsaenc_encrypt(void *ctx, unsigned char *out, size_t *outlen,
     result = RET_OSSL_OK;
 
 endsess:
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     return result;
 }
 
@@ -306,7 +306,7 @@ static int p11prov_rsaenc_decrypt(void *ctx, unsigned char *out, size_t *outlen,
     result = RET_OSSL_OK;
 
 endsess:
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     return result;
 }
 

--- a/src/digests.c
+++ b/src/digests.c
@@ -219,7 +219,7 @@ static void *p11prov_digest_dupctx(void *ctx)
     ret = p11prov_SetOperationState(dctx->provctx, sess, state, state_len,
                                     CK_INVALID_HANDLE, CK_INVALID_HANDLE);
     if (ret != CKR_OK) {
-        p11prov_session_free(dctx->session);
+        p11prov_return_session(dctx->session);
         dctx->session = NULL;
     }
 
@@ -237,7 +237,7 @@ static void p11prov_digest_freectx(void *ctx)
     if (!ctx) {
         return;
     }
-    p11prov_session_free(dctx->session);
+    p11prov_return_session(dctx->session);
     OPENSSL_clear_free(dctx, sizeof(P11PROV_DIGEST_CTX));
 }
 
@@ -273,7 +273,7 @@ static int p11prov_digest_init(void *ctx, const OSSL_PARAM params[])
 
     ret = p11prov_DigestInit(dctx->provctx, sess, &mechanism);
     if (ret != CKR_OK) {
-        p11prov_session_free(dctx->session);
+        p11prov_return_session(dctx->session);
         dctx->session = NULL;
         return RET_OSSL_ERR;
     }

--- a/src/digests.c
+++ b/src/digests.c
@@ -359,7 +359,7 @@ static int p11prov_digest_get_params(CK_MECHANISM_TYPE digest,
     OSSL_PARAM *p = NULL;
     CK_RV ret;
 
-    P11PROV_debug("digest get params: digest=%ld, params=%p", digest, params);
+    P11PROV_debug("digest get params: digest=%lX, params=%p", digest, params);
 
     p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
     if (p) {
@@ -374,7 +374,7 @@ static int p11prov_digest_get_params(CK_MECHANISM_TYPE digest,
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return RET_OSSL_ERR;
         }
-        P11PROV_debug("digest=%ld, block_size = %zd", digest, block_size);
+        P11PROV_debug("block_size = %zd", digest, block_size);
     }
     p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
     if (p) {
@@ -389,7 +389,7 @@ static int p11prov_digest_get_params(CK_MECHANISM_TYPE digest,
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return RET_OSSL_ERR;
         }
-        P11PROV_debug("digest=%ld, digest_size = %zd", digest, digest_size);
+        P11PROV_debug("digest_size = %zd", digest, digest_size);
     }
     p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_XOF);
     if (p) {

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -294,7 +294,7 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     FA_ASSIGN_ALL(attrs[0], CKA_VALUE, &secret, &secret_len, false, true);
     ret = p11prov_fetch_attributes(ecdhctx->provctx, session, secret_handle,
                                    attrs, 1);
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     if (ret != CKR_OK) {
         P11PROV_debug("ecdh failed to retrieve secret %lu", ret);
         return RET_OSSL_ERR;

--- a/src/interface.c
+++ b/src/interface.c
@@ -29,8 +29,10 @@ struct p11prov_interface {
     CK_C_GetSessionInfo GetSessionInfo;
     CK_C_GetOperationState GetOperationState;
     CK_C_SetOperationState SetOperationState;
-    CK_C_CreateObject CreateObject;
     CK_C_Login Login;
+    CK_C_CreateObject CreateObject;
+    CK_C_CopyObject CopyObject;
+    CK_C_DestroyObject DestroyObject;
     CK_C_GetAttributeValue GetAttributeValue;
     CK_C_SetAttributeValue SetAttributeValue;
     CK_C_FindObjectsInit FindObjectsInit;
@@ -158,6 +160,11 @@ IMPL_INTERFACE_FN_4_ARG(Login, CK_SESSION_HANDLE, hSession, CK_USER_TYPE,
 IMPL_INTERFACE_FN_4_ARG(CreateObject, CK_SESSION_HANDLE, hSession,
                         CK_ATTRIBUTE_PTR, pTemplate, CK_ULONG, ulCount,
                         CK_OBJECT_HANDLE_PTR, phObject);
+IMPL_INTERFACE_FN_5_ARG(CopyObject, CK_SESSION_HANDLE, hSession,
+                        CK_OBJECT_HANDLE, hObject, CK_ATTRIBUTE_PTR, pTemplate,
+                        CK_ULONG, ulCount, CK_OBJECT_HANDLE_PTR, phNewObject);
+IMPL_INTERFACE_FN_2_ARG(DestroyObject, CK_SESSION_HANDLE, hSession,
+                        CK_OBJECT_HANDLE, hObject);
 IMPL_INTERFACE_FN_4_ARG(GetAttributeValue, CK_SESSION_HANDLE, hSession,
                         CK_OBJECT_HANDLE, hObject, CK_ATTRIBUTE_PTR, pTemplate,
                         CK_ULONG, ulCount);
@@ -257,8 +264,10 @@ static void populate_interface(P11PROV_INTERFACE *intf, CK_INTERFACE *ck_intf)
     ASSIGN_FN(GetSessionInfo);
     ASSIGN_FN(GetOperationState);
     ASSIGN_FN(SetOperationState);
-    ASSIGN_FN(CreateObject);
     ASSIGN_FN(Login);
+    ASSIGN_FN(CreateObject);
+    ASSIGN_FN(CopyObject);
+    ASSIGN_FN(DestroyObject);
     ASSIGN_FN(GetAttributeValue);
     ASSIGN_FN(SetAttributeValue);
     ASSIGN_FN(FindObjectsInit);

--- a/src/interface.h
+++ b/src/interface.h
@@ -49,6 +49,11 @@ CK_RV p11prov_Login(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
 CK_RV p11prov_CreateObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                            CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
                            CK_OBJECT_HANDLE_PTR phObject);
+CK_RV p11prov_CopyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                         CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate,
+                         CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phNewObject);
+CK_RV p11prov_DestroyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                            CK_OBJECT_HANDLE hObject);
 CK_RV p11prov_GetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_OBJECT_HANDLE hObject,
                                 CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount);

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -72,7 +72,7 @@ static void p11prov_hkdf_reset(void *ctx)
     /* free all allocated resources */
     p11prov_obj_free(hkdfctx->key);
     if (hkdfctx->session) {
-        p11prov_session_free(hkdfctx->session);
+        p11prov_return_session(hkdfctx->session);
         hkdfctx->session = NULL;
     }
 

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -313,7 +313,7 @@ static void *p11prov_common_gen(struct key_generator *ctx,
         /* generate unique id for the key */
         ret = p11prov_GenerateRandom(ctx->provctx, sh, id, sizeof(id));
         if (ret != CKR_OK) {
-            p11prov_session_free(session);
+            p11prov_return_session(session);
             return NULL;
         }
         id_ptr = id;
@@ -343,17 +343,17 @@ static void *p11prov_common_gen(struct key_generator *ctx,
                                   pubkey_template, pubtsize, privkey_template,
                                   privtsize, &pubkey, &privkey);
     if (ret != CKR_OK) {
-        p11prov_session_free(session);
+        p11prov_return_session(session);
         return NULL;
     }
 
     ret = p11prov_obj_from_handle(ctx->provctx, session, privkey, &key);
     if (ret != CKR_OK) {
-        p11prov_session_free(session);
+        p11prov_return_session(session);
         return NULL;
     }
 
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     return key;
 }
 

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -469,7 +469,7 @@ static void *p11prov_rsa_load(const void *reference, size_t reference_sz)
         type = p11prov_obj_get_key_type(key);
         if (type == CKK_RSA) {
             /* add ref count */
-            key = p11prov_obj_ref(key);
+            key = p11prov_obj_ref_no_cache(key);
         } else {
             key = NULL;
         }
@@ -895,10 +895,25 @@ static void p11prov_ec_free(void *key)
 
 static void *p11prov_ec_load(const void *reference, size_t reference_sz)
 {
+    P11PROV_OBJ *key;
+
     P11PROV_debug("ec load %p, %ld", reference, reference_sz);
 
     /* the contents of the reference is the address to our object */
-    return p11prov_obj_from_reference(reference, reference_sz);
+    key = p11prov_obj_from_reference(reference, reference_sz);
+    if (key) {
+        CK_KEY_TYPE type = CK_UNAVAILABLE_INFORMATION;
+
+        type = p11prov_obj_get_key_type(key);
+        if (type == CKK_EC) {
+            /* add ref count */
+            key = p11prov_obj_ref_no_cache(key);
+        } else {
+            key = NULL;
+        }
+    }
+
+    return key;
 }
 
 static int p11prov_ec_has(const void *keydata, int selection)

--- a/src/objects.c
+++ b/src/objects.c
@@ -90,7 +90,7 @@ static void destroy_key_cache(P11PROV_OBJ *obj, P11PROV_SESSION *session)
     obj->cached = CK_INVALID_HANDLE;
 
     if (_session) {
-        p11prov_return_login_session(_session);
+        p11prov_return_session(_session);
     }
 }
 
@@ -127,7 +127,7 @@ static void cache_key(P11PROV_OBJ *obj)
     P11PROV_debug("Key %lu:%lu cached as %lu:%lu", obj->slotid, obj->handle,
                   session, obj->cached);
 
-    p11prov_return_login_session(session);
+    p11prov_return_session(session);
     return;
 }
 
@@ -805,7 +805,7 @@ static P11PROV_OBJ *find_associated_obj(P11PROV_CTX *provctx, P11PROV_OBJ *obj,
     }
 
 done:
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     return retobj;
 }
 
@@ -924,14 +924,14 @@ again:
         if (first_pass) {
             first_pass = false;
             /* TODO: Explicitly mark handle invalid */
-            p11prov_session_free(s);
+            p11prov_return_session(s);
             s = *session = NULL;
             goto again;
         }
         /* fallthrough */
     default:
         if (*session == NULL) {
-            p11prov_session_free(s);
+            p11prov_return_session(s);
         }
         return ret;
     }
@@ -969,7 +969,7 @@ CK_RV p11prov_obj_set_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
      * exactly the token is refusing ? */
 
     if (s != session) {
-        p11prov_session_free(s);
+        p11prov_return_session(s);
     }
     return ret;
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -7,6 +7,7 @@
 /* Objects */
 P11PROV_OBJ *p11prov_obj_new(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
                              CK_OBJECT_HANDLE handle, CK_OBJECT_CLASS class);
+P11PROV_OBJ *p11prov_obj_ref_no_cache(P11PROV_OBJ *obj);
 P11PROV_OBJ *p11prov_obj_ref(P11PROV_OBJ *obj);
 void p11prov_obj_free(P11PROV_OBJ *obj);
 CK_SLOT_ID p11prov_obj_get_slotid(P11PROV_OBJ *obj);

--- a/src/provider.c
+++ b/src/provider.c
@@ -828,6 +828,7 @@ static const OSSL_ITEM *p11prov_get_reason_strings(void *provctx)
         { CKR_ARGUMENTS_BAD,
           C("Invalid or improper arguments were provided to the "
             "invoked function") },
+        { CKR_CANT_LOCK, C("Internal locking failure") },
         { CKR_ATTRIBUTE_READ_ONLY,
           C("Attempted to set or modify an attribute that is Read "
             "Only for applications") },

--- a/src/provider.h
+++ b/src/provider.h
@@ -53,6 +53,7 @@ typedef struct p11prov_interface P11PROV_INTERFACE;
 typedef struct p11prov_uri P11PROV_URI;
 typedef struct p11prov_obj P11PROV_OBJ;
 typedef struct p11prov_slot P11PROV_SLOT;
+typedef struct p11prov_slots_ctx P11PROV_SLOTS_CTX;
 typedef struct p11prov_session P11PROV_SESSION;
 typedef struct p11prov_session_pool P11PROV_SESSION_POOL;
 
@@ -61,7 +62,7 @@ struct p11prov_interface *p11prov_ctx_get_interface(P11PROV_CTX *ctx);
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_status(P11PROV_CTX *ctx);
-int p11prov_ctx_get_slots(P11PROV_CTX *ctx, struct p11prov_slot ***slots);
+P11PROV_SLOTS_CTX *p11prov_ctx_get_slots(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void **data, CK_ULONG *size);
 CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,

--- a/src/provider.h
+++ b/src/provider.h
@@ -77,12 +77,12 @@ int p11prov_ctx_allow_export(P11PROV_CTX *ctx);
 void p11prov_raise(P11PROV_CTX *ctx, const char *file, int line,
                    const char *func, int errnum, const char *fmt, ...);
 
-#define P11PROV_raise(ctx, errnum, ...) \
+#define P11PROV_raise(ctx, errnum, format, ...) \
     do { \
         p11prov_raise((ctx), OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC, \
-                      (errnum), __VA_ARGS__); \
-        if (errnum) P11PROV_debug("Error: %lu", (unsigned long)(errnum)); \
-        P11PROV_debug(__VA_ARGS__); \
+                      (errnum), format, ##__VA_ARGS__); \
+        P11PROV_debug("Error: 0x%08lX; " format, (unsigned long)(errnum), \
+                      ##__VA_ARGS__); \
     } while (0)
 
 /* dispatching */

--- a/src/session.h
+++ b/src/session.h
@@ -5,14 +5,14 @@
 #define _SESSION_H
 
 /* Slots */
-CK_RV p11prov_get_slots(P11PROV_CTX *ctx, P11PROV_SLOT ***rslots, int *num);
-void p11prov_free_slots(P11PROV_SLOT **slots, int nslots);
+CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots);
+void p11prov_free_slots(P11PROV_SLOTS_CTX *slots);
+CK_RV p11prov_take_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots);
+void p11prov_return_slots(P11PROV_SLOTS_CTX *slots);
+P11PROV_SLOT *p11prov_fetch_slot(P11PROV_SLOTS_CTX *sctx, int *idx);
 int p11prov_slot_get_mechanisms(P11PROV_SLOT *slot, CK_MECHANISM_TYPE **mechs);
 
 /* Sessions */
-CK_RV p11prov_session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,
-                                P11PROV_SESSION_POOL **_pool);
-CK_RV p11prov_session_pool_free(P11PROV_SESSION_POOL *pool);
 void p11prov_session_free(P11PROV_SESSION *session);
 CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session);
 CK_SLOT_ID p11prov_session_slotid(P11PROV_SESSION *session);

--- a/src/session.h
+++ b/src/session.h
@@ -21,5 +21,8 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_MECHANISM_TYPE mechtype,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
+CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
+                                 P11PROV_SESSION **_session);
+void p11prov_return_login_session(P11PROV_SESSION *session);
 
 #endif /* _SESSION_H */

--- a/src/session.h
+++ b/src/session.h
@@ -13,7 +13,6 @@ P11PROV_SLOT *p11prov_fetch_slot(P11PROV_SLOTS_CTX *sctx, int *idx);
 int p11prov_slot_get_mechanisms(P11PROV_SLOT *slot, CK_MECHANISM_TYPE **mechs);
 
 /* Sessions */
-void p11prov_session_free(P11PROV_SESSION *session);
 CK_SESSION_HANDLE p11prov_session_handle(P11PROV_SESSION *session);
 CK_SLOT_ID p11prov_session_slotid(P11PROV_SESSION *session);
 CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
@@ -23,6 +22,6 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
 CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
                                  P11PROV_SESSION **_session);
-void p11prov_return_login_session(P11PROV_SESSION *session);
+void p11prov_return_session(P11PROV_SESSION *session);
 
 #endif /* _SESSION_H */

--- a/src/signature.c
+++ b/src/signature.c
@@ -139,7 +139,7 @@ static void *p11prov_sig_dupctx(void *ctx)
         ret = p11prov_SetOperationState(sigctx->provctx, sess, state, state_len,
                                         handle, handle);
         if (ret != CKR_OK) {
-            p11prov_session_free(sigctx->session);
+            p11prov_return_session(sigctx->session);
             sigctx->session = NULL;
         }
     }
@@ -157,7 +157,7 @@ static void p11prov_sig_freectx(void *ctx)
         return;
     }
 
-    p11prov_session_free(sigctx->session);
+    p11prov_return_session(sigctx->session);
     p11prov_obj_free(sigctx->key);
     OPENSSL_free(sigctx->properties);
     OPENSSL_clear_free(sigctx, sizeof(P11PROV_SIG_CTX));
@@ -619,7 +619,7 @@ static int p11prov_sig_operate_init(P11PROV_SIG_CTX *sigctx, bool digest_op,
             || ret == CKR_MECHANISM_PARAM_INVALID) {
             ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
         }
-        p11prov_session_free(session);
+        p11prov_return_session(session);
         return result;
     }
 
@@ -703,7 +703,7 @@ static int p11prov_sig_operate(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
     result = RET_OSSL_OK;
 
 endsess:
-    p11prov_session_free(session);
+    p11prov_return_session(session);
     if (tbs == data) {
         OPENSSL_cleanse(data, sizeof(data));
     }
@@ -731,7 +731,7 @@ static int p11prov_sig_digest_update(P11PROV_SIG_CTX *sigctx,
         ret = p11prov_VerifyUpdate(sigctx->provctx, sess, data, datalen);
     }
     if (ret != CKR_OK) {
-        p11prov_session_free(sigctx->session);
+        p11prov_return_session(sigctx->session);
         sigctx->session = NULL;
         return RET_OSSL_ERR;
     }
@@ -772,7 +772,7 @@ static int p11prov_sig_digest_final(P11PROV_SIG_CTX *sigctx, unsigned char *sig,
         result = RET_OSSL_OK;
     }
 
-    p11prov_session_free(sigctx->session);
+    p11prov_return_session(sigctx->session);
     sigctx->session = NULL;
     return result;
 }

--- a/src/store.c
+++ b/src/store.c
@@ -96,13 +96,13 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
 
         if (ctx->session != NULL) {
             p11prov_session_free(ctx->session);
-            ctx->session = CK_INVALID_HANDLE;
+            ctx->session = NULL;
         }
 
         ret = p11prov_get_session(ctx->provctx, &slotid, &nextid,
                                   ctx->parsed_uri, CK_UNAVAILABLE_INFORMATION,
                                   pw_cb, pw_cbarg, false, false, &ctx->session);
-        if (ret != CKR_OK || ctx->session == CK_INVALID_HANDLE) {
+        if (ret != CKR_OK) {
             P11PROV_raise(ctx->provctx, ret,
                           "Failed to get session to load keys");
 

--- a/src/store.c
+++ b/src/store.c
@@ -37,9 +37,7 @@ static void p11prov_store_ctx_free(struct p11prov_store_ctx *ctx)
         return;
     }
 
-    if (ctx->session != NULL) {
-        p11prov_session_free(ctx->session);
-    }
+    p11prov_return_session(ctx->session);
 
     p11prov_uri_free(ctx->parsed_uri);
     OPENSSL_free(ctx->subject.pValue);
@@ -95,7 +93,7 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
         nextid = CK_UNAVAILABLE_INFORMATION;
 
         if (ctx->session != NULL) {
-            p11prov_session_free(ctx->session);
+            p11prov_return_session(ctx->session);
             ctx->session = NULL;
         }
 

--- a/src/util.c
+++ b/src/util.c
@@ -91,7 +91,7 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                     return ret;
                 }
             }
-            P11PROV_debug("Attribute| type:%lu value:%p, len:%lu",
+            P11PROV_debug("Attribute| type:0x%08lX value:%p, len:%lu",
                           attrs[i].type, *attrs[i].value, *attrs[i].value_len);
         }
         ret = CKR_OK;

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,6 @@
 #define _UTIL_H
 
 /* Utilities to fetch objects from tokens */
-
 struct fetch_attrs {
     CK_ATTRIBUTE_TYPE type;
     CK_BYTE **value;


### PR DESCRIPTION
This code currently uses the login_session session as a stable, long term, open session.
Using any other session would require keeping another session open for as long as any key is cached.

Resolves: #55 