### PR TITLE
macOS build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,3 +64,54 @@ jobs:
           tests/tmp.${{ matrix.token }}/p11prov-debug.log
           tests/tmp.${{ matrix.token }}/testvars
           config.log
+  build-macos:
+    name: CI with software token
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-12]
+        token: [softokn, softhsm]
+    steps:
+    - name: Install Dependencies
+      run: |
+        brew update
+        brew install \
+          autoconf-archive \
+          automake \
+          libtool \
+          openssl@3 \
+          pkg-config
+        if [ "${{ matrix.token }}" = "softokn" ]; then
+          brew install nss
+        elif [ "${{ matrix.token }}" = "softhsm" ]; then
+          brew install \
+            opensc \
+            p11-kit \
+            softhsm
+        fi
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Setup
+      run: |
+        export PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig
+        export PATH=$(brew --prefix openssl@3)/bin:$PATH
+
+        autoreconf -fiv
+        CC=clang ./configure
+    - name: Build and Test
+      run: |
+        export PATH=$(brew --prefix openssl@3)/bin:$PATH
+
+        make -j$(sysctl -n hw.ncpu || echo 2)
+        make check
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: Test logs on macOS-12 with ${{ matrix.token }}
+        path: |
+          tests/*.log
+          tests/openssl.cnf
+          tests/tmp.${{ matrix.token }}/p11prov-debug.log
+          tests/tmp.${{ matrix.token }}/testvars
+          config.log

--- a/configure.ac
+++ b/configure.ac
@@ -95,8 +95,8 @@ PKG_CHECK_EXISTS(
         )]
 )
 
-AC_CHECK_FILE($SOFTOKENDIR/libsoftokn3.so, [],
-    [AC_CHECK_FILE($SOFTOKENDIR/nss/libsoftokn3.so,
+AC_CHECK_FILE($SOFTOKENDIR/libsoftokn3$SHARED_EXT, [],
+    [AC_CHECK_FILE($SOFTOKENDIR/nss/libsoftokn3$SHARED_EXT,
         [AC_SUBST([SOFTOKEN_SUBDIR], "nss/")],
         [AC_MSG_WARN([Softoken library missing, tests will fail!])])
     ])
@@ -108,6 +108,7 @@ PKG_CHECK_EXISTS([p11-kit-1],
                                 [p11_module_path])],
                  [AC_MSG_WARN([The p11-kit client not found. Can not run SoftHSM tests])])
 if test "$P11_MODULE_PATH" != "" ; then
+	# p11-kit-client is a module, so its name ends with .so also on macOS!
     AC_SUBST([P11KITCLIENTPATH], "$P11_MODULE_PATH/p11-kit-client.so")
 fi
 

--- a/src/provider.h
+++ b/src/provider.h
@@ -4,10 +4,14 @@
 #ifndef _PROVIDER_H
 #define _PROVIDER_H
 
-#define _XOPEN_SOURCE 500
+/* on macOS, snprintf and vsnprintf are in -D_XOPEN_SOURCE=600. This may be
+ * a bug in macOS' headers, or a deliberate choice because snprintf changed
+ * behavior with X/Open 6. */
+#define _XOPEN_SOURCE 600
 #include "config.h"
 
 #include <stdbool.h>
+#include <sys/types.h>
 
 #include "pkcs11.h"
 #include <openssl/core_dispatch.h>

--- a/src/session.c
+++ b/src/session.c
@@ -3,6 +3,7 @@
 
 #include "provider.h"
 #include <string.h>
