### PR TITLE
Eliminate use of asprintf

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -104,5 +104,6 @@ CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
                              CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data);
 CK_RV p11prov_copy_attr(CK_ATTRIBUTE *dst, CK_ATTRIBUTE *src);
 bool p11prov_x509_names_are_equal(CK_ATTRIBUTE *a, CK_ATTRIBUTE *b);
+char *p11prov_alloc_sprintf(int size_hint, const char *format, ...);
 
 #endif /* _UTIL_H */


### PR DESCRIPTION
Asprintf is convenient but causes mixing of OPENSSL and standard memory management in the code base which can quickly lead to bad problems, undetected until an application changes the openssl allocators.