### PR TITLE
Key generation callbacks

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -421,6 +421,9 @@ struct p11prov_session {
     CK_FLAGS flags;
 
     pthread_mutex_t lock;
+
+    p11prov_session_callback_t cb;
+    void *cbarg;
 };
 
 struct p11prov_session_pool {
@@ -439,11 +442,28 @@ struct p11prov_session_pool {
     pthread_mutex_t lock;
 };
 
+static CK_RV token_session_callback(CK_SESSION_HANDLE hSession,
+                                    CK_NOTIFICATION event,
+                                    CK_VOID_PTR pApplication)
+{
+    P11PROV_SESSION *session = (P11PROV_SESSION *)pApplication;
+
+    if (session->session != hSession) {
+        /* something not right, let's ignore this callback */
+        return CKR_OK;
+    }
+
+    if (session->cb) {
+        return session->cb(session->cbarg);
+    }
+
+    return CKR_OK;
+}
+
 /* in nanoseconds, 1 seconds */
 #define MAX_WAIT 1000000000
 /* sleep interval, 50 microseconds (max 20 attempts) */
 #define SLEEP 50000
-
 static CK_RV token_session_open(P11PROV_SESSION *session, CK_FLAGS flags)
 {
     uint64_t startime = 0;
@@ -451,7 +471,8 @@ static CK_RV token_session_open(P11PROV_SESSION *session, CK_FLAGS flags)
 
     do {
         ret = p11prov_OpenSession(session->provctx, session->slotid, flags,
-                                  NULL, NULL, &session->session);
+                                  session, token_session_callback,
+                                  &session->session);
         P11PROV_debug("C_OpenSession ret:%lu (session: %lu)", ret,
                       session->session);
         if (ret != CKR_SESSION_COUNT) {
@@ -1156,6 +1177,9 @@ void p11prov_return_session(P11PROV_SESSION *session)
         return;
     }
 
+    /* remove any callback */
+    p11prov_session_set_callback(session, NULL, NULL);
+
     pool = session->pool;
 
     if (pool) {
@@ -1184,4 +1208,11 @@ void p11prov_return_session(P11PROV_SESSION *session)
          * the pool was being freed */
         session_free(session);
     }
+}
+
+void p11prov_session_set_callback(P11PROV_SESSION *session,
+                                  p11prov_session_callback_t cb, void *cbarg)
+{
+    session->cb = cb;
+    session->cbarg = cbarg;
 }

--- a/src/session.h
+++ b/src/session.h
@@ -24,4 +24,8 @@ CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
                                  P11PROV_SESSION **_session);
 void p11prov_return_session(P11PROV_SESSION *session);
 
+typedef CK_RV (*p11prov_session_callback_t)(void *cbarg);
+void p11prov_session_set_callback(P11PROV_SESSION *session,
+                                  p11prov_session_callback_t cb, void *cbarg);
+
 #endif /* _SESSION_H */


### PR DESCRIPTION
This PR aims to address #161
I do not say fix because there is no requirement for a token to call callbacks.

In fact neither softokn nor softhsm call them during key generation so we can't regularly test this code.

However I manually tested that everything works well from pkcs11-provider up my hardcoding a few calls to token_session_callback() and running openssl genpkey and have verified that dots are printed by openssl (we return only zeros in the params and they correspond to the '.' char).

Resolves #161