### PR TITLE
Fixes to spec file to include the right release, source URL, man page, and docs.

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -46,5 +46,5 @@ jobs:
       if: ${{ matrix.name == 'fedora' }}
       run: |
         mkdir -p rpmbuild/SOURCES
-        cp pkcs11-provider*tar.gz rpmbuild/SOURCES/
+        cp pkcs11-provider*tar.xz rpmbuild/SOURCES/
         rpmbuild --define "_topdir $PWD/rpmbuild" -ba packaging/pkcs11-provider.spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -Im4
 
 SUBDIRS = src tests docs
-dist_doc_DATA = README
+dist_doc_DATA = README.md
 
 check-style:
 	@lines=`git diff -U0 --no-color --relative origin/main | clang-format-diff -p1 |wc -l`; \

--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -1,10 +1,10 @@
 Name:          pkcs11-provider
 Version:       0.1
-Release:       1%{dist}
+Release:       1%{?dist}
 Summary:       A PKCS#11 provider for OpenSSL 3.0+
 License:       Apache-2.0
 URL:           https://github.com/latchset/pkcs11-provider
-Source:        pkcs11-provider-%{version}.tar.gz
+Source0:       %{url}/releases/download/v%{version}/%{name}-%{version}.tar.xz
 
 BuildRequires: openssl-devel >= 3.0.5
 BuildRequires: gcc
@@ -24,6 +24,7 @@ BuildRequires: p11-kit-server
 BuildRequires: gnutls-utils
 BuildRequires: xz
 BuildRequires: expect
+BuildRequires: make
 
 
 %description
@@ -55,7 +56,7 @@ make check || if [ $? -ne 0 ]; then cat tests/*.log; exit 1; fi;
 %files
 %license COPYING
 %{_mandir}/man7/*
-%doc README
+%doc README.md
 %{_libdir}/ossl-modules/pkcs11.so
 
 


### PR DESCRIPTION
Fixes to spec file to include the right release, source URL, man page and docs.
These errors were discovered by fedora-review
https://bugzilla.redhat.com/show_bug.cgi?id=2211754
