### PR TITLE
Streamlinbe fetch_attrs interface

### DIFF
--- a/src/exchange.c
+++ b/src/exchange.c
@@ -227,6 +227,7 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     CK_SLOT_ID slotid;
     unsigned long secret_len;
     struct fetch_attrs attrs[1];
+    int num = 0;
     CK_RV ret;
 
     if (ecdhctx->key == NULL || ecdhctx->peer_key == NULL) {
@@ -291,9 +292,9 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     }
 
     P11PROV_debug("ECDH derived hey handle: %lu", secret_handle);
-    FA_ASSIGN_ALL(attrs[0], CKA_VALUE, &secret, &secret_len, false, true);
+    FA_SET_BUF_VAL(attrs, num, CKA_VALUE, secret, secret_len, false, true);
     ret = p11prov_fetch_attributes(ecdhctx->provctx, session, secret_handle,
-                                   attrs, 1);
+                                   attrs, num);
     p11prov_return_session(session);
     if (ret != CKR_OK) {
         P11PROV_debug("ecdh failed to retrieve secret %lu", ret);

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -109,6 +109,7 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     CK_SLOT_ID slotid;
     unsigned long dkey_len;
     struct fetch_attrs attrs[1];
+    int num = 0;
     CK_RV ret;
 
     P11PROV_debug("hkdf derive (ctx:%p, key:%p[%zu], params:%p)", ctx, key,
@@ -154,9 +155,9 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     }
 
     P11PROV_debug("HKDF derived hey handle: %lu", dkey_handle);
-    FA_ASSIGN_ALL(attrs[0], CKA_VALUE, &key, &dkey_len, false, true);
+    FA_SET_BUF_VAL(attrs, num, CKA_VALUE, key, dkey_len, false, true);
     ret = p11prov_fetch_attributes(hkdfctx->provctx, hkdfctx->session,
-                                   dkey_handle, attrs, 1);
+                                   dkey_handle, attrs, num);
     if (ret != CKR_OK) {
         P11PROV_debug("hkdf failed to retrieve secret %lu", ret);
         return RET_OSSL_ERR;


### PR DESCRIPTION
This allows for writing much shorter functions with a lot less auxiliary variables needed.
It also avoids many manual coding errors by providing more utility functions.
