### PR TITLE
Simplify utulity to fetch attributes

### DIFF
--- a/src/kdf.c
+++ b/src/kdf.c
@@ -107,7 +107,6 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     CK_OBJECT_HANDLE pkey_handle;
     CK_OBJECT_HANDLE dkey_handle;
     CK_SLOT_ID slotid;
-    unsigned long dkey_len;
     struct fetch_attrs attrs[1];
     int num = 0;
     CK_RV ret;
@@ -155,11 +154,19 @@ static int p11prov_hkdf_derive(void *ctx, unsigned char *key, size_t keylen,
     }
 
     P11PROV_debug("HKDF derived hey handle: %lu", dkey_handle);
-    FA_SET_BUF_VAL(attrs, num, CKA_VALUE, key, dkey_len, false, true);
+    FA_SET_BUF_VAL(attrs, num, CKA_VALUE, key, keylen, true);
     ret = p11prov_fetch_attributes(hkdfctx->provctx, hkdfctx->session,
                                    dkey_handle, attrs, num);
     if (ret != CKR_OK) {
-        P11PROV_debug("hkdf failed to retrieve secret %lu", ret);
+        P11PROV_raise(hkdfctx->provctx, ret, "Failed to retrieve derived key");
+        return RET_OSSL_ERR;
+    }
+    FA_GET_LEN(attrs, 0, key_size);
+    if (key_size != keylen) {
+        ret = CKR_GENERAL_ERROR;
+        P11PROV_raise(hkdfctx->provctx, ret,
+                      "Expected derived key of len %lz, but got %lu", keylen,
+                      key_size);
         return RET_OSSL_ERR;
     }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -615,11 +615,12 @@ CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,
         if (ret != CKR_OK) {
             P11PROV_raise(ctx, ret, "Failed to probe quirk");
         } else if (token_supports_allowed_mechs == CK_TRUE) {
-            num = 0;
-            FA_SET_BUF_ALLOC(attrs, num, CKA_ALLOWED_MECHANISMS, false);
-            ret = p11prov_fetch_attributes(ctx, session, handle, attrs, num);
+            struct fetch_attrs a[1];
+            CK_ULONG an = 0;
+            FA_SET_BUF_ALLOC(a, an, CKA_ALLOWED_MECHANISMS, false);
+            ret = p11prov_fetch_attributes(ctx, session, handle, a, 1);
             if (ret == CKR_OK) {
-                CKATTR_MOVE(obj->attrs[obj->numattrs], attrs[0]);
+                obj->attrs[obj->numattrs] = a[0].attr;
                 obj->numattrs++;
             } else if (ret == CKR_ATTRIBUTE_TYPE_INVALID) {
                 token_supports_allowed_mechs = CK_FALSE;


### PR DESCRIPTION
REduce the size and reuse the CK_ATTRIBUTE structure within fetch_attrs to further simplify copying data between attribute storages when needed.

Also fix some checks in the derive key functions that I found wrong while refactoring.

Fixes #163 