### PR TITLE
CID 433656: Invalid type in argument to printf

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -563,7 +563,7 @@ static CK_RV session_new(P11PROV_SESSION_POOL *pool, P11PROV_SESSION **_session)
 
     if (pool->num_sessions >= pool->max_sessions) {
         ret = CKR_SESSION_COUNT;
-        P11PROV_raise(pool->provctx, ret, "Max sessions (%lu) exceeded",
+        P11PROV_raise(pool->provctx, ret, "Max sessions (%d) exceeded",
                       pool->max_sessions);
         return ret;
     }


### PR DESCRIPTION
Just one more coverity fix after #162 was pushed.

The good news is that all the items coverity found about locking where intentional choices (like returning a locked object from a function which coverity flags as "forgot to unlock").

Only a printf format mistake remains.

