### PR TITLE
Allow retrieving group name for EC keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: Test logs ${{ matrix.name }} / ${{ matrix.compiler }} / ${{ matrix.token }}
+        name: Test logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
         path: |
           tests/*.log
           tests/openssl.cnf

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests/tmp.softokn
 tests/tdigests
 tests/tsession
 tests/tgenkey
+tests/treadkeys
 tests/ttls
 tests/pinfile.txt
 tests/*.log

--- a/src/interface.c
+++ b/src/interface.c
@@ -312,7 +312,10 @@ CK_RV p11prov_interface_init(void *dlhandle, P11PROV_INTERFACE **interface,
     intf->GetInterface = dlsym(dlhandle, "C_GetInterface");
     if (!intf->GetInterface) {
         char *err = dlerror();
-        P11PROV_debug("dlsym() failed: %s", err);
+        P11PROV_debug(
+            "C_GetInterface() not available. Falling back to "
+            "C_GetFunctionList(): %s",
+            err);
         intf->GetInterface = p11prov_NO_GetInterface;
     }
 

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1068,6 +1068,17 @@ static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
             return ret;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_GROUP_NAME);
+    if (p) {
+        const char *curve_name = p11prov_obj_get_ec_group_name(key);
+        if (curve_name == NULL) {
+            return RET_OSSL_ERR;
+        }
+        ret = OSSL_PARAM_set_utf8_string(p, curve_name);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -1078,10 +1089,10 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
         OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
         /* OSSL_PKEY_PARAM_DEFAULT_DIGEST
          * OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY
          * OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAM
-         * OSSL_PKEY_PARAM_GROUP_NAME
          * OSSL_PKEY_PARAM_EC_ENCODING
          * OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT
          * OSSL_PKEY_PARAM_EC_FIELD_TYPE

--- a/src/objects.c
+++ b/src/objects.c
@@ -1306,31 +1306,21 @@ int p11prov_obj_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     return ret;
 }
 
-#define EC_PUB_ATTRS 2
-int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
-                                     void *cb_arg)
+const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj)
 {
-    CK_ATTRIBUTE attrs[EC_PUB_ATTRS] = { 0 };
-    OSSL_PARAM params[EC_PUB_ATTRS + 1];
-    ASN1_OCTET_STRING *octet = NULL;
+    CK_ATTRIBUTE attrs[1] = { 0 };
     EC_GROUP *group = NULL;
     const unsigned char *val;
     const char *curve_name;
     int curve_nid;
     CK_RV rv;
-    int ret;
-
-    if (p11prov_obj_get_key_type(obj) != CKK_EC) {
-        return RET_OSSL_ERR;
-    }
 
     attrs[0].type = CKA_EC_PARAMS;
-    attrs[1].type = CKA_EC_POINT;
 
-    rv = get_public_attrs(obj, attrs, EC_PUB_ATTRS);
+    rv = get_public_attrs(obj, attrs, 1);
     if (rv != CKR_OK) {
         P11PROV_raise(obj->ctx, rv, "Failed to get public key attributes");
-        return RET_OSSL_ERR;
+        return NULL;
     }
 
     /* in d2i functions 'in' is overwritten to return the remainder of the
@@ -1340,16 +1330,42 @@ int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     group = d2i_ECPKParameters(NULL, (const unsigned char **)&val,
                                attrs[0].ulValueLen);
     if (group == NULL) {
-        ret = RET_OSSL_ERR;
         goto done;
     }
 
     curve_nid = EC_GROUP_get_curve_name(group);
     if (curve_nid == NID_undef) {
-        ret = RET_OSSL_ERR;
         goto done;
     }
     curve_name = OSSL_EC_curve_nid2name(curve_nid);
+    if (curve_name == NULL) {
+        goto done;
+    }
+    return curve_name;
+
+done:
+    OPENSSL_free(attrs[0].pValue);
+    EC_GROUP_free(group);
+    return NULL;
+}
+
+#define EC_PUB_ATTRS 2
+int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
+                                     void *cb_arg)
+{
+    CK_ATTRIBUTE attrs[1] = { 0 };
+    OSSL_PARAM params[EC_PUB_ATTRS + 1];
+    ASN1_OCTET_STRING *octet = NULL;
+    const unsigned char *val;
+    const char *curve_name;
+    CK_RV rv;
+    int ret;
+
+    if (p11prov_obj_get_key_type(obj) != CKK_EC) {
+        return RET_OSSL_ERR;
+    }
+
+    curve_name = p11prov_obj_get_ec_group_name(obj);
     if (curve_name == NULL) {
         ret = RET_OSSL_ERR;
         goto done;
@@ -1357,11 +1373,21 @@ int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                  (char *)curve_name, 0);
 
-    val = attrs[1].pValue;
+    attrs[0].type = CKA_EC_POINT;
+
+    rv = get_public_attrs(obj, attrs, 1);
+    if (rv != CKR_OK) {
+        P11PROV_raise(obj->ctx, rv, "Failed to get public key attributes");
+        ret = RET_OSSL_ERR;
+        goto done;
+    }
+
+    val = attrs[0].pValue;
     octet = d2i_ASN1_OCTET_STRING(NULL, (const unsigned char **)&val,
-                                  attrs[1].ulValueLen);
+                                  attrs[0].ulValueLen);
     if (octet == NULL) {
-        return RET_OSSL_ERR;
+        ret = RET_OSSL_ERR;
+        goto done;
     }
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
                                                   octet->data, octet->length);
@@ -1372,10 +1398,7 @@ int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
 
 done:
     /* must be freed after callback */
