### PR TITLE
Improve URI management

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -99,7 +99,7 @@ static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
     P11PROV_OBJ *key = (P11PROV_OBJ *)inkey;
     CK_KEY_TYPE type;
     CK_ULONG keysize;
-    CK_ATTRIBUTE *a;
+    char *uri = NULL;
     BIO *out;
     int ret;
 
@@ -137,14 +137,9 @@ static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
         }
     }
 
-    a = p11prov_obj_get_attr(key, CKA_ID);
-    if (a) {
-        BIO_printf(out, "Key ID:\n");
-        ASN1_buf_print(out, a->pValue, a->ulValueLen, 4);
-    }
-    a = p11prov_obj_get_attr(key, CKA_LABEL);
-    if (a) {
-        BIO_printf(out, "Label: %*s\n", (int)a->ulValueLen, (char *)a->pValue);
+    uri = p11prov_key_to_uri(ctx->provctx, key);
+    if (uri) {
+        BIO_printf(out, "URI %s\n", uri);
     }
 
     BIO_free(out);
@@ -727,7 +722,7 @@ static int p11prov_ec_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
     P11PROV_OBJ *key = (P11PROV_OBJ *)inkey;
     CK_KEY_TYPE type;
     CK_ULONG keysize;
-    CK_ATTRIBUTE *a;
+    char *uri = NULL;
     BIO *out;
     int ret;
 
@@ -764,16 +759,12 @@ static int p11prov_ec_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
         }
     }
 
-    a = p11prov_obj_get_attr(key, CKA_ID);
-    if (a) {
-        BIO_printf(out, "Key ID:\n");
-        ASN1_buf_print(out, a->pValue, a->ulValueLen, 4);
-    }
-    a = p11prov_obj_get_attr(key, CKA_LABEL);
-    if (a) {
-        BIO_printf(out, "Label: %*s\n", (int)a->ulValueLen, (char *)a->pValue);
+    uri = p11prov_key_to_uri(ctx->provctx, key);
+    if (uri) {
+        BIO_printf(out, "URI %s\n", uri);
     }
 
+    OPENSSL_free(uri);
     BIO_free(out);
     return RET_OSSL_OK;
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -925,11 +925,11 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
         /* nothing to find for us */
         return CKR_OK;
     }
