### PR TITLE
Fix broken debug output to stderr

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -54,6 +54,9 @@ void p11prov_debug_init(void)
         if (dbg_level < 1) {
             dbg_level = 1;
         }
+        if (stddebug == NULL) {
+            stddebug = stderr;
+        }
     }
 
 done:


### PR DESCRIPTION
This fixes crash when debug log file is not specified in the `PKCS11_PROVIDER_DEBUG` environment variable (e.g. `PKCS11_PROVIDER_DEBUG=level:99`). The bug has been introduced in commit b39e45e9.