### PR TITLE
Fix SoftHSM issues wth PSS keys

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -432,7 +432,7 @@ static CK_RV p11prov_sig_pss_restrictions(P11PROV_SIG_CTX *sigctx,
 
     if (allowed_mechs) {
         CK_ATTRIBUTE_TYPE *mechs = (CK_ATTRIBUTE_TYPE *)allowed_mechs->pValue;
-        int num_mechs = allowed_mechs->ulValueLen;
+        int num_mechs = allowed_mechs->ulValueLen / sizeof(CK_MECHANISM_TYPE);
         bool allowed = false;
 
         if (num_mechs == 0) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -435,6 +435,14 @@ static CK_RV p11prov_sig_pss_restrictions(P11PROV_SIG_CTX *sigctx,
         int num_mechs = allowed_mechs->ulValueLen;
         bool allowed = false;
 
+        if (num_mechs == 0) {
+            /* It makes no sense to return 0 allowed mechanisms for a key,
+             * this just means the token is bogus, let's ignore the check
+             * and try the operation and see what happens */
+            P11PROV_debug("Buggy CKA_ALLOWED_MECHANISMS implementation");
+            return CKR_OK;
+        }
+
         for (int i = 0; i < num_mechs; i++) {
             if (mechs[i] == mechanism->mechanism) {
                 allowed = true;

--- a/src/util.c
+++ b/src/util.c
@@ -20,6 +20,8 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     CK_RV ret;
 
     for (size_t i = 0; i < attrnums; i++) {
+        P11PROV_debug("Fetching attributes (%d): 0x%08x", i,
+                      attrs[i].attr.type);
         q[i] = attrs[i].attr;
     }
 
@@ -56,7 +58,13 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
             attrs[i].attr = q[i];
         }
         if (retrnums > 0) {
+            P11PROV_debug("(Re)Fetching %d attributes", retrnums);
             ret = p11prov_GetAttributeValue(ctx, sess, object, r, retrnums);
+        }
+        for (size_t i = 0; i < attrnums; i++) {
+            P11PROV_debug("Attribute| type:0x%08lX value:%p, len:%lu",
+                          attrs[i].attr.type, attrs[i].attr.pValue,
+                          attrs[i].attr.ulValueLen);
         }
     } else if (attrnums > 1
                && (ret == CKR_ATTRIBUTE_SENSITIVE

--- a/tests/ttls
+++ b/tests/ttls
@@ -18,7 +18,7 @@ exec 3<>${TMPPDIR}/s_server_input
 #Make sure we terminate programs if test fails in the middle
 trap 'jobs -p | xargs -r kill >/dev/null 2>&1 || true' EXIT
 
-openssl s_server -accept 12345 -key ${ECPRIURI} -cert ${ECCRTURI} <&3 &
+openssl s_server -accept 12345 -key ${PRIURI} -cert ${CRTURI} <&3 &
 
 # Wait a sec to make sure server is up before client tries to connect
 sleep 0.5

--- a/tests/ttls
+++ b/tests/ttls
@@ -15,6 +15,9 @@ rm -f ${TMPPDIR}/s_server_output
 mkfifo ${TMPPDIR}/s_server_input
 exec 3<>${TMPPDIR}/s_server_input
 
+#Make sure we terminate programs if test fails in the middle
+trap 'jobs -p | xargs -r kill >/dev/null 2>&1 || true' EXIT
+
 openssl s_server -accept 12345 -key ${ECPRIURI} -cert ${ECCRTURI} <&3 &
 
 # Wait a sec to make sure server is up before client tries to connect


### PR DESCRIPTION
Looks like SoftHSM sometimes returns an empty CKA_ALLOWED_MECHANISMS attributes, which clearly makes no sense.

For right now we work around this, if no mechanisms are really allowed a following operation will simply fail anyway.

Fixes #217 