+#include <sys/types.h>
 
 /* Slot stuff */
 struct p11prov_slot {

--- a/src/tls.c
+++ b/src/tls.c
@@ -178,7 +178,7 @@ struct {
 
 int tls_group_capabilities(OSSL_CALLBACK *cb, void *arg)
 {
-    for (int i = 0; tls_params[i].name != NULL; i++) {
+    for (size_t i = 0; i < sizeof(tls_params) / sizeof(*tls_params); i++) {
         int ret = cb(tls_params[i].list, arg);
         if (ret != RET_OSSL_OK) {
             return ret;

--- a/src/util.c
+++ b/src/util.c
@@ -2,6 +2,7 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include "provider.h"
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include "platform/endian.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,12 +30,14 @@ tmp.softokn:
 	LIBSPATH=$(libspath) \
 	TESTSSRCDIR=$(testssrcdir) \
 	TESTBLDDIR=$(testsblddir) \
+	SHARED_EXT=$(SHARED_EXT) \
 	SOFTOKNPATH="$(SOFTOKENDIR)/$(SOFTOKEN_SUBDIR)" \
 	$(testssrcdir)/setup-softokn.sh > setup-softokn.log 2>&1
 tmp.softhsm:
 	LIBSPATH=$(libspath) \
 	TESTSSRCDIR=$(testssrcdir) \
 	TESTBLDDIR=$(testsblddir) \
+	SHARED_EXT=$(SHARED_EXT) \
 	P11KITCLIENTPATH="$(P11KITCLIENTPATH)" \
 	$(testssrcdir)/setup-softhsm.sh > setup-softhsm.log 2>&1
 

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -20,7 +20,7 @@ activate = 1
 activate = 1
 
 [pkcs11_sect]
-module = @libtoollibs@/pkcs11.so
+module = @libtoollibs@/pkcs11@SHARED_EXT@
 pkcs11-module-init-args = configDir=@testsblddir@/tmp.softokn/tokens
 pkcs11-module-token-pin = file:@testsblddir@/pinfile.txt
 #pkcs11-module-allow-export

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -204,6 +204,7 @@ title LINE "Generate openssl config file"
 sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
     -e "s|@testssrcdir[@]|${BASEDIR}|g" \
     -e "s|@testsblddir@|${TESTBLDDIR}|g" \
+    -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
     -e "/pkcs11-module-init-args/d" \
     ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
 

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -28,7 +28,21 @@ find_softhsm() {
 }
 
 title SECTION "Searching for SoftHSM PKCS#11 library"
+# Attempt to guess the path to libsofthsm2.so relative to that. This fixes
+# auto-detection on platforms such as macOS with MacPorts (and potentially
+# Homebrew).
+#
+# This should never be empty, since we checked for the presence of
+# softhsm2-util above and use it below.
+
+# Strip bin/softhsm2-util
+softhsm_prefix=$(dirname "$(dirname "$(type -p softhsm2-util)")")
+
 find_softhsm \
+    "$softhsm_prefix/lib64/softhsm/libsofthsm2.so" \
+    "$softhsm_prefix/lib/softhsm/libsofthsm2.so" \
+    "$softhsm_prefix/lib64/pkcs11/libsofthsm2.so" \
+    "$softhsm_prefix/lib/pkcs11/libsofthsm2.so" \
     /usr/local/lib/softhsm/libsofthsm2.so \
     /usr/lib64/pkcs11/libsofthsm2.so \
     /usr/lib/pkcs11/libsofthsm2.so \

--- a/tests/setup-softokn.sh
+++ b/tests/setup-softokn.sh
@@ -157,12 +157,13 @@ title LINE "Generate openssl config file"
 sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
     -e "s|@testssrcdir[@]|${BASEDIR}|g" \
     -e "s|@testsblddir@|${TESTBLDDIR}|g" \
+    -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
     ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
 
 title LINE "Export tests variables to ${TMPPDIR}/testvars"
 cat > ${TMPPDIR}/testvars <<DBGSCRIPT
 export PKCS11_PROVIDER_DEBUG="file:${BASEDIR}/${TMPPDIR}/p11prov-debug.log"
-export PKCS11_PROVIDER_MODULE="${SOFTOKNPATH}/libsoftokn3.so"
+export PKCS11_PROVIDER_MODULE="${SOFTOKNPATH%%/}/libsoftokn3${SHARED_EXT}"
 export OPENSSL_CONF="${OPENSSL_CONF}"
 export TESTSSRCDIR="${TESTSSRCDIR}"
 export TESTBLDDIR="${TESTBLDDIR}"

--- a/tests/ttls.c
+++ b/tests/ttls.c
@@ -2,7 +2,32 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <openssl/ssl.h>
+#include <openssl/err.h>
+
+static void ossl_err_print(void)
+{
+    bool first = true;
+    unsigned long err = 0;
+    while (true) {
+        const char *file, *func, *data;
+        int line;
+        err = ERR_get_error_all(&file, &line, &func, &data, NULL);
+        if (err == 0) break;
+
+        char buf[1024];
+        ERR_error_string_n(err, buf, sizeof(buf));
+
+        const char *fmt =
+            first ? ": %s (in function %s in %s:%d): %s\n"
+                  : "  caused by: %s (in function %s in %s:%d): %s\n";
+        fprintf(stderr, fmt, buf, func, file, line, data);
+
+        first = false;
+    }
+    if (first) fprintf(stderr, "\n");
+}
 
 int main(int argc, char *argv[])
 {
@@ -11,6 +36,7 @@ int main(int argc, char *argv[])
     ctx = SSL_CTX_new(TLS_server_method());
     if (!ctx) {
         fprintf(stderr, "Failed to create SSL Context\n");
+        ossl_err_print();
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
macOS requires `_XOPEN_SOURCE=600` for snprintf(3) and vsnprintf(3). The previous value of `_XOPEN_SOURCE=500` hides the declaration.

`src/session.c` uses `ssize_t` which is in `sys/types.h` on macOS.

Also fix libsoftokn3 detection on macOS in configure.ac:

macOS uses `.dylib` as extension for shared libraries, but `.so` for loadable modules. NSS seems to treat libsoftokn3 as shared library, so it uses `.dylib`.

Autoconf has `$SHARED_EXT` for the platform-specific library suffix, so use that. Add a comment above `p11-kit-client.so` indicating that this is correct so we don't change it accidentally in the future.

See: #179