### PR TITLE
Delay pkcs11 module loading and initialization

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -253,7 +253,7 @@ CK_RV p11prov_module_new(P11PROV_CTX *ctx, const char *path,
 CK_RV p11prov_module_init(P11PROV_MODULE *mctx)
 {
     P11PROV_SLOTS_CTX *slots;
-    CK_C_INITIALIZE_ARGS args;
+    CK_C_INITIALIZE_ARGS args = { 0 };
     CK_INFO ck_info = { 0 };
     CK_RV ret;
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -127,7 +127,9 @@ static void populate_interface(P11PROV_INTERFACE *intf, CK_INTERFACE *ck_intf)
     ASSIGN_FN(GenerateKeyPair);
     ASSIGN_FN(DeriveKey);
     ASSIGN_FN(GenerateRandom);
-    ASSIGN_FN_3_0(GetInterface);
+    if (intf->version.major == 3) {
+        ASSIGN_FN_3_0(GetInterface);
+    }
 }
 
 CK_RV p11prov_interface_init(void *dlhandle, P11PROV_INTERFACE **interface,

--- a/src/interface.gen.c
+++ b/src/interface.gen.c
@@ -4,7 +4,11 @@
 CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Initialize");
     ret = intf->Initialize(pInitArgs);
@@ -19,7 +23,11 @@ CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs)
 CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Finalize");
     ret = intf->Finalize(pReserved);
@@ -34,7 +42,11 @@ CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved)
 CK_RV p11prov_GetInfo(P11PROV_CTX *ctx, CK_INFO_PTR pInfo)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetInfo");
     ret = intf->GetInfo(pInfo);
@@ -51,7 +63,11 @@ CK_RV p11prov_GetInterface(P11PROV_CTX *ctx, CK_UTF8CHAR_PTR pInterfaceName,
                            CK_INTERFACE_PTR_PTR ppInterface, CK_FLAGS flags)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetInterface");
     ret = intf->GetInterface(pInterfaceName, pVersion, ppInterface, flags);
@@ -67,7 +83,11 @@ CK_RV p11prov_GetFunctionList(P11PROV_CTX *ctx,
                               CK_FUNCTION_LIST_PTR_PTR ppFunctionList)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetFunctionList");
     ret = intf->GetFunctionList(ppFunctionList);
@@ -83,7 +103,11 @@ CK_RV p11prov_GetSlotList(P11PROV_CTX *ctx, CK_BBOOL tokenPresent,
                           CK_SLOT_ID_PTR pSlotList, CK_ULONG_PTR pulCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetSlotList");
     ret = intf->GetSlotList(tokenPresent, pSlotList, pulCount);
@@ -99,7 +123,11 @@ CK_RV p11prov_GetSlotInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
                           CK_SLOT_INFO_PTR pInfo)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetSlotInfo");
     ret = intf->GetSlotInfo(slotID, pInfo);
@@ -115,7 +143,11 @@ CK_RV p11prov_GetTokenInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
                            CK_TOKEN_INFO_PTR pInfo)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetTokenInfo");
     ret = intf->GetTokenInfo(slotID, pInfo);
@@ -132,7 +164,11 @@ CK_RV p11prov_GetMechanismList(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
                                CK_ULONG_PTR pulCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetMechanismList");
     ret = intf->GetMechanismList(slotID, pMechanismList, pulCount);
@@ -149,7 +185,11 @@ CK_RV p11prov_GetMechanismInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
                                CK_MECHANISM_INFO_PTR pInfo)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetMechanismInfo");
     ret = intf->GetMechanismInfo(slotID, type, pInfo);
@@ -166,7 +206,11 @@ CK_RV p11prov_OpenSession(P11PROV_CTX *ctx, CK_SLOT_ID slotID, CK_FLAGS flags,
                           CK_SESSION_HANDLE_PTR phSession)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "OpenSession");
     ret = intf->OpenSession(slotID, flags, pApplication, Notify, phSession);