-    if (id.pValue != NULL) {
+    if (id.ulValueLen != 0) {
         template[tsize] = id;
         tsize++;
     }
-    if (label.pValue != NULL) {
+    if (label.ulValueLen != 0) {
         template[tsize] = label;
         tsize++;
     }
@@ -1011,7 +1011,7 @@ static P11PROV_OBJ *find_associated_obj(P11PROV_CTX *provctx, P11PROV_OBJ *obj,
     P11PROV_debug("Find associated object");
 
     id = p11prov_obj_get_attr(obj, CKA_ID);
-    if (!id) {
+    if (!id || id->ulValueLen == 0) {
         P11PROV_raise(provctx, CKR_GENERAL_ERROR, "No CKA_ID in source object");
         goto done;
     }

--- a/src/objects.c
+++ b/src/objects.c
@@ -925,11 +925,11 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
         /* nothing to find for us */
         return CKR_OK;
     }
-    if (id.type == CKA_ID) {
+    if (id.pValue != NULL) {
         template[tsize] = id;
         tsize++;
     }
-    if (label.type == CKA_LABEL) {
+    if (label.pValue != NULL) {
         template[tsize] = label;
         tsize++;
     }

--- a/src/provider.c
+++ b/src/provider.c
@@ -1288,7 +1288,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
     }
 
     if (cfg[P11PROV_CFG_TOKEN_PIN] != NULL) {
-        ret = p11prov_get_pin(cfg[P11PROV_CFG_TOKEN_PIN], &ctx->pin);
+        ret = p11prov_get_pin(ctx, cfg[P11PROV_CFG_TOKEN_PIN], &ctx->pin);
         if (ret != 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_IN_ERROR_STATE);
             p11prov_ctx_free(ctx);

--- a/src/provider.h
+++ b/src/provider.h
@@ -4,10 +4,8 @@
 #ifndef _PROVIDER_H
 #define _PROVIDER_H
 
-/* on macOS, snprintf and vsnprintf are in -D_XOPEN_SOURCE=600. This may be
- * a bug in macOS' headers, or a deliberate choice because snprintf changed
- * behavior with X/Open 6. */
-#define _XOPEN_SOURCE 600
+/* We need at least -D_XOPEN_SOURCE=700 for strnlen. */
+#define _XOPEN_SOURCE 700
 #include "config.h"
 
 #include <stdbool.h>

--- a/src/session.c
+++ b/src/session.c
@@ -479,7 +479,7 @@ static CK_RV check_slot(P11PROV_CTX *ctx, P11PROV_SLOT *slot, P11PROV_URI *uri,
                         CK_MECHANISM_TYPE mechtype, bool rw)
 {
     CK_TOKEN_INFO *token;
-    CK_FLAGS slot_flags;
+    CK_SLOT_INFO *ck_slot;
     CK_SLOT_ID slotid;
     CK_RV ret;
 
@@ -488,8 +488,8 @@ static CK_RV check_slot(P11PROV_CTX *ctx, P11PROV_SLOT *slot, P11PROV_URI *uri,
     P11PROV_debug("Checking Slot id=%lu, uri=%p, mechtype=%lx, rw=%s)", slotid,
                   uri, mechtype, rw ? "true" : "false");
 
-    slot_flags = p11prov_slot_get_slot_flags(slot);
-    if ((slot_flags & CKF_TOKEN_PRESENT) == 0) {
+    ck_slot = p11prov_slot_get_slot(slot);
+    if ((ck_slot->flags & CKF_TOKEN_PRESENT) == 0) {
         return CKR_TOKEN_NOT_PRESENT;
     }
     token = p11prov_slot_get_token(slot);
@@ -500,8 +500,7 @@ static CK_RV check_slot(P11PROV_CTX *ctx, P11PROV_SLOT *slot, P11PROV_URI *uri,
         return CKR_TOKEN_WRITE_PROTECTED;
     }
     if (uri) {
-        /* skip slots that do not match */
-        ret = p11prov_uri_match_token(uri, token);
+        ret = p11prov_uri_match_token(uri, slotid, ck_slot, token);
         if (ret != CKR_OK) {
             return ret;
         }

--- a/src/slot.c
+++ b/src/slot.c
@@ -376,6 +376,16 @@ P11PROV_SLOT *p11prov_fetch_slot(P11PROV_SLOTS_CTX *sctx, int *idx)
     return sctx->slots[i];
 }
 
+P11PROV_SLOT *p11prov_get_slot_by_id(P11PROV_SLOTS_CTX *sctx, CK_SLOT_ID id)
+{
+    for (int s = 0; s < sctx->num; s++) {
+        if (sctx->slots[s]->id == id) {
+            return sctx->slots[s];
+        }
+    }
+    return NULL;
+}
+
 int p11prov_slot_get_mechanisms(P11PROV_SLOT *slot, CK_MECHANISM_TYPE **mechs)
 {
     if (!slot) {

--- a/src/slot.c
+++ b/src/slot.c
@@ -463,9 +463,9 @@ CK_SLOT_ID p11prov_slot_get_slot_id(P11PROV_SLOT *slot)
     return slot->id;
 }
 
-CK_FLAGS p11prov_slot_get_slot_flags(P11PROV_SLOT *slot)
+CK_SLOT_INFO *p11prov_slot_get_slot(P11PROV_SLOT *slot)
 {
-    return slot->slot.flags;
+    return &slot->slot;
 }
 
 CK_TOKEN_INFO *p11prov_slot_get_token(P11PROV_SLOT *slot)

--- a/src/slot.h
+++ b/src/slot.h
@@ -20,7 +20,7 @@ int p11prov_check_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID id,
 CK_RV p11prov_slot_get_obj_pool(P11PROV_CTX *provctx, CK_SLOT_ID id,
                                 P11PROV_OBJ_POOL **pool);
 CK_SLOT_ID p11prov_slot_get_slot_id(P11PROV_SLOT *slot);
-CK_FLAGS p11prov_slot_get_slot_flags(P11PROV_SLOT *slot);
+CK_SLOT_INFO *p11prov_slot_get_slot(P11PROV_SLOT *slot);
 CK_TOKEN_INFO *p11prov_slot_get_token(P11PROV_SLOT *slot);
 const char *p11prov_slot_get_login_info(P11PROV_SLOT *slot);
 const char *p11prov_slot_get_bad_pin(P11PROV_SLOT *slot);

--- a/src/slot.h
+++ b/src/slot.h
@@ -13,6 +13,7 @@ void p11prov_slot_fork_reset(P11PROV_SLOTS_CTX *sctx);
 CK_RV p11prov_take_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots);
 void p11prov_return_slots(P11PROV_SLOTS_CTX *slots);
 P11PROV_SLOT *p11prov_fetch_slot(P11PROV_SLOTS_CTX *sctx, int *idx);
+P11PROV_SLOT *p11prov_get_slot_by_id(P11PROV_SLOTS_CTX *sctx, CK_SLOT_ID id);
 int p11prov_slot_get_mechanisms(P11PROV_SLOT *slot, CK_MECHANISM_TYPE **mechs);
 int p11prov_check_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID id,
                             CK_MECHANISM_TYPE mechtype);

--- a/src/util.c
+++ b/src/util.c
@@ -537,6 +537,7 @@ P11PROV_URI *p11prov_parse_uri(P11PROV_CTX *ctx, const char *uri)
 {
     struct p11prov_uri u = {
         .type = CK_UNAVAILABLE_INFORMATION,
+        .slot_id = CK_UNAVAILABLE_INFORMATION,
         .id = { .type = CKA_ID },
         .object = { .type = CKA_LABEL },
     };
@@ -829,8 +830,27 @@ char *p11prov_uri_get_pin(P11PROV_URI *uri)
     return uri->pin;
 }
 
-CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token)
+CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_SLOT_ID slot_id,
+                              CK_SLOT_INFO *slot, CK_TOKEN_INFO *token)
 {
+    if (uri->slot_id != CK_UNAVAILABLE_INFORMATION && uri->slot_id != slot_id) {
+        return CKR_CANCEL;
+    }
+
+    if (uri->slot_description
+        && strncmp(uri->slot_description, (const char *)slot->slotDescription,
+                   64)
+               != 0) {
+        return CKR_CANCEL;
+    }
+
+    if (uri->slot_manufacturer
+        && strncmp(uri->slot_manufacturer, (const char *)slot->manufacturerID,
+                   32)
+               != 0) {
+        return CKR_CANCEL;
+    }
+
     if (uri->model
         && strncmp(uri->model, (const char *)token->model, 16) != 0) {
         return CKR_CANCEL;

--- a/src/util.c
+++ b/src/util.c
@@ -20,7 +20,7 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     CK_RV ret;
 
     for (size_t i = 0; i < attrnums; i++) {
-        P11PROV_debug("Fetching attributes (%d): 0x%08x", i,
+        P11PROV_debug("Fetching attributes (%d): 0x%08lx", (int)i,
                       attrs[i].attr.type);
         q[i] = attrs[i].attr;
     }
@@ -58,7 +58,7 @@ CK_RV p11prov_fetch_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
             attrs[i].attr = q[i];
         }
         if (retrnums > 0) {
-            P11PROV_debug("(Re)Fetching %d attributes", retrnums);
+            P11PROV_debug("(Re)Fetching %lu attributes", retrnums);
             ret = p11prov_GetAttributeValue(ctx, sess, object, r, retrnums);
         }
         for (size_t i = 0; i < attrnums; i++) {

--- a/src/util.h
+++ b/src/util.h
@@ -60,7 +60,7 @@ CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri);
 char *p11prov_uri_get_serial(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
-int p11prov_get_pin(const char *in, char **out);
+int p11prov_get_pin(P11PROV_CTX *ctx, const char *in, char **out);
 bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
                             uint64_t *start_time);
 #define GET_ATTR 0

--- a/src/util.h
+++ b/src/util.h
@@ -53,6 +53,7 @@ void p11prov_fetch_attrs_free(struct fetch_attrs *attrs, int num);
 
 #define MAX_PIN_LENGTH 32
 P11PROV_URI *p11prov_parse_uri(P11PROV_CTX *ctx, const char *uri);
+char *p11prov_key_to_uri(P11PROV_CTX *ctx, P11PROV_OBJ *key);
 void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);

--- a/src/util.h
+++ b/src/util.h
@@ -60,7 +60,8 @@ CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
 CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri);
 char *p11prov_uri_get_serial(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
-CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_TOKEN_INFO *token);
+CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_SLOT_ID slot_id,
+                              CK_SLOT_INFO *slot, CK_TOKEN_INFO *token);
 int p11prov_get_pin(P11PROV_CTX *ctx, const char *in, char **out);
 bool cyclewait_with_timeout(uint64_t max_wait, uint64_t interval,
                             uint64_t *start_time);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -52,7 +52,7 @@ tmp.softhsm:
 dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
 	test-wrapper tbasic tcerts tecc tecdh tedwards tdemoca thkdf \
-	toaepsha2 trsapss tdigest ttls tpubkey tfork
+	toaepsha2 trsapss tdigest ttls tpubkey tfork turi
 
 test_LIST = \
 	basic-softokn basic-softhsm \
@@ -70,7 +70,8 @@ test_LIST = \
 	genkey-softokn genkey-softhsm \
 	session-softokn session-softhsm \
 	readkeys-softokn readkeys-softhsm \
-	tls-softokn tls-softhsm
+	tls-softokn tls-softhsm \
+	uri-softokn uri-softhsm
 
 .PHONY: $(test_LIST)
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -38,17 +38,19 @@ cleanup_server()
     kill -9 -- $2
 }
 
+helper_emit=1
+
 ossl()
 {
-    local __output=$2
+    helper_output=""
     echo "# r "$1 >> ${TMPPDIR}/gdb-commands.txt
     echo openssl $1
     __out=$(eval openssl $1)
     __res=$?
-    if [[ "$__output" ]]; then
-        eval $__output="'$__out'"
+    if [ $2 -eq $helper_emit ]; then
+        helper_output="$__out"
     else
-        echo $__out
+        echo "$__out"
     fi
     return $__res
 }

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -86,7 +86,8 @@ title PARA "Test Disallow Public Export"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
 sed "s/#pkcs11-module-allow-export/pkcs11-module-allow-export = 1/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.noexport
 OPENSSL_CONF=${OPENSSL_CONF}.noexport
-ossl 'pkey -in $PUBURI -pubin -pubout -text' output
+ossl 'pkey -in $PUBURI -pubin -pubout -text' $helper_emit
+output="$helper_output"
 FAIL=0
 echo "$output" | grep "^PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -ne 0 ]; then

--- a/tests/tecc
+++ b/tests/tecc
@@ -7,7 +7,8 @@ source ${TESTSSRCDIR}/helpers.sh
 title PARA "Export EC Public key to a file"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ecout.pub'
 title LINE "Print EC Public key from private"
-ossl 'pkey -in $ECPRIURI -pubout -text' output
+ossl 'pkey -in $ECPRIURI -pubout -text' $helper_emit
+output="$helper_output"
 FAIL=0
 echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -8,7 +8,8 @@ title PARA "Export ED25519 Public key to a file"
 ossl 'pkey -in $EDPUBURI -pubin -pubout -out ${TMPPDIR}/edout.pub'
 
 title LINE "Print ED25519 Public key from private"
-ossl 'pkey -in $EDPRIURI -pubout -text' output
+ossl 'pkey -in $EDPRIURI -pubout -text' $helper_emit
+output="$helper_output"
 FAIL=0
 echo $output | grep "ED25519 Public-Key" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then

--- a/tests/tpubkey
+++ b/tests/tpubkey
@@ -9,7 +9,8 @@ ossl 'pkey -in $BASEURI -pubin -pubout -out ${TMPPDIR}/baseout.pub'
 title LINE "Export Public key to a file (pub-uri)"
 ossl 'pkey -in $PUBURI -pubin -pubout -out ${TMPPDIR}/pubout.pub'
 title LINE "Print Public key from private"
-ossl 'pkey -in $PRIURI -pubout -text' output
+ossl 'pkey -in $PRIURI -pubout -text' $helper_emit
+output="$helper_output"
 FAIL=0
 echo $output | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
@@ -35,7 +36,8 @@ ossl 'pkey -in $ECBASEURI -pubin -pubout -out ${TMPPDIR}/baseecout.pub'
 title LINE "Export EC Public key to a file (pub-uri)"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/pubecout.pub'
 title LINE "Print EC Public key from private"
-ossl 'pkey -in $ECPRIURI -pubout -text' output
+ossl 'pkey -in $ECPRIURI -pubout -text' $helper_emit
+output="$helper_output"
 FAIL=0
 echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then

--- a/tests/turi
+++ b/tests/turi
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+# Copyright (C) 2023 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source ${TESTSSRCDIR}/helpers.sh
+
+title PARA "Check that storeutl returns URIs"
+ossl 'storeutl -text pkcs11:' $helper_emit
+output="$helper_output"
+FAIL=0
+echo "$output" | grep "URI pkcs11:" > /dev/null 2>&1 || FAIL=1
+if [ $FAIL -ne 0 ]; then
+    echo "no URIs returned by storeutl"
+    exit 1
+fi
+
+URISonly=$(echo "$helper_output" | grep "^URI")
+URIS=(${URISonly//URI / })
+
+title PARA "Check returned URIs work to find objects"
+for uri in "${URIS[@]#URI }"; do
+    echo "\$uri=${uri}"
+    ossl 'storeutl -text "$uri"' $helper_emit
+    output="$helper_output"
+    matchURI=`echo "$output" | grep "URI pkcs11:" | cut -d ' ' -f 2`
+    if [[ "${uri}" != "${matchURI}" ]]; then
+        echo "Unmatched URI returned by storeutl"
+        echo "Expected $uri"
+        echo "Received $matchURI"
+        exit 1
+    fi
+done
+
+firstURI=${URIS[0]#URI pkcs11:}
+firstCMPS=(${firstURI//;/ })
+
+title PARA "Check each URI component is tested"
+
+for cmp in "${firstCMPS[@]}"; do
+    echo "\$cmp=${cmp}"
+    ossl 'storeutl -text "pkcs11:${cmp}"' $helper_emit
+    output="$helper_output"
+    echo "$output" | grep "URI pkcs11:" > /dev/null 2>&1 || FAIL=1
+    if [ $FAIL -ne 0 ]; then
+        echo "Failed to get an object with URI \"pkcs11:${cmp}\""
+    fi
+done


### PR DESCRIPTION
Overhaul how URI are parsed.
Add missing attributes specified in [RFC 7512](https://www.rfc-editor.org/rfc/rfc7512)
Print URIs instead of ID/Label in text encoders