### PR TITLE
Fix test as OpenSSL change output formatting

### DIFF
--- a/tests/tcerts
+++ b/tests/tcerts
@@ -8,8 +8,8 @@ title PARA "Check we can fetch certifiatce objects"
 
 ossl '
 x509 -in ${CRTURI} -subject -out ${TMPPDIR}/crt-subj.txt'
-DATA=$(cat ${TMPPDIR}/crt-subj.txt)
-CHECK="subject=O = PKCS11 Provider, CN = My Test Cert"
+DATA=$(cat ${TMPPDIR}/crt-subj.txt | sed -e 's/\ =\ /=/g')
+CHECK="subject=O=PKCS11 Provider, CN=My Test Cert"
 if [[ ! ${DATA} =~ ${CHECK} ]]; then
     echo "Cert not found looking for ${CHECK}"
     exit 1
@@ -17,8 +17,8 @@ fi
 
 ossl '
 x509 -in ${ECCRTURI} -subject -out ${TMPPDIR}/eccrt-subj.txt'
-DATA=$(cat ${TMPPDIR}/eccrt-subj.txt)
-CHECK="subject=O = PKCS11 Provider, CN = My EC Cert"
+DATA=$(cat ${TMPPDIR}/eccrt-subj.txt | sed -e 's/\ =\ /=/g')
+CHECK="subject=O=PKCS11 Provider, CN=My EC Cert"
 if [[ ! ${DATA} =~ ${CHECK} ]]; then
     echo "Cert not found looking for ${CHECK}"
     exit 1


### PR DESCRIPTION
For certs, at some point the master tree has changed the way Subjects are printed (remving spaces around the equal signs that separates attribute names from values in DNs).

Fix tests to cope with both older and newer formatting.