@@ -181,7 +225,11 @@ CK_RV p11prov_OpenSession(P11PROV_CTX *ctx, CK_SLOT_ID slotID, CK_FLAGS flags,
 CK_RV p11prov_CloseSession(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "CloseSession");
     ret = intf->CloseSession(hSession);
@@ -197,7 +245,11 @@ CK_RV p11prov_GetSessionInfo(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                              CK_SESSION_INFO_PTR pInfo)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetSessionInfo");
     ret = intf->GetSessionInfo(hSession, pInfo);
@@ -214,7 +266,11 @@ CK_RV p11prov_GetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_ULONG_PTR pulOperationStateLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetOperationState");
     ret = intf->GetOperationState(hSession, pOperationState,
@@ -234,7 +290,11 @@ CK_RV p11prov_SetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_OBJECT_HANDLE hAuthenticationKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "SetOperationState");
     ret =
@@ -253,7 +313,11 @@ CK_RV p11prov_Login(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                     CK_ULONG ulPinLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Login");
     ret = intf->Login(hSession, userType, pPin, ulPinLen);
@@ -270,7 +334,11 @@ CK_RV p11prov_CreateObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                            CK_OBJECT_HANDLE_PTR phObject)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "CreateObject");
     ret = intf->CreateObject(hSession, pTemplate, ulCount, phObject);
@@ -287,7 +355,11 @@ CK_RV p11prov_CopyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                          CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phNewObject)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "CopyObject");
     ret = intf->CopyObject(hSession, hObject, pTemplate, ulCount, phNewObject);
@@ -303,7 +375,11 @@ CK_RV p11prov_DestroyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                             CK_OBJECT_HANDLE hObject)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DestroyObject");
     ret = intf->DestroyObject(hSession, hObject);
@@ -320,7 +396,11 @@ CK_RV p11prov_GetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GetAttributeValue");
     ret = intf->GetAttributeValue(hSession, hObject, pTemplate, ulCount);
@@ -337,7 +417,11 @@ CK_RV p11prov_SetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "SetAttributeValue");
     ret = intf->SetAttributeValue(hSession, hObject, pTemplate, ulCount);
@@ -353,7 +437,11 @@ CK_RV p11prov_FindObjectsInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                               CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "FindObjectsInit");
     ret = intf->FindObjectsInit(hSession, pTemplate, ulCount);
@@ -371,7 +459,11 @@ CK_RV p11prov_FindObjects(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                           CK_ULONG_PTR pulObjectCount)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "FindObjects");
     ret =
@@ -387,7 +479,11 @@ CK_RV p11prov_FindObjects(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
 CK_RV p11prov_FindObjectsFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "FindObjectsFinal");
     ret = intf->FindObjectsFinal(hSession);
@@ -403,7 +499,11 @@ CK_RV p11prov_EncryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                           CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "EncryptInit");
     ret = intf->EncryptInit(hSession, pMechanism, hKey);
@@ -421,7 +521,11 @@ CK_RV p11prov_Encrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                       CK_ULONG_PTR pulEncryptedDataLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Encrypt");
     ret = intf->Encrypt(hSession, pData, ulDataLen, pEncryptedData,
@@ -438,7 +542,11 @@ CK_RV p11prov_DecryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                           CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DecryptInit");
     ret = intf->DecryptInit(hSession, pMechanism, hKey);
@@ -455,7 +563,11 @@ CK_RV p11prov_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                       CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Decrypt");
     ret = intf->Decrypt(hSession, pEncryptedData, ulEncryptedDataLen, pData,
@@ -472,7 +584,11 @@ CK_RV p11prov_DigestInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                          CK_MECHANISM_PTR pMechanism)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DigestInit");
     ret = intf->DigestInit(hSession, pMechanism);
@@ -488,7 +604,11 @@ CK_RV p11prov_DigestUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                            CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DigestUpdate");
     ret = intf->DigestUpdate(hSession, pPart, ulPartLen);
@@ -504,7 +624,11 @@ CK_RV p11prov_DigestFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                           CK_BYTE_PTR pDigest, CK_ULONG_PTR pulDigestLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DigestFinal");
     ret = intf->DigestFinal(hSession, pDigest, pulDigestLen);
@@ -520,7 +644,11 @@ CK_RV p11prov_SignInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                        CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "SignInit");
     ret = intf->SignInit(hSession, pMechanism, hKey);