-    for (int i = 0; i < EC_PUB_ATTRS; i++) {
-        OPENSSL_free(attrs[i].pValue);
-    }
+    OPENSSL_free(attrs[0].pValue);
     ASN1_OCTET_STRING_free(octet);
-    EC_GROUP_free(group);
     return ret;
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -13,6 +13,7 @@ struct p11prov_key {
     CK_BBOOL always_auth;
     CK_ULONG bit_size;
     CK_ULONG size;
+    const char *curve_name;
 };
 
 struct p11prov_crt {
@@ -1315,6 +1316,11 @@ const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj)
     int curve_nid;
     CK_RV rv;
 
+    if (obj->data.key.curve_name != NULL) {
+        P11PROV_debug("Using cached curve name %s", obj->data.key.curve_name);
+        return obj->data.key.curve_name;
+    }
+
     attrs[0].type = CKA_EC_PARAMS;
 
     rv = get_public_attrs(obj, attrs, 1);
@@ -1341,6 +1347,9 @@ const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj)
     if (curve_name == NULL) {
         goto done;
     }
+
+    obj->data.key.curve_name = curve_name;
+    P11PROV_debug("Caching curve name %s", curve_name);
     return curve_name;
 
 done:

--- a/src/objects.h
+++ b/src/objects.h
@@ -44,5 +44,6 @@ int p11prov_obj_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                       void *cb_arg);
 int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
                                      void *cb_arg);
+const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj);
 
 #endif /* _OBJECTS_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ libspath=@abs_top_builddir@/src/.libs
 testsblddir=@abs_top_builddir@/tests
 testssrcdir=@abs_srcdir@
 
-check_PROGRAMS = tsession tgenkey ttls tdigests
+check_PROGRAMS = tsession tgenkey ttls tdigests treadkeys
 
 tsession_SOURCES = tsession.c
 tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -21,6 +21,10 @@ ttls_LDADD = $(OPENSSL_LIBS)
 tdigests_SOURCES = tdigests.c
 tdigests_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 tdigests_LDADD = $(OPENSSL_LIBS)
+
+treadkeys_SOURCES = treadkeys.c
+treadkeys_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+treadkeys_LDADD = $(OPENSSL_LIBS)
 
 tmp.softokn:
 	LIBSPATH=$(libspath) \
@@ -49,6 +53,7 @@ test_LIST = \
 	digests-softokn digests-softhsm-proxy \
 	genkey-softokn genkey-softhsm \
 	session-softokn session-softhsm-proxy \
+	readkeys-softokn readkeys-softhsm-proxy \
 	tls-softokn tls-softhsm-proxy
 .PHONY: $(test_LIST)
 

--- a/tests/treadkeys.c
+++ b/tests/treadkeys.c
@@ -1,0 +1,72 @@
+/* Copyright (C) 2023 Jakub Jelen <jjelen@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/store.h>
+#include <openssl/core_names.h>
+
+static void test_group_name(EVP_PKEY *pkey)
+{
+    char gname[25] = { 0 };
+    int ret;
+
+    ret = EVP_PKEY_get_utf8_string_param(pkey, OSSL_PKEY_PARAM_GROUP_NAME,
+                                         gname, 25, NULL);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to get the group name\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (strcmp(gname, "prime256v1") != 0) {
+        fprintf(stderr, "Received unexpected group name. Got %s\n", gname);
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    const char *baseuri;
+    OSSL_STORE_CTX *store;
+    OSSL_STORE_INFO *info;
+    EVP_PKEY *prikey = NULL;
+    EVP_PKEY *pubkey = NULL;
+
+    baseuri = getenv("ECBASEURI");
+    if (baseuri == NULL) {
+        fprintf(stderr, "No ECBASEURI\n");
+        exit(EXIT_FAILURE);
+    }
+
+    store = OSSL_STORE_open(baseuri, NULL, NULL, NULL, NULL);
+    if (store == NULL) {
+        fprintf(stderr, "Failed to open pkcs11 store\n");
+        exit(EXIT_FAILURE);
+    }
+
+    for (info = OSSL_STORE_load(store); info != NULL;
+         info = OSSL_STORE_load(store)) {
+        int type = OSSL_STORE_INFO_get_type(info);
+
+        switch (type) {
+        case OSSL_STORE_INFO_PUBKEY:
+            pubkey = OSSL_STORE_INFO_get1_PUBKEY(info);
+            break;
+        case OSSL_STORE_INFO_PKEY:
+            prikey = OSSL_STORE_INFO_get1_PKEY(info);
+            break;
+        }
+    }
+
+    if (pubkey == NULL) {
+        fprintf(stderr, "Failed to load public key\n");
+        exit(EXIT_FAILURE);
+    }
+    test_group_name(pubkey);
+
+    if (prikey == NULL) {
+        fprintf(stderr, "Failed to load private key\n");
+        exit(EXIT_FAILURE);
+    }
+    test_group_name(pubkey);
+}


### PR DESCRIPTION
The openssl excersises different code paths when accessing OSSL_PARAMS of a
provided EVP_PKEY structures. While going with EVP_PKEY_todata() works as
expected, using EVP_PKEY_get_utf8_string_param() goes through different code
path to retrive the parameters and in current version fails.