### PR TITLE
Add early load behavior configuration and test it

### DIFF
--- a/src/provider.h
+++ b/src/provider.h
@@ -35,6 +35,7 @@
 #define P11PROV_PKCS11_MODULE_TOKEN_PIN "pkcs11-module-token-pin"
 #define P11PROV_PKCS11_MODULE_ALLOW_EXPORT "pkcs11-module-allow-export"
 #define P11PROV_PKCS11_MODULE_LOGIN_BEHAVIOR "pkcs11-module-login-behavior"
+#define P11PROV_PKCS11_MODULE_LOAD_BEHAVIOR "pkcs11-module-load-behavior"
 
 #define P11PROV_DEFAULT_PROPERTIES "provider=pkcs11"
 #define P11PROV_NAME_RSA "RSA"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,7 +44,7 @@ tmp.softhsm:
 dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
 	test-wrapper tbasic tcerts tecc tecdh tedwards tdemoca thkdf \
-	toaepsha2 trsapss
+	toaepsha2 trsapss tdigest
 
 test_LIST = \
 	basic-softokn basic-softhsm-proxy \
@@ -53,10 +53,10 @@ test_LIST = \
 	edwards-softhsm-proxy \
 	ecdh-softokn \
 	democa-softokn democa-softhsm-proxy \
+	digest-softokn digest-softhsm-proxy \
 	oaepsha2-softokn \
 	hkdf-softokn \
 	rsapss-softokn \
-	digests-softokn digests-softhsm-proxy \
 	genkey-softokn genkey-softhsm \
 	session-softokn session-softhsm-proxy \
 	readkeys-softokn readkeys-softhsm-proxy \

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -24,6 +24,7 @@ module = @libtoollibs@/pkcs11@SHARED_EXT@
 pkcs11-module-init-args = configDir=@testsblddir@/tmp.softokn/tokens
 pkcs11-module-token-pin = file:@testsblddir@/pinfile.txt
 #pkcs11-module-allow-export
+#pkcs11-module-load-behavior
 activate = 1
 
 ####################################################################

--- a/tests/tdigest
+++ b/tests/tdigest
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source ${TESTSSRCDIR}/helpers.sh
+
+# We need to configure early loading otherwise no digests are loaded,
+# and all checks are skipped
+sed "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.early_load
+OPENSSL_CONF=${OPENSSL_CONF}.early_load
+
+title PARA "Test Digests support"
+./tdigests
+
+exit 0


### PR DESCRIPTION
This deals with the delayed initialization issue and the tdigests test, by adding an option to bring back early initialization.

I tried to deal with dynamic loading of digests by providing a static set of digests always but asking openssl not to cache the provided digests in p11prov_query_operation() by setting no_cache = 1, but this seemed not only to cache the digest alogotihms, insuring the dynamically loaded once would be completely ignored, but also result in these digest algorithms being preferred to the default module digests.

The exact opposite of what we wanted to have.

Fixes #211 