@@ -537,7 +665,11 @@ CK_RV p11prov_Sign(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                    CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Sign");
     ret = intf->Sign(hSession, pData, ulDataLen, pSignature, pulSignatureLen);
@@ -553,7 +685,11 @@ CK_RV p11prov_SignUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                          CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "SignUpdate");
     ret = intf->SignUpdate(hSession, pPart, ulPartLen);
@@ -569,7 +705,11 @@ CK_RV p11prov_SignFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                         CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "SignFinal");
     ret = intf->SignFinal(hSession, pSignature, pulSignatureLen);
@@ -585,7 +725,11 @@ CK_RV p11prov_VerifyInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                          CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "VerifyInit");
     ret = intf->VerifyInit(hSession, pMechanism, hKey);
@@ -602,7 +746,11 @@ CK_RV p11prov_Verify(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                      CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "Verify");
     ret = intf->Verify(hSession, pData, ulDataLen, pSignature, ulSignatureLen);
@@ -618,7 +766,11 @@ CK_RV p11prov_VerifyUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                            CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "VerifyUpdate");
     ret = intf->VerifyUpdate(hSession, pPart, ulPartLen);
@@ -634,7 +786,11 @@ CK_RV p11prov_VerifyFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                           CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "VerifyFinal");
     ret = intf->VerifyFinal(hSession, pSignature, ulSignatureLen);
@@ -653,7 +809,11 @@ CK_RV p11prov_GenerateKeyPair(
     CK_OBJECT_HANDLE_PTR phPublicKey, CK_OBJECT_HANDLE_PTR phPrivateKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GenerateKeyPair");
     ret = intf->GenerateKeyPair(hSession, pMechanism, pPublicKeyTemplate,
@@ -674,7 +834,11 @@ CK_RV p11prov_DeriveKey(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                         CK_OBJECT_HANDLE_PTR phKey)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "DeriveKey");
     ret = intf->DeriveKey(hSession, pMechanism, hBaseKey, pTemplate,
@@ -691,7 +855,11 @@ CK_RV p11prov_GenerateRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                              CK_BYTE_PTR RandomData, CK_ULONG ulRandomLen)
 {
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
-    CK_RV ret;
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
     P11PROV_debug("Calling C_"
                   "GenerateRandom");
     ret = intf->GenerateRandom(hSession, RandomData, ulRandomLen);

--- a/src/interface.h
+++ b/src/interface.h
@@ -5,9 +5,11 @@
 #define _INTERFACE_H
 
 /* interface declarations for PKCS#11 wrapper functions */
-CK_RV p11prov_interface_init(void *dlhandle, P11PROV_INTERFACE **interface,
-                             CK_FLAGS *interface_flags);
-void p11prov_interface_free(P11PROV_INTERFACE *interface);
+CK_RV p11prov_module_new(P11PROV_CTX *ctx, const char *path,
+                         const char *init_args, P11PROV_MODULE **_mctx);
+CK_RV p11prov_module_init(P11PROV_MODULE *mctx);
+P11PROV_INTERFACE *p11prov_module_get_interface(P11PROV_MODULE *mctx);
+void p11prov_module_free(P11PROV_MODULE *mctx);
 CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs);
 CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved);
 CK_RV p11prov_GetInfo(P11PROV_CTX *ctx, CK_INFO_PTR pInfo);

--- a/src/interface.pre
+++ b/src/interface.pre
@@ -5,7 +5,11 @@ BEGIN:
 
 #define IMPL_CALL_PROLOG(name) \
     P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx); \
