### PR TITLE
Session locking fixes

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -412,12 +412,12 @@ struct p11prov_session_pool {
     P11PROV_CTX *provctx;
     CK_SLOT_ID slotid;
 
-    CK_ULONG max_sessions;
-    CK_ULONG limit_sessions;
-    CK_ULONG cur_sessions;
+    int num_sessions;
+    int max_sessions;
+    int open_sessions;
+    int max_cached_sessions;
 
     P11PROV_SESSION **sessions;
-    int num_p11sessions;
 
     P11PROV_SESSION *login_session;
 
@@ -429,32 +429,29 @@ struct p11prov_session_pool {
 /* sleep interval, 50 microseconds (max 20 attempts) */
 #define SLEEP 50000
 
-/* NOTE: to be called with Pool Lock held */
 static CK_RV token_session_open(P11PROV_SESSION *session, CK_FLAGS flags)
 {
-    bool wait_ok = true;
     uint64_t startime = 0;
     CK_RV ret;
 
-    if (session->pool->cur_sessions >= session->pool->max_sessions) {
-        P11PROV_debug_once("Max Session (%lu) exceeded!",
-                           session->pool->max_sessions);
-        return CKR_SESSION_COUNT;
-    }
-
-    while (wait_ok) {
+    do {
         ret = p11prov_OpenSession(session->provctx, session->slotid, flags,
                                   NULL, NULL, &session->session);
         P11PROV_debug("C_OpenSession ret:%lu (session: %lu)", ret,
                       session->session);
-        if (ret == CKR_SESSION_COUNT) {
-            wait_ok = cyclewait_with_timeout(MAX_WAIT, SLEEP, &startime);
-            continue;
+        if (ret != CKR_SESSION_COUNT) {
+            break;
         }
-        break;
+    } while (cyclewait_with_timeout(MAX_WAIT, SLEEP, &startime));
+
+    if (ret != CKR_OK) {
+        session->session = CK_INVALID_HANDLE;
+        session->flags = DEFLT_SESSION_FLAGS;
+        return ret;
     }
 
-    return ret;
+    session->flags = flags;
+    return CKR_OK;
 }
 
 static void token_session_close(P11PROV_SESSION *session)
@@ -493,17 +490,17 @@ static CK_RV session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,
         && token->ulMaxSessionCount != CK_UNAVAILABLE_INFORMATION) {
         pool->max_sessions = token->ulMaxSessionCount;
         /* keep a max of 10% of the sessions */
-        pool->limit_sessions = pool->max_sessions / 10;
-        if (pool->limit_sessions == 0) {
-            pool->limit_sessions = 3;
+        pool->max_cached_sessions = pool->max_sessions / 10;
+        if (pool->max_cached_sessions == 0) {
+            pool->max_cached_sessions = 3;
         }
     } else {
         /* arbitrary max concurrent open sessions */
         pool->max_sessions = 1024;
-        pool->limit_sessions = 8;
+        pool->max_cached_sessions = 8;
     }
-    if (pool->limit_sessions > pool->max_sessions) {
-        pool->limit_sessions = pool->max_sessions;
+    if (pool->max_cached_sessions > pool->max_sessions) {
+        pool->max_cached_sessions = pool->max_sessions;
     }
 
     P11PROV_debug("New session pool %p created", pool);
@@ -514,56 +511,53 @@ static CK_RV session_pool_init(P11PROV_CTX *ctx, CK_TOKEN_INFO *token,
 
 static void session_pool_free(P11PROV_SESSION_POOL *pool)
 {
-    CK_RV ret;
-
     P11PROV_debug("Freeing session pool %p", pool);
 
     if (!pool) {
         return;
     }
 
-    ret = MUTEX_LOCK(pool);
-    if (ret != CKR_OK) {
+    /* LOCKED SECTION ------------- */
+    if (MUTEX_LOCK(pool) == CKR_OK) {
+        for (int i = 0; i < pool->num_sessions; i++) {
+            session_free(pool->sessions[i]);
+            pool->sessions[i] = NULL;
+        }
+        OPENSSL_free(pool->sessions);
+        (void)MUTEX_UNLOCK(pool);
+    }
+    /* ------------- LOCKED SECTION */
+    else {
         return;
     }
-    /* LOCKED SECTION ------------- */
 
-    for (int i = 0; i < pool->num_p11sessions; i++) {
-        session_free(pool->sessions[i]);
-        pool->sessions[i] = NULL;
-    }
-    OPENSSL_free(pool->sessions);
-
-    /* ------------- LOCKED SECTION */
-    (void)MUTEX_UNLOCK(pool);
     (void)MUTEX_DESTROY(pool);
     OPENSSL_clear_free(pool, sizeof(P11PROV_SESSION_POOL));
 }
 
 #define SESS_ALLOC_SIZE 32
 
-/* NOTE: to be called with Pool Lock held */
-static P11PROV_SESSION *session_new(P11PROV_SESSION_POOL *pool)
+/* NOTE: to be called with Pool Lock held,
+ * returns a locked session */
+static CK_RV session_new(P11PROV_SESSION_POOL *pool, P11PROV_SESSION **_session)
 {
     P11PROV_SESSION *session;
     int ret;
 
     P11PROV_debug("Creating new P11PROV_SESSION session on pool %p", pool);
 
-    /* cap the amount of obtainable P11PROV_SESSIONs to double the max
-     * number of available pkcs11 token sessions, just to have a limit
-     * in case of runaway concurrent threads */
-    if (pool->num_p11sessions > (int)(pool->max_sessions * 2)) {
-        P11PROV_raise(pool->provctx, CKR_SESSION_COUNT,
-                      "Max sessions limit reached");
-        return NULL;
+    if (pool->num_sessions >= pool->max_sessions) {
+        ret = CKR_SESSION_COUNT;
+        P11PROV_raise(pool->provctx, ret, "Max sessions (%lu) exceeded",
+                      pool->max_sessions);
+        return ret;
     }
 
     session = OPENSSL_zalloc(sizeof(P11PROV_SESSION));
     if (session == NULL) {
-        P11PROV_raise(pool->provctx, CKR_HOST_MEMORY,
-                      "Failed to allocate session");
-        return NULL;
+        ret = CKR_HOST_MEMORY;
+        P11PROV_raise(pool->provctx, ret, "Failed to allocate session");
+        return ret;
     }
     session->provctx = pool->provctx;
     session->slotid = pool->slotid;
@@ -574,19 +568,20 @@ static P11PROV_SESSION *session_new(P11PROV_SESSION_POOL *pool)
     ret = MUTEX_INIT(session);
     if (ret != CKR_OK) {
         OPENSSL_free(session);
-        return NULL;
+        return ret;
     }
 
     /* check if we need to expand the sessions array */
-    if ((pool->num_p11sessions % SESS_ALLOC_SIZE) == 0) {
+    if ((pool->num_sessions % SESS_ALLOC_SIZE) == 0) {
         P11PROV_SESSION **tmp = OPENSSL_realloc(
-            pool->sessions, (pool->num_p11sessions + SESS_ALLOC_SIZE)
-                                * sizeof(P11PROV_SESSION *));
+            pool->sessions,
+            (pool->num_sessions + SESS_ALLOC_SIZE) * sizeof(P11PROV_SESSION *));
         if (tmp == NULL) {
-            P11PROV_raise(pool->provctx, CKR_HOST_MEMORY,
+            ret = CKR_HOST_MEMORY;
+            P11PROV_raise(pool->provctx, ret,
                           "Failed to re-allocate sessions array");
             session_free(session);
-            return NULL;
+            return ret;
         }
         pool->sessions = tmp;
     }
@@ -594,18 +589,19 @@ static P11PROV_SESSION *session_new(P11PROV_SESSION_POOL *pool)
     ret = MUTEX_LOCK(session);
     if (ret != CKR_OK) {
         session_free(session);
-        return NULL;
+        return ret;
     }
 
-    pool->sessions[pool->num_p11sessions] = session;
-    pool->num_p11sessions++;
-    P11PROV_debug("Total sessions: %d", pool->num_p11sessions);
+    pool->sessions[pool->num_sessions] = session;
+    pool->num_sessions++;
+    P11PROV_debug("Total sessions: %d", pool->num_sessions);
 
-    return session;
+    *_session = session;
+    return CKR_OK;
 }
 
-/* NOTE: to be called with Pool Lock held */
-static CK_RV session_check(P11PROV_SESSION *session, CK_FLAGS flags)
+static CK_RV session_check(P11PROV_SESSION *session, CK_FLAGS flags,
+                           CK_STATE *state)
 {
     CK_SESSION_INFO session_info;
     int ret;
@@ -623,24 +619,25 @@ static CK_RV session_check(P11PROV_SESSION *session, CK_FLAGS flags)
     ret = p11prov_GetSessionInfo(session->provctx, session->session,
                                  &session_info);
     if (ret == CKR_OK) {
+        if (state) {
+            *state = session_info.state;
+        }
         if (flags == session_info.flags) {
             return ret;
         }
         (void)p11prov_CloseSession(session->provctx, session->session);
+        session->session = CK_INVALID_HANDLE;
+        /* tell the caller that the session was closed so they can
+         * keep up with accounting */
+        return CKR_SESSION_CLOSED;
     }
-    /* regardless of the result the session is gone */
+
+    /* session has been closed elsewhere, or otherwise unusable */
     session->session = CK_INVALID_HANDLE;
-    session->pool->cur_sessions--;
-
-    if (ret == CKR_SESSION_CLOSED || ret == CKR_SESSION_HANDLE_INVALID) {
-        /* session has been closed elsewhere */
-        return CKR_OK;
-    }
-
-    /* some unrecoverable internal error happened, report it */
     return ret;
 }
 
+/* only call this from session_new or session_pool_free */
 static void session_free(P11PROV_SESSION *session)
 {
     int ret;
@@ -653,7 +650,7 @@ static void session_free(P11PROV_SESSION *session)
 
     ret = MUTEX_TRY_LOCK(session, false);
     if (ret != CKR_OK) {
-        /* just orphan this session, will likely leak memory ... */
+        /* just orphan this session, will potentially leak memory ... */
         session->pool = NULL;
         return;
     }
@@ -676,48 +673,20 @@ CK_SLOT_ID p11prov_session_slotid(P11PROV_SESSION *session)
 }
 
 /* returns a locked login_session if _session is not NULL */
-static CK_RV token_login(P11PROV_SESSION_POOL *pool, P11PROV_URI *uri,
-                         OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
-                         P11PROV_SESSION **_session)
+static CK_RV token_login(P11PROV_SESSION *session, P11PROV_URI *uri,
+                         OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
-    P11PROV_SESSION *session = NULL;
     char cb_pin[MAX_PIN_LENGTH + 1] = { 0 };
     size_t cb_pin_len = 0;
     CK_UTF8CHAR_PTR pin = NULL_PTR;
     CK_ULONG pinlen = 0;
-    bool locked;
     CK_RV ret;
-
-    ret = MUTEX_LOCK(pool);
-    if (ret != CKR_OK) {
-        return ret;
-    }
-    /* LOCKED SECTION ------------- */
-    locked = true;
-
-    if (pool->login_session) {
-        ret = MUTEX_LOCK(pool->login_session);
-        if (ret != CKR_OK) {
-            goto done;
-        }
-        session = pool->login_session;
-
-        /* we already have a login_session, check if it is valid */
-        ret = session_check(session, session->flags);
-        if (ret != CKR_OK) {
-            goto done;
-        }
-        if (session->session != CK_INVALID_HANDLE) {
-            /* fully valid handle, we are done */
-            goto done;
-        }
-    }
 
     if (uri) {
         pin = (CK_UTF8CHAR_PTR)p11prov_uri_get_pin(uri);
     }
     if (!pin) {
-        pin = p11prov_ctx_pin(pool->provctx);
+        pin = p11prov_ctx_pin(session->provctx);
     }
     if (pin) {
         pinlen = strlen((const char *)pin);
@@ -745,36 +714,6 @@ static CK_RV token_login(P11PROV_SESSION_POOL *pool, P11PROV_URI *uri,
         goto done;
     }
 
-    if (!session) {
-        session = session_new(pool);
-        if (!session) {
-            ret = CKR_HOST_MEMORY;
-            goto done;
-        }
-    }
-
-    /* ------------- LOCKED SECTION */
-    (void)MUTEX_UNLOCK(pool);
-    locked = false;
-
-    if (session->session == CK_INVALID_HANDLE) {
-        ret = token_session_open(session, session->flags);
-        if (ret == CKR_OK) {
-            ret = MUTEX_LOCK(pool);
-            if (ret != CKR_OK) {
-                goto done;
-            }
-            locked = true;
-            /* LOCKED SECTION ------------- */
-            pool->cur_sessions++;
-            /* ------------- LOCKED SECTION */
-            (void)MUTEX_UNLOCK(pool);
-            locked = false;
-        } else {
-            goto done;
-        }
-    }
-
     P11PROV_debug("Attempt Login on session %lu", session->session);
     /* Supports only USER login sessions for now */
     ret = p11prov_Login(session->provctx, session->session, CKU_USER, pin,
@@ -782,26 +721,8 @@ static CK_RV token_login(P11PROV_SESSION_POOL *pool, P11PROV_URI *uri,
     if (ret == CKR_USER_ALREADY_LOGGED_IN) {
         ret = CKR_OK;
     }
-    if (ret == CKR_OK) {
-        pool->login_session = session;
-    }
 
 done:
-    if (locked) {
-        (void)MUTEX_UNLOCK(pool);
-        locked = false;
-    }
-
-    if (session) {
-        /* if session is not null it is always locked */
-        if (ret != CKR_OK || !_session) {
-            MUTEX_UNLOCK(session);
-        }
-    }
-    if (ret == CKR_OK && _session) {
-        *_session = session;
-    }
-
     OPENSSL_cleanse(cb_pin, cb_pin_len);
     return ret;
 }
@@ -843,15 +764,20 @@ static CK_RV check_slot(struct p11prov_slot *provslot, P11PROV_URI *uri,
     return CKR_OK;
 }
 
-/* NOTE: to be called with Pool Lock held */
-static P11PROV_SESSION *find_free_session(P11PROV_SESSION_POOL *pool,
-                                          CK_FLAGS flags)
+static CK_RV fetch_session(P11PROV_SESSION_POOL *pool, CK_FLAGS flags,
+                           P11PROV_SESSION **_session)
 {
     P11PROV_SESSION *session = NULL;
     int ret;
 
+    ret = MUTEX_LOCK(pool);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+    /* LOCKED SECTION ------------- */
+
     /* try to find session with a cached handle first */
-    for (int i = 0; i < pool->num_p11sessions; i++) {
+    for (int i = 0; i < pool->num_sessions; i++) {
         session = pool->sessions[i];
         if (session == pool->login_session) {
             continue;
@@ -861,13 +787,14 @@ static P11PROV_SESSION *find_free_session(P11PROV_SESSION_POOL *pool,
                 ret = MUTEX_TRY_LOCK(session, false);
                 if (ret == CKR_OK) {
                     /* Bingo! A compatible session with a cached handle */
-                    return session;
+                    goto done;
                 }
             }
         }
     }
+
     /* try again, get any free session */
-    for (int i = 0; i < pool->num_p11sessions; i++) {
+    for (int i = 0; i < pool->num_sessions; i++) {
         session = pool->sessions[i];
         if (session == pool->login_session) {
             continue;
@@ -875,11 +802,137 @@ static P11PROV_SESSION *find_free_session(P11PROV_SESSION_POOL *pool,
         ret = MUTEX_TRY_LOCK(session, false);
         if (ret == CKR_OK) {
             /* we got a free session */
-            return session;
+            goto done;
         }
     }
 
-    return NULL;
+    /* no free sessions, try to allocate a new one */
+    ret = session_new(pool, &session);
+
+done:
+    (void)MUTEX_UNLOCK(pool);
+    /* ------------- LOCKED SECTION */
+
+    if (ret == CKR_OK) {
+        *_session = session;
+    }
+    return ret;
+}
+
+static CK_RV slot_login(P11PROV_SLOT *slot, P11PROV_URI *uri,
+                        OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
+                        P11PROV_SESSION **_session)
+{
+    P11PROV_SESSION_POOL *pool = slot->pool;
+    P11PROV_SESSION *session = NULL;
+    CK_FLAGS flags = DEFLT_SESSION_FLAGS;
+    CK_STATE state = CKS_RO_PUBLIC_SESSION;
+    int num_open_sessions = 0;
+    uint64_t startime = 0;
+    CK_RV ret;
+
+    /* try to lock the login_session */
+    do {
+        ret = MUTEX_LOCK(pool);
+        if (ret != CKR_OK) {
+            break;
+        }
+
+        /* LOCKED SECTION ------------- */
+        session = pool->login_session;
+        if (session) {
+            ret = MUTEX_TRY_LOCK(session, false);
+        }
+        (void)MUTEX_UNLOCK(pool);
+        /* ------------- LOCKED SECTION */
+
+        /* we cycle only if we have a session but failed to lock it */
+        if (ret == CKR_OK) {
+            break;
+        }
+
+    } while (cyclewait_with_timeout(MAX_WAIT, SLEEP, &startime));
+
+    if (ret != CKR_OK) {
+        if (session) {
+            P11PROV_raise(
+                pool->provctx, ret,
+                "Failed to lock login_session after several attemepts");
+            session = NULL;
+        }
+        goto done;
+    }
+
+    if (session) {
+        /* we have a login session */
+        flags = session->flags;
+    } else {
+        ret = fetch_session(pool, flags, &session);
+        if (ret != CKR_OK) {
+            return ret;
+        }
+    }
+
+    /* we have a locked session, check that it is ok */
+    ret = session_check(session, flags, &state);
+    if (ret == CKR_OK) {
+        if (state == CKS_RW_PUBLIC_SESSION || state == CKS_RW_USER_FUNCTIONS
+            || state == CKS_RW_SO_FUNCTIONS) {
+            /* we have a valid logged in session */
+            goto done;
+        }
+    } else {
+        num_open_sessions--;
+    }
+
+    if (session->session == CK_INVALID_HANDLE) {
+        ret = token_session_open(session, flags);
+        if (ret == CKR_OK) {
+            num_open_sessions++;
+        } else {
+            goto done;
+        }
+    }
+
+    /* here we have a locked, open session */
+    ret = token_login(session, uri, pw_cb, pw_cbarg);
+
+done:
+    if (session) {
+        /* if we found or created a session we need to update the pool
+         * status */
+
+        /* LOCKED SECTION ------------- */
+        if (MUTEX_LOCK(pool) == CKR_OK) {
+
+            pool->open_sessions += num_open_sessions;
+
+            if (ret == CKR_OK) {
+                if (pool->login_session == NULL) {
+                    /* Any session can be used as login session.
+                     * As long as there is one session open */
+                    pool->login_session = session;
+                }
+            } else {
+                if (pool->login_session == session) {
+                    /* broken login session, unmark it as a login session */
+                    pool->login_session = NULL;
+                }
+            }
+
+            (void)MUTEX_UNLOCK(pool);
+        }
+        /* ------------- LOCKED SECTION */
+
+        if (_session) {
+            *_session = session;
+        } else {
+            /* unlock the session */
+            p11prov_return_session(session);
+        }
+    }
+
+    return ret;
 }
 
 /* There are three possible ways to call this function.
@@ -903,11 +956,12 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **_session)
 {
-    P11PROV_SESSION_POOL *pool = NULL;
     P11PROV_SLOTS_CTX *slots = NULL;
     P11PROV_SLOT *slot = NULL;
+    P11PROV_SESSION_POOL *pool = NULL;
     CK_SLOT_ID id = *slotid;
     P11PROV_SESSION *session = NULL;
+    int num_open_sessions = 0;
     CK_FLAGS flags = DEFLT_SESSION_FLAGS;
     int slot_idx;
     CK_RV ret;
@@ -937,7 +991,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
             goto done;
         }
         if ((slot->token.flags & CKF_LOGIN_REQUIRED) || reqlogin) {
-            ret = token_login(slot->pool, uri, pw_cb, pw_cbarg, NULL);
+            ret = slot_login(slot, uri, pw_cb, pw_cbarg, NULL);
             if (ret == CKR_CANCEL && !reqlogin) {
                 ret = CKR_OK;
             }
@@ -965,7 +1019,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                 continue;
             }
             if ((slot->token.flags & CKF_LOGIN_REQUIRED) || reqlogin) {
-                ret = token_login(slot->pool, uri, pw_cb, pw_cbarg, NULL);
+                ret = slot_login(slot, uri, pw_cb, pw_cbarg, NULL);
                 if (ret == CKR_CANCEL && !reqlogin) {
                     ret = CKR_OK;
                 }
@@ -1001,46 +1055,41 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
         }
     }
 
+    pool = slot->pool;
+
     if (rw) {
         flags |= CKF_RW_SESSION;
     }
 
-    pool = slot->pool;
-
-    ret = MUTEX_LOCK(pool);
-    if (ret != CKR_OK) {
-        goto done;
-    }
-    /* LOCKED SECTION ------------- */
-
-    session = find_free_session(pool, flags);
-    if (!session) {
-        /* no session found, we have to allocate a new one */
-        session = session_new(pool);
-    }
-    ret = session_check(session, flags);
-
-    /* ------------- LOCKED SECTION */
-    (void)MUTEX_UNLOCK(pool);
-    /* we can continue here on error, but future operations will likely fail */
-
+    ret = fetch_session(pool, flags, &session);
     if (ret == CKR_OK) {
+        ret = session_check(session, flags, NULL);
+        if (ret != CKR_OK) {
+            num_open_sessions--;
+            ret = CKR_OK;
+        }
         if (session->session == CK_INVALID_HANDLE) {
             ret = token_session_open(session, flags);
             if (ret == CKR_OK) {
-                session->flags = flags;
-
-                ret = MUTEX_LOCK(pool);
-                if (ret != CKR_OK) {
-                    goto done;
-                }
-                pool->cur_sessions++;
-                (void)MUTEX_UNLOCK(pool);
+                num_open_sessions++;
             }
         }
     }
 
 done:
+    if (pool && num_open_sessions != 0) {
+
+        /* if locking fails here we have bigger problems than
+         * just bad accounting */
+
+        /* LOCKED SECTION ------------- */
+        if (MUTEX_LOCK(pool) == CKR_OK) {
+            pool->open_sessions += num_open_sessions;
+            (void)MUTEX_UNLOCK(pool);
+        }
+        /* ------------- LOCKED SECTION */
+    }
+
     if (ret == CKR_OK) {
         *_session = session;
     } else {
@@ -1077,7 +1126,7 @@ CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
         goto done;
     }
 
-    ret = token_login(slot->pool, NULL, NULL, NULL, _session);
+    ret = slot_login(slot, NULL, NULL, NULL, _session);
 
 done:
     p11prov_return_slots(slots);
@@ -1086,44 +1135,38 @@ done:
 
 void p11prov_return_session(P11PROV_SESSION *session)
 {
-    int err;
+    P11PROV_SESSION_POOL *pool;
 
     if (!session) {
         return;
     }
 
-    if (session->pool) {
-        P11PROV_SESSION_POOL *pool = session->pool;
-        int ret;
+    pool = session->pool;
 
+    if (pool) {
         /* peek at the pool lockless worst case we waste some time */
-        if (pool->cur_sessions >= pool->limit_sessions) {
+        if (pool->open_sessions >= pool->max_cached_sessions) {
+            /* not much we can do if this fails,
+             * but only accounting will be a bit off */
 
-            ret = MUTEX_LOCK(pool);
-            if (ret != CKR_OK) {
-                /* nothing we can do */
-                return;
-            }
             /* LOCKED SECTION ------------- */
-            if (pool->cur_sessions >= pool->limit_sessions) {
-                token_session_close(session);
-                pool->cur_sessions--;
+            if (MUTEX_LOCK(pool) == CKR_OK) {
+                if (pool->open_sessions >= pool->max_cached_sessions
+                    && session != pool->login_session) {
+                    token_session_close(session);
+                    pool->open_sessions--;
+                }
+                (void)MUTEX_UNLOCK(pool);
             }
             /* ------------- LOCKED SECTION */
-            (void)MUTEX_UNLOCK(pool);
         }
     }
+    /* not much we can do if this fails */
+    (void)MUTEX_UNLOCK(session);
 
-    err = pthread_mutex_unlock(&session->lock);
-    if (err != 0) {
-        err = errno;
-        P11PROV_raise(session->provctx, CKR_CANT_LOCK,
-                      "Failed to unlock session %p (errno=%d)", session, err);
-    }
-
-    /* handle case where session was orphaned because locked while the
-     * pool was being freed */
-    if (session->pool == NULL) {
+    if (!pool) {
+        /* handle case where session was orphaned because locked while
+         * the pool was being freed */
         session_free(session);
     }
 }


### PR DESCRIPTION
In PR #156 an attempt to fix some minor locking issues resulted in a much worse potential deadlock within the code that attempts to create a login session.

The code roughly did the following:
    token_login {

        /* A section */
        lock -> pool
        lock -> session
        unlock -> pool

        /* issue  */

        /* B section */
        lock->pool
        unlock->pool
        return
    }

After section A, we hold the session lock, but do not hold the pool lock, that means another thread could be calling token_login() before we enter section B, and take the pool lock.
Then attempt to take the session lock and be stuck waiting. At the same time the original thread will be stuck trying to get the pool lock in section B, and not releaseing the session lock. This is a classic deadlock situation and both threads will wait forever.

The basic solution is to use MUTEX_TRY_LOCK to get the session lock so that in case of deadlock we'll get an error instead of being stuck forever.

After taking a step back however I reeliazed there were many shortcomings in how the code was refactor to avoid waiting withing locked sections, so the solution is a bit larger than a minimal fix, and better streamlines some internal operations reducing the number of locking sections to the bare minimum needed.