### PR TITLE
Add a quirk to prevent calling the module on exit

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -436,7 +436,12 @@ CK_RV p11prov_slot_get_obj_pool(P11PROV_CTX *ctx, CK_SLOT_ID id,
     if (!slot) {
         ret = CKR_SLOT_ID_INVALID;
     } else {
-        *pool = slot->objects;
+        if (slot->objects) {
+            *pool = slot->objects;
+            ret = CKR_OK;
+        } else {
+            ret = CKR_GENERAL_ERROR;
+        }
     }
 
     p11prov_return_slots(sctx);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,22 +55,22 @@ dist_check_SCRIPTS = \
 	toaepsha2 trsapss tdigest ttls tpubkey tfork
 
 test_LIST = \
-	basic-softokn basic-softhsm-proxy \
-	pubkey-softokn pubkey-softhsm-proxy \
-	certs-softokn certs-softhsm-proxy \
-	ecc-softokn ecc-softhsm-proxy \
-	edwards-softhsm-proxy \
+	basic-softokn basic-softhsm \
+	pubkey-softokn pubkey-softhsm \
+	certs-softokn certs-softhsm \
+	ecc-softokn ecc-softhsm \
+	edwards-softhsm \
 	ecdh-softokn \
-	democa-softokn democa-softhsm-proxy \
-	digest-softokn digest-softhsm-proxy \
-	fork-softokn fork-softhsm-proxy \
+	democa-softokn democa-softhsm \
+	digest-softokn digest-softhsm \
+	fork-softokn fork-softhsm \
 	oaepsha2-softokn \
 	hkdf-softokn \
 	rsapss-softokn \
 	genkey-softokn genkey-softhsm \
-	session-softokn session-softhsm-proxy \
-	readkeys-softokn readkeys-softhsm-proxy \
-	tls-softokn tls-softhsm-proxy
+	session-softokn session-softhsm \
+	readkeys-softokn readkeys-softhsm \
+	tls-softokn tls-softhsm
 
 .PHONY: $(test_LIST)
 

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -25,6 +25,7 @@ pkcs11-module-init-args = configDir=@testsblddir@/tmp.softokn/tokens
 pkcs11-module-token-pin = file:@testsblddir@/pinfile.txt
 #pkcs11-module-allow-export
 #pkcs11-module-load-behavior
+##QUIRKS
 activate = 1
 
 ####################################################################

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -321,6 +321,7 @@ sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
     -e "s|@testsblddir@|${TESTBLDDIR}|g" \
     -e "s|@testsdir[@]|${BASEDIR}/${TMPPDIR}|g" \
     -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
+    -e "s|##QUIRKS|pkcs11-module-quirks = no-deinit|g" \
     -e "/pkcs11-module-init-args/d" \
     ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
 


### PR DESCRIPTION
This allows to avoid some issues with bad modules that link into openssl or have atexit() handlers that interfere with graceful shutdown.'

Tested against the YubiHSM pkcs#11 driver which hangs and another vendor cloud HSM driver which segfaults.