-    CK_RV ret; \
+    CK_RV ret = CKR_GENERAL_ERROR; \
+    if (!intf) { \
+        P11PROV_raise(ctx, ret, "Can't get module interfaces"); \
+        return ret; \
+    } \
     P11PROV_debug("Calling C_" #name);
 #define IMPL_CALL_EPILOG(name) \
     if (ret != CKR_OK) { \

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -475,7 +475,15 @@ static const OSSL_PARAM *p11prov_rsa_gen_settable_params(void *genctx,
 
 static void *p11prov_rsa_new(void *provctx)
 {
+    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
+    CK_RV ret;
+
     P11PROV_debug("rsa new");
+
+    ret = p11prov_ctx_status(ctx);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
 
     return p11prov_obj_new(provctx, CK_UNAVAILABLE_INFORMATION,
                            CK_INVALID_HANDLE, CK_UNAVAILABLE_INFORMATION);
@@ -858,7 +866,16 @@ DISPATCH_KEYMGMT_FN(ec, gettable_params);
 
 static void *p11prov_ec_new(void *provctx)
 {
+    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
+    CK_RV ret;
+
     P11PROV_debug("ec new");
+
+    ret = p11prov_ctx_status(ctx);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
     return NULL;
 }
 
@@ -1176,7 +1193,16 @@ const void *p11prov_hkdf_static_ctx = NULL;
 
 static void *p11prov_hkdf_new(void *provctx)
 {
+    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
+    CK_RV ret;
+
     P11PROV_debug("hkdf keymgmt new");
+
+    ret = p11prov_ctx_status(ctx);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
+
     return (void *)&p11prov_hkdf_static_ctx;
 }
 

--- a/src/provider.h
+++ b/src/provider.h
@@ -56,6 +56,7 @@
 #define P11PROV_PARAM_SLOT_ID "pkcs11_slot_id"
 
 typedef struct p11prov_ctx P11PROV_CTX;
+typedef struct p11prov_module_ctx P11PROV_MODULE;
 typedef struct p11prov_interface P11PROV_INTERFACE;
 typedef struct p11prov_uri P11PROV_URI;
 typedef struct p11prov_obj P11PROV_OBJ;
@@ -65,11 +66,12 @@ typedef struct p11prov_session P11PROV_SESSION;
 typedef struct p11prov_session_pool P11PROV_SESSION_POOL;
 
 /* Provider ctx */
-struct p11prov_interface *p11prov_ctx_get_interface(P11PROV_CTX *ctx);
+P11PROV_INTERFACE *p11prov_ctx_get_interface(P11PROV_CTX *ctx);
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_status(P11PROV_CTX *ctx);
 P11PROV_SLOTS_CTX *p11prov_ctx_get_slots(P11PROV_CTX *ctx);
+void p11prov_ctx_set_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX *slots);
 CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
                             void **data, CK_ULONG *size);
 CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,

--- a/src/store.c
+++ b/src/store.c
@@ -159,25 +159,31 @@ DISPATCH_STORE_FN(settable_ctx_params);
 static void *p11prov_store_open(void *pctx, const char *uri)
 {
     struct p11prov_store_ctx *ctx = NULL;
-    CK_RV result = CKR_CANCEL;
+    P11PROV_CTX *provctx = (P11PROV_CTX *)pctx;
+    CK_RV ret = CKR_CANCEL;
 
     P11PROV_debug("object open (%p, %s)", pctx, uri);
+
+    ret = p11prov_ctx_status(provctx);
+    if (ret != CKR_OK) {
+        return NULL;
+    }
 
     ctx = OPENSSL_zalloc(sizeof(struct p11prov_store_ctx));
     if (ctx == NULL) {
         return NULL;
     }
-    ctx->provctx = (P11PROV_CTX *)pctx;
+    ctx->provctx = provctx;
 
     ctx->parsed_uri = p11prov_parse_uri(ctx->provctx, uri);
     if (ctx->parsed_uri == NULL) {
         goto done;
     }
 
-    result = CKR_OK;
+    ret = CKR_OK;
 
 done:
-    if (result != CKR_OK) {
+    if (ret != CKR_OK) {
         p11prov_store_ctx_free(ctx);
         ctx = NULL;
     }


### PR DESCRIPTION
This patchset delays pkcs11 modules initialization until an application actually causes openssl to try to use pkcs11-provider for some operation.

This requires to make keymgmt static, because keymgm and store interfaces can be called directly by openssl before any other fnction causes module initialization.

All direct entrypoints now must call pkcs11_ctx_status() which causes module intialization and returns an error if it fails.

Fixes #187