### PR TITLE
Support OSSL_PKEY_PARAM_DEFAULT/MANDATORY_DIGEST

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -5,6 +5,8 @@
 #include "platform/endian.h"
 #include <string.h>
 
+#define DFLT_DIGEST "SHA256"
+
 DISPATCH_KEYMGMT_FN(common, gen_set_params);
 DISPATCH_KEYMGMT_FN(common, gen_cleanup);
 
@@ -716,6 +718,13 @@ static int p11prov_rsa_get_params(void *keydata, OSSL_PARAM params[])
             return ret;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DEFAULT_DIGEST);
+    if (p) {
+        ret = OSSL_PARAM_set_utf8_string(p, DFLT_DIGEST);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -726,9 +735,11 @@ static const OSSL_PARAM *p11prov_rsa_gettable_params(void *provctx)
         OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
-        /* OSSL_PKEY_PARAM_DEFAULT_DIGEST,
-         * OSSL_PKEY_PARAM_RSA_N,
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_DEFAULT_DIGEST, NULL, 0),
+        /* OSSL_PKEY_PARAM_RSA_N,
          * OSSL_PKEY_PARAM_RSA_E, */
+        /* PKCS#11 does not have restrictions associated to keys so
+         * we can't support OSSL_PKEY_PARAM_MANDATORY_DIGEST yet */
         OSSL_PARAM_END,
     };
     return params;
@@ -1139,6 +1150,13 @@ static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
             return ret;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DEFAULT_DIGEST);
+    if (p) {
+        ret = OSSL_PARAM_set_utf8_string(p, DFLT_DIGEST);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -1150,7 +1168,8 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
         OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
-        /* OSSL_PKEY_PARAM_DEFAULT_DIGEST
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_DEFAULT_DIGEST, NULL, 0),
+        /*
          * OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY
          * OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAM
          * OSSL_PKEY_PARAM_EC_ENCODING
@@ -1396,6 +1415,13 @@ static int p11prov_ed_get_params(void *keydata, OSSL_PARAM params[])
             return ret;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_MANDATORY_DIGEST);
+    if (p) {
+        ret = OSSL_PARAM_set_utf8_string(p, "");
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -1407,6 +1433,7 @@ static const OSSL_PARAM *p11prov_ed_gettable_params(void *provctx)
         OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
         OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_MANDATORY_DIGEST, NULL, 0),
         OSSL_PARAM_END,
     };
     return params;

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -20,12 +20,6 @@ if [ $FAIL -eq 1 ]; then
     exit 1
 fi
 
-
-# FIXME: Currently not test backend supports CKM_EDDSA
-# SoftHSM does support it with Ed25519, but the p11-proxy we have to use to
-# avoid segfaults in the destructors does not support proxying CKM_EDDSA
-exit 0
-
 title PARA "DigestSign and DigestVerify with ED25519"
 ossl '
 pkeyutl -sign -inkey "${EDBASEURI}"


### PR DESCRIPTION
This is needed to inform OpenSSL that EDDSA must not use a digest, and also allow openssl to inquire what the default digest is, if any.