### PR TITLE
Run Shellcheck as part of CI and squash the shellcheck and yamlint warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
+---
 name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -23,63 +24,63 @@ jobs:
             container: debian:sid
     container: ${{ matrix.container }}
     steps:
-    - name: Install Dependencies
-      run: |
-          if [ -f /etc/fedora-release ]; then
-            dnf -y install git ${{ matrix.compiler }} automake libtool \
-              pkgconf-pkg-config autoconf-archive openssl-devel openssl \
-              diffutils expect valgrind
-            if [ "${{ matrix.token }}" = "softokn" ]; then
-              dnf -y install nss-softokn nss-tools nss-softokn-devel
-            elif [ "${{ matrix.token }}" = "softhsm" ]; then
-              dnf -y install softhsm opensc p11-kit-devel p11-kit-server \
-                gnutls-utils
+      - name: Install Dependencies
+        run: |
+            if [ -f /etc/fedora-release ]; then
+              dnf -y install git ${{ matrix.compiler }} automake libtool \
+                pkgconf-pkg-config autoconf-archive openssl-devel openssl \
+                diffutils expect valgrind
+              if [ "${{ matrix.token }}" = "softokn" ]; then
+                dnf -y install nss-softokn nss-tools nss-softokn-devel
+              elif [ "${{ matrix.token }}" = "softhsm" ]; then
+                dnf -y install softhsm opensc p11-kit-devel p11-kit-server \
+                  gnutls-utils
+              fi
+            elif [ -f /etc/debian_version ]; then
+              apt-get -q update
+              apt-get -yq install git ${{ matrix.compiler }} make automake \
+                libtool pkg-config autoconf-archive libssl-dev openssl expect \
+                valgrind procps
+              if [ "${{ matrix.token }}" = "softokn" ]; then
+                apt-get -yq install libnss3 libnss3-tools libnss3-dev
+              elif [ "${{ matrix.token }}" = "softhsm" ]; then
+                apt-get -yq install softhsm opensc p11-kit libp11-kit-dev \
+                  p11-kit-modules gnutls-bin
+              fi
             fi
-          elif [ -f /etc/debian_version ]; then
-            apt-get -q update
-            apt-get -yq install git ${{ matrix.compiler }} make automake \
-              libtool pkg-config autoconf-archive libssl-dev openssl expect \
-              valgrind procps
-            if [ "${{ matrix.token }}" = "softokn" ]; then
-              apt-get -yq install libnss3 libnss3-tools libnss3-dev
-            elif [ "${{ matrix.token }}" = "softhsm" ]; then
-              apt-get -yq install softhsm opensc p11-kit libp11-kit-dev \
-                p11-kit-modules gnutls-bin
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          autoreconf -fiv
+          CC=${{ matrix.compiler }} ./configure
+      - name: Build and Test
+        run: make check
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
+          path: |
+            tests/*.log
+            tests/openssl.cnf
+            tests/tmp.${{ matrix.token }}/p11prov-debug.log
+            tests/tmp.${{ matrix.token }}/testvars
+            config.log
+      - name: Run tests with valgrind
+        run: |
+            if [ "${{ matrix.compiler }}" = "gcc" ]; then
+              make check-valgrind-memcheck
             fi
-          fi
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Setup
-      run: |
-        autoreconf -fiv
-        CC=${{ matrix.compiler }} ./configure
-    - name: Build and Test
-      run: make check
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: Test logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
-        path: |
-          tests/*.log
-          tests/openssl.cnf
-          tests/tmp.${{ matrix.token }}/p11prov-debug.log
-          tests/tmp.${{ matrix.token }}/testvars
-          config.log
-    - name: Run tests with valgrind
-      run: |
-          if [ "${{ matrix.compiler }}" = "gcc" ]; then
-            make check-valgrind-memcheck
-          fi
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: Test valgrind logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
-        path: |
-          tests/*.log
-          tests/openssl.cnf
-          tests/tmp.${{ matrix.token }}/p11prov-debug.log
-          tests/tmp.${{ matrix.token }}/testvars
-          config.log
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test valgrind logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
+          path: |
+            tests/*.log
+            tests/openssl.cnf
+            tests/tmp.${{ matrix.token }}/p11prov-debug.log
+            tests/tmp.${{ matrix.token }}/testvars
+            config.log
   build-macos:
     name: CI with software token
     runs-on: ${{ matrix.os }}
@@ -89,45 +90,45 @@ jobs:
         os: [macos-12]
         token: [softokn, softhsm]
     steps:
-    - name: Install Dependencies
-      run: |
-        brew update
-        brew install \
-          autoconf-archive \
-          automake \
-          libtool \
-          openssl@3 \
-          pkg-config
-        if [ "${{ matrix.token }}" = "softokn" ]; then
-          brew install nss
-        elif [ "${{ matrix.token }}" = "softhsm" ]; then
+      - name: Install Dependencies
+        run: |
+          brew update
           brew install \
-            opensc \
-            p11-kit \
-            softhsm
-        fi
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Setup
-      run: |
-        export PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig
-        export PATH=$(brew --prefix openssl@3)/bin:$PATH
+            autoconf-archive \
+            automake \
+            libtool \
+            openssl@3 \
+            pkg-config
+          if [ "${{ matrix.token }}" = "softokn" ]; then
+            brew install nss
+          elif [ "${{ matrix.token }}" = "softhsm" ]; then
+            brew install \
+              opensc \
+              p11-kit \
+              softhsm
+          fi
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          export PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig
+          export PATH=$(brew --prefix openssl@3)/bin:$PATH
 
-        autoreconf -fiv
-        CC=clang ./configure
-    - name: Build and Test
-      run: |
-        export PATH=$(brew --prefix openssl@3)/bin:$PATH
+          autoreconf -fiv
+          CC=clang ./configure
+      - name: Build and Test
+        run: |
+          export PATH=$(brew --prefix openssl@3)/bin:$PATH
 
-        make -j$(sysctl -n hw.ncpu || echo 2)
-        make check
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: Test logs on macOS-12 with ${{ matrix.token }}
-        path: |
-          tests/*.log
-          tests/openssl.cnf
-          tests/tmp.${{ matrix.token }}/p11prov-debug.log
-          tests/tmp.${{ matrix.token }}/testvars
-          config.log
+          make -j$(sysctl -n hw.ncpu || echo 2)
+          make check
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test logs on macOS-12 with ${{ matrix.token }}
+          path: |
+            tests/*.log
+            tests/openssl.cnf
+            tests/tmp.${{ matrix.token }}/p11prov-debug.log
+            tests/tmp.${{ matrix.token }}/testvars
+            config.log

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,10 +1,11 @@
+---
 name: Coverity Scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron:  '41 3 * * 0'
+    - cron: '41 3 * * 0'
 
 jobs:
   coverity:
@@ -12,29 +13,30 @@ jobs:
     runs-on: ubuntu-22.04
     container: fedora:latest
     steps:
-    - name: Install Dependencies
-      run: |
-          dnf -y install git gcc automake libtool pkgconf-pkg-config \
-              autoconf-archive openssl-devel openssl \
-              nss-softokn nss-tools nss-softokn-devel
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Setup
-      run: |
-        autoreconf -fiv
-        ./configure
-    - name: Check for changes
-      run: |
-          echo "RUN_COV=0" >> $GITHUB_ENV;
-          git config --global --add safe.directory /__w/pkcs11-provider/pkcs11-provider
-          DIFF=`git log --since=1week | wc -l`
-          if [ x${DIFF} != "x0" ]; then
-            echo "RUN_COV=1" >> $GITHUB_ENV;
-          fi
-    - name: Coverity Scan
-      if: env.RUN_COV == 1
-      uses: vapier/coverity-scan-action@v1
-      with:
-        project: "PKCS%2311+Provider"
-        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
-        token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      - name: Install Dependencies
+        run: |
+            dnf -y install git gcc automake libtool pkgconf-pkg-config \
+                autoconf-archive openssl-devel openssl \
+                nss-softokn nss-tools nss-softokn-devel
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          autoreconf -fiv
+          ./configure
+      - name: Check for changes
+        run: |
+            echo "RUN_COV=0" >> $GITHUB_ENV;
+            git config --global --add safe.directory \
+                /__w/pkcs11-provider/pkcs11-provider
+            DIFF=`git log --since=1week | wc -l`
+            if [ x${DIFF} != "x0" ]; then
+              echo "RUN_COV=1" >> $GITHUB_ENV;
+            fi
+      - name: Coverity Scan
+        if: env.RUN_COV == 1
+        uses: vapier/coverity-scan-action@v1
+        with:
+          project: "PKCS%2311+Provider"
+          email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -1,8 +1,9 @@
+---
 name: Distribution checks
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   distcheck:
@@ -19,32 +20,33 @@ jobs:
             container: debian:sid
     container: ${{ matrix.container }}
     steps:
-    - name: Install Dependencies
-      run: |
-          if [ -f /etc/fedora-release ]; then
-            dnf -y install git gcc automake libtool expect \
-              pkgconf-pkg-config autoconf-archive openssl-devel openssl xz \
-              nss-softokn nss-tools nss-softokn-devel \
-              softhsm opensc p11-kit-devel p11-kit-server \
-              rpm-build nss-devel gnutls-utils
-          elif [ -f /etc/debian_version ]; then
-            apt-get -q update
-            apt-get -yq install git gcc make automake expect \
-              libtool pkg-config autoconf-archive libssl-dev openssl xz-utils \
-              libnss3 libnss3-tools libnss3-dev \
-              softhsm opensc p11-kit libp11-kit-dev p11-kit-modules gnutls-bin
-          fi
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Setup
-      run: |
-        autoreconf -fiv
-        ./configure
-    - name: Distcheck
-      run: make distcheck
-    - name: RPM Build
-      if: ${{ matrix.name == 'fedora' }}
-      run: |
-        mkdir -p rpmbuild/SOURCES
-        cp pkcs11-provider*tar.xz rpmbuild/SOURCES/
-        rpmbuild --define "_topdir $PWD/rpmbuild" -ba packaging/pkcs11-provider.spec
+      - name: Install Dependencies
+        run: |
+            if [ -f /etc/fedora-release ]; then
+              dnf -y install git gcc automake libtool expect \
+                pkgconf-pkg-config autoconf-archive openssl-devel openssl xz \
+                nss-softokn nss-tools nss-softokn-devel \
+                softhsm opensc p11-kit-devel p11-kit-server \
+                rpm-build nss-devel gnutls-utils
+            elif [ -f /etc/debian_version ]; then
+              apt-get -q update
+              apt-get -yq install git gcc make automake expect \
+                libtool pkg-config autoconf-archive libssl-dev openssl \
+                xz-utils libnss3 libnss3-tools libnss3-dev \
+                softhsm opensc p11-kit libp11-kit-dev p11-kit-modules gnutls-bin
+            fi
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup
+        run: |
+          autoreconf -fiv
+          ./configure
+      - name: Distcheck
+        run: make distcheck
+      - name: RPM Build
+        if: ${{ matrix.name == 'fedora' }}
+        run: |
+          mkdir -p rpmbuild/SOURCES
+          cp pkcs11-provider*tar.xz rpmbuild/SOURCES/
+          rpmbuild --define "_topdir $PWD/rpmbuild" -ba \
+              packaging/pkcs11-provider.spec

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,3 +1,4 @@
+---
 name: REUSE Compliance Check
 
 on: [push, pull_request]
@@ -6,6 +7,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v1
+      - uses: actions/checkout@v2
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,8 +1,9 @@
+---
 name: Scan Build
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -10,26 +11,26 @@ jobs:
     runs-on: ubuntu-22.04
     container: fedora:latest
     steps:
-    - name: Install Dependencies
-      run: |
-        dnf -y install $COMPILER automake libtool pkgconf-pkg-config autoconf-archive \
-              git openssl-devel clang-analyzer
-    - uses: actions/checkout@v3
-      name: Checkout Repository
-    - name: Setup
-      run: |
-        autoreconf -fiv
-        ./configure
-    - name: Scan Build
-      run: |
-        scan-build --html-title="PKCS#11 Provider ($GITHUB_SHA)" \
-                  --keep-cc \
-                  --status-bugs \
-                  --keep-going \
-                  -o scan-build.reports make
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: Scan Build logs
-        path: |
-          scan-build.reports/
+      - name: Install Dependencies
+        run: |
+          dnf -y install $COMPILER automake libtool pkgconf-pkg-config \
+              autoconf-archive git openssl-devel clang-analyzer
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+      - name: Setup
+        run: |
+          autoreconf -fiv
+          ./configure
+      - name: Scan Build
+        run: |
+          scan-build --html-title="PKCS#11 Provider ($GITHUB_SHA)" \
+                    --keep-cc \
+                    --status-bugs \
+                    --keep-going \
+                    -o scan-build.reports make
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Scan Build logs
+          path: |
+            scan-build.reports/

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,40 @@
+---
+name: Shellcheck
+permissions: {}
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          additional_files: >-
+            tbasic
+            tcerts
+            tdemoca
+            tdigest
+            tecc
+            tecdh
+            tedwards
+            test-wrapper
+            thkdf
+            toaepsha2
+            tpubkey
+            trand
+            trsapss
+            ttls
+            turi
+          check_together: 'yes'
+        env:
+          # The expressions in the ossl macro are not expanded
+          # We use tests as default source path
+          SHELLCHECK_OPTS: -e SC2016 -P tests

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,8 +1,9 @@
+---
 name: Check Style
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -10,33 +11,36 @@ jobs:
     runs-on: ubuntu-22.04
     container: fedora:latest
     steps:
-    - name: Install Dependencies
-      run: |
-        dnf -y install $COMPILER automake libtool pkgconf-pkg-config autoconf-archive \
-              git openssl-devel clang-tools-extra python3-pip codespell
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-    - name: Install compiledb
-      run: |
-        pip install compiledb
-    - name: Setup
-      if: ${{ github.event.pull_request.base.sha }}
-      run: |
-        git config --global --add safe.directory /__w/pkcs11-provider/pkcs11-provider
-        git fetch origin main ${{ github.event.pull_request.base.sha }}
-    - name: Generate Makefile
-      run: |
-        autoreconf -fiv
-        ./configure
-        compiledb make
-    - name: Run Clang Tidy
-      run: |
-        run-clang-tidy \
-          -checks=-*,readability-braces-around-statements \
-          -config "{WarningsAsErrors: '*'}" \
-          -header-filter "src/oasis" \
-          -quiet
-    - name: Check the Style
-      run: make check-style || (make check-style-show; exit -1)
-    - name: Check spelling
-      run: codespell --ignore-words-list="sorce,clen,adin" *.md Makefile.am configure.ac src tests -S src/oasis
+      - name: Install Dependencies
+        run: |
+          dnf -y install $COMPILER automake libtool pkgconf-pkg-config \
+                autoconf-archive git openssl-devel clang-tools-extra \
+                python3-pip codespell
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Install compiledb
+        run: |
+          pip install compiledb
+      - name: Setup
+        if: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git config --global --add safe.directory \
+              /__w/pkcs11-provider/pkcs11-provider
+          git fetch origin main ${{ github.event.pull_request.base.sha }}
+      - name: Generate Makefile
+        run: |
+          autoreconf -fiv
+          ./configure
+          compiledb make
+      - name: Run Clang Tidy
+        run: |
+          run-clang-tidy \
+            -checks=-*,readability-braces-around-statements \
+            -config "{WarningsAsErrors: '*'}" \
+            -header-filter "src/oasis" \
+            -quiet
+      - name: Check the Style
+        run: make check-style || (make check-style-show; exit -1)
+      - name: Check spelling
+        run: codespell --ignore-words-list="sorce,clen,adin" *.md Makefile.am \
+            configure.ac src tests -S src/oasis

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -35,7 +35,7 @@ title()
 cleanup_server()
 {
     echo "killing $1 server"
-    kill -9 -- $2
+    kill -9 -- "$2"
 }
 
 helper_emit=1
@@ -43,11 +43,13 @@ helper_emit=1
 ossl()
 {
     helper_output=""
-    echo "# r "$1 >> ${TMPPDIR}/gdb-commands.txt
-    echo $CHECKER openssl $1
+    echo "# r $1" >> "${TMPPDIR}/gdb-commands.txt"
+    echo "$CHECKER openssl $1"
+    # shellcheck disable=SC2086  # this is intentionally split by words
     __out=$(eval $CHECKER openssl $1)
     __res=$?
-    if [ ${2:-0} -eq $helper_emit ]; then
+    if [ "${2:-0}" -eq "$helper_emit" ]; then
+        # shellcheck disable=SC2034  # used externally by caller
         helper_output="$__out"
     else
         echo "$__out"
@@ -56,9 +58,9 @@ ossl()
 }
 
 gen_unsetvars() {
-    grep "^export" ${TMPPDIR}/testvars \
+    grep "^export" "${TMPPDIR}/testvars" \
     | sed -e 's/export/unset/' -e 's/=.*$//' \
-    >> ${TMPPDIR}/unsetvars
+    >> "${TMPPDIR}/unsetvars"
 }
 
 kill_children() {

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 if ! command -v softhsm2-util &> /dev/null
 then
@@ -19,7 +19,6 @@ if [ "$(uname)" == "Darwin" ]; then
     certtool=$(type -p gnutls-certtool)
 else
     certtool=$(type -p certtool)
-    sed_backup=""
 fi
 if [ -z "$certtool" ]; then
     echo "Missing GnuTLS certtool (on macOS, commonly installed as gnutls-certtool)"
@@ -89,7 +88,7 @@ mkdir ${TMPPDIR}
 
 PINVALUE="12345678"
 PINFILE="${PWD}/pinfile.txt"
-echo ${PINVALUE} > ${PINFILE}
+echo ${PINVALUE} > "${PINFILE}"
 
 #RANDOM data
 SEEDFILE="${TMPPDIR}/noisefile.bin"
@@ -134,7 +133,7 @@ KEYID='0000'
 URIKEYID="%00%00"
 CACRT="${TMPPDIR}/CAcert"
 CACRTN="caCert"
-let "SERIAL+=1"
+((SERIAL+=1))
 pkcs11-tool --keypairgen --key-type="RSA:2048" --login --pin=$PINVALUE \
 	--module="$P11LIB" --label="${CACRTN}" --id="$KEYID"
 "${certtool}" --generate-self-signed --outfile="${CACRT}.crt" \
@@ -152,7 +151,7 @@ ca_sign() {
     LABEL=$2
     CN=$3
     KEYID=$4
-    let "SERIAL+=1"
+    ((SERIAL+=1))
     sed -e "s|cn = .*|cn = $CN|g" \
         -e "s|serial = .*|serial = $SERIAL|g" \
         -e "/^ca$/d" \
@@ -164,7 +163,7 @@ ca_sign() {
         --load-pubkey "pkcs11:object=$LABEL;type=public" --outder \
         --load-ca-certificate "${CACRT}.crt" --inder \
         --load-ca-privkey="pkcs11:object=$CACRTN;type=private"
-    pkcs11-tool --write-object "${CRT}.crt" --type=cert --id=$KEYID \
+    pkcs11-tool --write-object "${CRT}.crt" --type=cert --id="$KEYID" \
         --label="$LABEL" --module="$P11LIB"
 
 }
@@ -254,7 +253,6 @@ EDPRIURI="pkcs11:type=private;id=${URIKEYID}"
 EDCRTURI="pkcs11:type=cert;object=${EDCRTN}"
 
 title LINE "ED25519 PKCS11 URIS"
-echo "${EDBASEURIWITHPIN}"
 echo "${EDBASEURI}"
 echo "${EDPUBURI}"
 echo "${EDPRIURI}"
@@ -323,7 +321,7 @@ sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
     -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
     -e "s|##QUIRKS|pkcs11-module-quirks = no-deinit|g" \
     -e "/pkcs11-module-init-args/d" \
-    ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
+    "${TESTSSRCDIR}/openssl.cnf.in" > "${OPENSSL_CONF}"
 
 title LINE "Export test variables to ${TMPPDIR}/testvars"
 cat >> ${TMPPDIR}/testvars <<DBGSCRIPT

--- a/tests/setup-softokn.sh
+++ b/tests/setup-softokn.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 if ! command -v certutil &> /dev/null
 then
@@ -20,7 +20,7 @@ mkdir ${TMPPDIR}
 
 PINVALUE="12345678"
 PINFILE="${PWD}/pinfile.txt"
-echo ${PINVALUE} > ${PINFILE}
+echo ${PINVALUE} > "${PINFILE}"
 
 #RANDOM data
 SEEDFILE="${TMPPDIR}/noisefile.bin"
@@ -38,14 +38,14 @@ mkdir ${TOKDIR}
 SERIAL=0
 
 title LINE "Creating new NSS Database"
-certutil -N -d ${TOKDIR} -f ${PINFILE}
+certutil -N -d "${TOKDIR}" -f "${PINFILE}"
 
 title LINE "Creating new Self Sign CA"
-let "SERIAL+=1"
+((SERIAL+=1))
 certutil -S -s "CN=Issuer" -n selfCA -x -t "C,C,C" \
-    -m ${SERIAL} -1 -2 -5 --keyUsage certSigning,crlSigning \
+    -m "${SERIAL}" -1 -2 -5 --keyUsage certSigning,crlSigning \
     --nsCertType sslCA,smimeCA,objectSigningCA \
-    -f ${PINFILE} -d ${TOKDIR} -z ${SEEDFILE} >/dev/null 2>&1 <<CERTSCRIPT
+    -f "${PINFILE}" -d "${TOKDIR}" -z "${SEEDFILE}" >/dev/null 2>&1 <<CERTSCRIPT
 y
 
 n
@@ -55,18 +55,18 @@ CERTSCRIPT
 TSTCRT="${TMPPDIR}/testcert"
 TSTCRTN="testCert"
 title LINE  "Creating Certificate request for 'My Test Cert'"
-certutil -R -s "CN=My Test Cert, O=PKCS11 Provider" -o ${TSTCRT}.req \
-            -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
-let "SERIAL+=1"
-certutil -C -m ${SERIAL} -i ${TSTCRT}.req -o ${TSTCRT}.crt -c selfCA \
-            -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n ${TSTCRTN} -i ${TSTCRT}.crt -t "u,u,u" -d ${TOKDIR} \
-            -f ${PINFILE} >/dev/null 2>&1
+certutil -R -s "CN=My Test Cert, O=PKCS11 Provider" -o "${TSTCRT}.req" \
+            -d "${TOKDIR}" -f "${PINFILE}" -z "${SEEDFILE}" >/dev/null 2>&1
+((SERIAL+=1))
+certutil -C -m "${SERIAL}" -i "${TSTCRT}.req" -o "${TSTCRT}.crt" -c selfCA \
+            -d "${TOKDIR}" -f "${PINFILE}" >/dev/null 2>&1
+certutil -A -n "${TSTCRTN}" -i "${TSTCRT}.crt" -t "u,u,u" -d "${TOKDIR}" \
+            -f "${PINFILE}" >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${TSTCRTN}"| cut -b 15-54`
+KEYID=$(certutil -K -d "${TOKDIR}" -f "${PINFILE}" |grep "${TSTCRTN}"| cut -b 15-54)
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
-    line=`echo "${KEYID:$i:2}"`
+    line="${KEYID:$i:2}"
     URIKEYID="$URIKEYID%$line"
 done
 
@@ -89,17 +89,17 @@ ECCRT="${TMPPDIR}/eccert"
 ECCRTN="ecCert"
 title LINE  "Creating Certificate request for 'My EC Cert'"
 certutil -R -s "CN=My EC Cert, O=PKCS11 Provider" -k ec -q nistp256 \
-            -o ${ECCRT}.req -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
-let "SERIAL+=1"
-certutil -C -m ${SERIAL} -i ${ECCRT}.req -o ${ECCRT}.crt -c selfCA \
-            -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n ${ECCRTN} -i ${ECCRT}.crt -t "u,u,u" \
-            -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
+            -o "${ECCRT}.req" -d "${TOKDIR}" -f "${PINFILE}" -z "${SEEDFILE}" >/dev/null 2>&1
+((SERIAL+=1))
+certutil -C -m "${SERIAL}" -i "${ECCRT}.req" -o "${ECCRT}.crt" -c selfCA \
+            -d "${TOKDIR}" -f "${PINFILE}" >/dev/null 2>&1
+certutil -A -n "${ECCRTN}" -i "${ECCRT}.crt" -t "u,u,u" \
+            -d "${TOKDIR}" -f "${PINFILE}" >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${ECCRTN}"| cut -b 15-54`
+KEYID=$(certutil -K -d "${TOKDIR}" -f "${PINFILE}" |grep "${ECCRTN}"| cut -b 15-54)
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
-    line=`echo "${KEYID:$i:2}"`
+    line="${KEYID:$i:2}"
     URIKEYID="$URIKEYID%$line"
 done
 
@@ -113,18 +113,18 @@ title LINE  "Creating Certificate request for 'My Peer EC Cert'"
 ECPEERCRT="${TMPPDIR}/ecpeercert"
 ECPEERCRTN="ecPeerCert"
 certutil -R -s "CN=My Peer EC Cert, O=PKCS11 Provider" \
-            -k ec -q nistp256 -o ${ECPEERCRT}.req \
-            -d ${TOKDIR} -f ${PINFILE} -z ${SEEDFILE} >/dev/null 2>&1
-let "SERIAL+=1"
-certutil -C -m ${SERIAL} -i ${ECPEERCRT}.req -o ${ECPEERCRT}.crt \
-            -c selfCA -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
-certutil -A -n ${ECPEERCRTN} -i ${ECPEERCRT}.crt -t "u,u,u" \
-            -d ${TOKDIR} -f ${PINFILE} >/dev/null 2>&1
+            -k ec -q nistp256 -o "${ECPEERCRT}.req" \
+            -d "${TOKDIR}" -f "${PINFILE}" -z "${SEEDFILE}" >/dev/null 2>&1
+((SERIAL+=1))
+certutil -C -m "${SERIAL}" -i "${ECPEERCRT}.req" -o "${ECPEERCRT}.crt" \
+            -c selfCA -d "${TOKDIR}" -f "${PINFILE}" >/dev/null 2>&1
+certutil -A -n "${ECPEERCRTN}" -i "${ECPEERCRT}.crt" -t "u,u,u" \
+            -d "${TOKDIR}" -f "${PINFILE}" >/dev/null 2>&1
 
-KEYID=`certutil -K -d ${TOKDIR} -f ${PINFILE} |grep "${ECPEERCRTN}"| cut -b 15-54`
+KEYID=$(certutil -K -d "${TOKDIR}" -f "${PINFILE}" |grep "${ECPEERCRTN}"| cut -b 15-54)
 URIKEYID=""
 for (( i=0; i<${#KEYID}; i+=2 )); do
-    line=`echo "${KEYID:$i:2}"`
+    line="${KEYID:$i:2}"
     URIKEYID="$URIKEYID%$line"
 done
 
@@ -147,8 +147,8 @@ echo ""
 
 title PARA "Show contents of softoken"
 echo " ----------------------------------------------------------------------------------------------------"
-certutil -L -d ${TOKDIR}
-certutil -K -d ${TOKDIR} -f ${PINFILE}
+certutil -L -d "${TOKDIR}"
+certutil -K -d "${TOKDIR}" -f "${PINFILE}"
 echo " ----------------------------------------------------------------------------------------------------"
 
 title PARA "Output configurations"
@@ -160,10 +160,10 @@ sed -e "s|@libtoollibs[@]|${LIBSPATH}|g" \
     -e "s|@testsblddir@|${TESTBLDDIR}|g" \
     -e "s|@testsdir[@]|${BASEDIR}/${TMPPDIR}|g" \
     -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
-    ${TESTSSRCDIR}/openssl.cnf.in > ${OPENSSL_CONF}
+    "${TESTSSRCDIR}/openssl.cnf.in" > "${OPENSSL_CONF}"
 
 title LINE "Export tests variables to ${TMPPDIR}/testvars"
-cat > ${TMPPDIR}/testvars <<DBGSCRIPT
+cat > "${TMPPDIR}/testvars" <<DBGSCRIPT
 export PKCS11_PROVIDER_DEBUG="file:${BASEDIR}/${TMPPDIR}/p11prov-debug.log"
 export PKCS11_PROVIDER_MODULE="${SOFTOKNPATH%%/}/libsoftokn3${SHARED_EXT}"
 export OPENSSL_CONF="${OPENSSL_CONF}"

--- a/tests/softhsm-proxy.sh
+++ b/tests/softhsm-proxy.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 # p11-kit complains if there is not runtime directory
 if [ -z "$XDG_RUNTIME_DIR" ]; then
@@ -10,16 +10,17 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
 fi
 
 title PARA "Start the p11-kit server and check if it works"
+# shellcheck disable=SC2046 # we want to split these for eval
 eval $(p11-kit server --provider "$P11LIB" "pkcs11:")
 
 # unset OPENSSL_CONF here to avoid automatically loading the provider
 # and SoftHSM from pkcs11-tool and crashing during the cleanup again.
-OPENSSL_CONF= pkcs11-tool -O --login --pin=$PINVALUE --module="$P11KITCLIENTPATH" > /dev/null
+OPENSSL_CONF='' pkcs11-tool -O --login --pin="$PINVALUE" --module="$P11KITCLIENTPATH" > /dev/null
 
 #register clean function to kill p11-kit-server
-trap "cleanup_server p11-kit $P11_KIT_SERVER_PID" EXIT
+trap 'cleanup_server p11-kit $P11_KIT_SERVER_PID' EXIT
 
 #Set up environment variables
 export PKCS11_PROVIDER_MODULE="${P11KITCLIENTPATH}"
 
-$*
+"$*"

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -2,10 +2,10 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Raw Sign check error"
-dd if=/dev/urandom of=${TMPPDIR}/64Brandom.bin bs=64 count=1 >/dev/null 2>&1
+dd if=/dev/urandom of="${TMPPDIR}/64Brandom.bin" bs=64 count=1 >/dev/null 2>&1
 FAIL=0
 ossl '
 pkeyutl -sign -inkey "${BASEURI}"
@@ -69,7 +69,7 @@ pkeyutl -verify -inkey "${PUBURI}"
 
 
 SECRETFILE=${TMPPDIR}/rsasecret.txt
-echo "Super Secret" > ${SECRETFILE}
+echo "Super Secret" > "${SECRETFILE}"
 
 title LINE "RSA basic encrypt and decrypt"
 ossl '
@@ -80,13 +80,13 @@ ossl '
 pkeyutl -decrypt -inkey "${PRIURI}"
                  -in ${SECRETFILE}.enc
                  -out ${SECRETFILE}.dec'
-diff ${SECRETFILE} ${SECRETFILE}.dec
+diff "${SECRETFILE}" "${SECRETFILE}.dec"
 
 title PARA "Test Disallow Public Export"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed "s/#pkcs11-module-allow-export/pkcs11-module-allow-export = 1/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.noexport
+sed "s/#pkcs11-module-allow-export/pkcs11-module-allow-export = 1/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.noexport"
 OPENSSL_CONF=${OPENSSL_CONF}.noexport
-ossl 'pkey -in $PUBURI -pubin -pubout -text' $helper_emit
+ossl 'pkey -in $PUBURI -pubin -pubout -text' "$helper_emit"
 output="$helper_output"
 FAIL=0
 echo "$output" | grep "^PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
@@ -107,7 +107,7 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-rm -f ${OPENSSL_CONF}.noexport
+rm -f "${OPENSSL_CONF}.noexport"
 
 title PARA "Test CSR generation from RSA private keys"
 ossl '
@@ -117,7 +117,7 @@ req -in ${TMPPDIR}/rsa_csr.pem -verify -noout'
 
 title PARA "Test fetching public keys without PIN in config files"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed "s/^pkcs11-module-token-pin.*$/##nopin/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.nopin
+sed "s/^pkcs11-module-token-pin.*$/##nopin/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.nopin"
 OPENSSL_CONF=${OPENSSL_CONF}.nopin
 ossl 'pkey -in $PUBURI -pubin -pubout -out ${TMPPDIR}/rsa.pub.nopin.pem'
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ec.pub.nopin.pem'
@@ -127,10 +127,10 @@ ossl 'pkey -in $BASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/rsa.pub.uripin.pem
 ossl 'pkey -in $ECBASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/ec.pub.uripin.pem'
 
 title PARA "Test prompting without PIN in config files"
-output=`expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PRIURI}\" -text -noout;
+output=$(expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PRIURI}\" -text -noout;
                    expect \"Enter pass phrase for PKCS#11 Token (Slot *:\";
                    send \"${PINVALUE}\r\";
-                   expect \"Key ID:\";"`
+                   expect \"Key ID:\";")
 echo "$output" | grep "Enter pass phrase for PKCS#11 Token (Slot .*):" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 0 ]; then
     echo "$output" | grep "PKCS11 RSA Public Key" > /dev/null 2>&1 || FAIL=2
@@ -150,13 +150,14 @@ if [ $FAIL -ne 0 ]; then
 fi
 
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-rm -f ${OPENSSL_CONF}.nopin
+rm -f "${OPENSSL_CONF}.nopin"
 
 title PARA "Test PIN caching"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed "s/^pkcs11-module-token-pin.*$/pkcs11-module-cache-pins = cache/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.pincaching
+sed "s/^pkcs11-module-token-pin.*$/pkcs11-module-cache-pins = cache/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.pincaching"
 OPENSSL_CONF=${OPENSSL_CONF}.pincaching
-$CHECKER ${TESTBLDDIR}/pincache
+$CHECKER "${TESTBLDDIR}/pincache"
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 
 

--- a/tests/tcerts
+++ b/tests/tcerts
@@ -2,13 +2,13 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Check we can fetch certifiatce objects"
 
 ossl '
 x509 -in ${CRTURI} -subject -out ${TMPPDIR}/crt-subj.txt'
-DATA=$(cat ${TMPPDIR}/crt-subj.txt | sed -e 's/\ =\ /=/g')
+DATA=$(sed -e 's/\ =\ /=/g' "${TMPPDIR}/crt-subj.txt")
 CHECK="subject=O=PKCS11 Provider, CN=My Test Cert"
 if [[ ! ${DATA} =~ ${CHECK} ]]; then
     echo "Cert not found looking for ${CHECK}"
@@ -17,7 +17,7 @@ fi
 
 ossl '
 x509 -in ${ECCRTURI} -subject -out ${TMPPDIR}/eccrt-subj.txt'
-DATA=$(cat ${TMPPDIR}/eccrt-subj.txt | sed -e 's/\ =\ /=/g')
+DATA=$(sed -e 's/\ =\ /=/g' "${TMPPDIR}/eccrt-subj.txt")
 CHECK="subject=O=PKCS11 Provider, CN=My EC Cert"
 if [[ ! ${DATA} =~ ${CHECK} ]]; then
     echo "Cert not found looking for ${CHECK}"
@@ -36,7 +36,7 @@ ossl '
 storeutl -certs -subject "${subj}"
                 -out ${TMPPDIR}/storeutl-crt-subj.txt
                 pkcs11:type=cert'
-DATA=$(cat ${TMPPDIR}/storeutl-crt-subj.txt)
+DATA=$(cat "${TMPPDIR}/storeutl-crt-subj.txt")
 if [[ ! ${DATA} =~ "Total found: 1" ]]; then
     echo "Cert not found matching by subject=${subj}"
     exit 1

--- a/tests/tdemoca
+++ b/tests/tdemoca
@@ -2,19 +2,19 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 DEMOCA="${TMPPDIR}/demoCA"
 
 title PARA "Set up demoCA"
-mkdir -p ${DEMOCA}/newcerts ${DEMOCA}/private
-if [ ! -e ${DEMOCA}/serial ]; then
-    echo "01" > ${DEMOCA}/serial
+mkdir -p "${DEMOCA}/newcerts" "${DEMOCA}/private"
+if [ ! -e "${DEMOCA}/serial" ]; then
+    echo "01" > "${DEMOCA}/serial"
 fi
-touch ${DEMOCA}/index.txt
+touch "${DEMOCA}/index.txt"
 
 title PARA "Generating CA cert if needed"
-if [ ! -e ${DEMOCA}/cacert.pem ]; then
+if [ ! -e "${DEMOCA}/cacert.pem" ]; then
     ossl 'req -batch -noenc -x509 -new -key ${PRIURI} -out ${DEMOCA}/cacert.pem'
 fi
 
@@ -47,9 +47,9 @@ PORT=12345
 trap kill_children EXIT
 #Unclear why but w/o -rmd sha1 this fails
 #call this without wrapper otherwise we have issues killing it later ...
-$CHECKER openssl ocsp -index ${DEMOCA}/index.txt -rsigner \
-    ${DEMOCA}/ocspSigning.pem -rkey ${PRIURI} -CA ${DEMOCA}/cacert.pem \
-    -rmd sha1 -port ${PORT} -text &
+$CHECKER openssl ocsp -index "${DEMOCA}/index.txt" -rsigner \
+    "${DEMOCA}/ocspSigning.pem" -rkey "${PRIURI}" -CA "${DEMOCA}/cacert.pem" \
+    -rmd sha1 -port "${PORT}" -text &
 sleep 0.5
 # with valgrind, it might take a bit longer
 if [ -n "$VALGRIND" ]; then
@@ -61,7 +61,7 @@ ocsp -CAfile ${DEMOCA}/cacert.pem -issuer ${DEMOCA}/cacert.pem
      -url http://127.0.0.1:${PORT}' $helper_emit
 output="$helper_output"
 FAIL=0
-echo $output | grep ": good" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep ": good" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "The OCSP response failed"
     echo

--- a/tests/tdigest
+++ b/tests/tdigest
@@ -2,11 +2,12 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 # We need to configure early loading otherwise no digests are loaded,
 # and all checks are skipped
-sed "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.early_load
+sed "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.early_load"
 OPENSSL_CONF=${OPENSSL_CONF}.early_load
 
 title PARA "Test Digests support"

--- a/tests/tecc
+++ b/tests/tecc
@@ -2,15 +2,15 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Export EC Public key to a file"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ecout.pub'
 title LINE "Print EC Public key from private"
-ossl 'pkey -in $ECPRIURI -pubout -text' $helper_emit
+ossl 'pkey -in $ECPRIURI -pubout -text' "$helper_emit"
 output="$helper_output"
 FAIL=0
-echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Pkcs11 encoder function failed"
     echo

--- a/tests/tecdh
+++ b/tests/tecdh
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "ECDH Exchange"
 ossl '

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Export ED25519 Public key to a file"
 ossl 'pkey -in $EDPUBURI -pubin -pubout -out ${TMPPDIR}/edout.pub'
@@ -11,7 +11,7 @@ title LINE "Print ED25519 Public key from private"
 ossl 'pkey -in $EDPRIURI -pubout -text' $helper_emit
 output="$helper_output"
 FAIL=0
-echo $output | grep "ED25519 Public-Key" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "ED25519 Public-Key" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Could not extract public key from private"
     echo

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -2,19 +2,18 @@
 # Copyright (C) 2022 Simo sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-TEST_PATH=$(dirname ${1})
-BNAME=$(basename ${1})
+TEST_PATH=$(dirname "${1}")
+BNAME=$(basename "${1}")
 
+# the test name is {TEST_NAME}-{TOKEN_DRIVER}.t
 # split extension
-TEST_EXT=(${BNAME//./ })
-NAME=${TEST_EXT[0]}
-TEST_PARAMS=(${NAME//-/ })
+NAME=${BNAME%.*}
+TEST_NAME=${NAME%-*}
+TOKEN_DRIVER=${NAME#*-}
 
-TEST_NAME=${TEST_PARAMS[0]}
-TOKEN_DRIVER=${TEST_PARAMS[1]}
-
-if [ -f "./tmp.${TOKEN_DRIVER}/testvars" ];  then
-    source ./tmp.${TOKEN_DRIVER}/testvars
+if [ -f "./tmp.${TOKEN_DRIVER}/testvars" ]; then
+    # shellcheck source=/dev/null # we do not care about linting this source
+    source "./tmp.${TOKEN_DRIVER}/testvars"
 else
     exit 77 # token not configured, skip
 fi
@@ -30,7 +29,7 @@ else
 fi
 
 # Run the tests under valgrind with appropriate flags
-if [ -n "$VALGRIND" -a -n "$LOG_COMPILER" ]; then
+if [ -n "$VALGRIND" ] && [ -n "$LOG_COMPILER" ]; then
     CHECKER="$LOG_COMPILER"
 fi
 

--- a/tests/thkdf
+++ b/tests/thkdf
@@ -2,12 +2,12 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "HKDF Derivation"
-HKDF_HEX_SECRET=ffeeddccbbaa
-HKDF_HEX_SALT=ffeeddccbbaa
-HKDF_HEX_INFO=ffeeddccbbaa
+export HKDF_HEX_SECRET=ffeeddccbbaa
+export HKDF_HEX_SALT=ffeeddccbbaa
+export HKDF_HEX_INFO=ffeeddccbbaa
 ossl '
 pkeyutl -derive -kdf HKDF -kdflen 48
                 -pkeyopt md:SHA256
@@ -25,11 +25,11 @@ pkeyutl -derive -kdf HKDF -kdflen 48
                 -pkeyopt hexsalt:${HKDF_HEX_SALT}
                 -pkeyopt hexinfo:${HKDF_HEX_INFO}
                 -out ${TMPPDIR}/hkdf1-out.bin'
-diff ${TMPPDIR}/hkdf1-out-pkcs11.bin ${TMPPDIR}/hkdf1-out.bin
+diff "${TMPPDIR}/hkdf1-out-pkcs11.bin" "${TMPPDIR}/hkdf1-out.bin"
 
-HKDF_HEX_SECRET=6dc3bcf529a350e0423befb3deef8aef78d912c4f1dc3e6e52bf61f681e40904
-HKDF_SALT="I'm a Salt!"
-HKDF_INFO="And I'm an Info?"
+export HKDF_HEX_SECRET=6dc3bcf529a350e0423befb3deef8aef78d912c4f1dc3e6e52bf61f681e40904
+export HKDF_SALT="I'm a Salt!"
+export HKDF_INFO="And I'm an Info?"
 ossl '
 pkeyutl -derive -kdf HKDF -kdflen 48
                 -pkeyopt md:SHA256
@@ -47,4 +47,4 @@ pkeyutl -derive -kdf HKDF -kdflen 48
                 -pkeyopt salt:"${HKDF_SALT}"
                 -pkeyopt info:"${HKDF_INFO}"
                 -out ${TMPPDIR}/hkdf2-out.bin'
-diff ${TMPPDIR}/hkdf2-out-pkcs11.bin ${TMPPDIR}/hkdf2-out.bin
+diff "${TMPPDIR}/hkdf2-out-pkcs11.bin" "${TMPPDIR}/hkdf2-out.bin"

--- a/tests/toaepsha2
+++ b/tests/toaepsha2
@@ -2,10 +2,10 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 SECRETFILE=${TMPPDIR}/rsa-oaep-secret.txt
-echo "Super Secret" > ${SECRETFILE}
+echo "Super Secret" > "${SECRETFILE}"
 title PARA "Encrypt and decrypt with RSA OAEP"
 # Let openssl encrypt by importing the public key
 ossl '
@@ -23,4 +23,4 @@ pkeyutl -decrypt -inkey "${PRIURI}"
                  -pkeyopt mgf1-digest:sha256
                  -in ${SECRETFILE}.enc
                  -out ${SECRETFILE}.dec'
-diff ${SECRETFILE} ${SECRETFILE}.dec
+diff "${SECRETFILE}" "${SECRETFILE}.dec"

--- a/tests/tpubkey
+++ b/tests/tpubkey
@@ -2,17 +2,17 @@
 # Copyright (C) 2022 Jakub Jelen <jjelen@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Export RSA Public key to a file"
 ossl 'pkey -in $BASEURI -pubin -pubout -out ${TMPPDIR}/baseout.pub'
 title LINE "Export Public key to a file (pub-uri)"
 ossl 'pkey -in $PUBURI -pubin -pubout -out ${TMPPDIR}/pubout.pub'
 title LINE "Print Public key from private"
-ossl 'pkey -in $PRIURI -pubout -text' $helper_emit
+ossl 'pkey -in $PRIURI -pubout -text' "$helper_emit"
 output="$helper_output"
 FAIL=0
-echo $output | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "PKCS11 RSA Public Key (2048 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Pkcs11 encoder function failed"
     echo
@@ -36,10 +36,10 @@ ossl 'pkey -in $ECBASEURI -pubin -pubout -out ${TMPPDIR}/baseecout.pub'
 title LINE "Export EC Public key to a file (pub-uri)"
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/pubecout.pub'
 title LINE "Print EC Public key from private"
-ossl 'pkey -in $ECPRIURI -pubout -text' $helper_emit
+ossl 'pkey -in $ECPRIURI -pubout -text' "$helper_emit"
 output="$helper_output"
 FAIL=0
-echo $output | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "PKCS11 EC Public Key (256 bits)" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Pkcs11 encoder function failed"
     echo
@@ -50,14 +50,14 @@ if [ $FAIL -eq 1 ]; then
 fi
 
 # The softokn does not support removing only public key from the key pair
-if [ ! -z "$BASE2URI" ]; then
+if [ -n "$BASE2URI" ]; then
     title PARA "Check we can get RSA public keys from certificate objects"
 
     title LINE "Export Public key to a file (priv-uri)"
     ossl 'pkey -in $PRI2URI -pubout -out ${TMPPDIR}/priv-cert.pub'
     title LINE "Export Public key to a file (base-uri)"
     ossl 'pkey -in $BASE2URI -pubout -out ${TMPPDIR}/base-cert.pub'
-    diff ${TMPPDIR}/base-cert.pub ${TMPPDIR}/priv-cert.pub
+    diff "${TMPPDIR}/base-cert.pub" "${TMPPDIR}/priv-cert.pub"
 
     # The MacOS keeps crashing in this step so lets skip the remaining tests
     if [ "$(uname)" == "Darwin" ]; then
@@ -68,7 +68,7 @@ if [ ! -z "$BASE2URI" ]; then
     ossl 'pkey -in $ECPRI2URI -pubout -out ${TMPPDIR}/ec-priv-cert.pub'
     title LINE "Export Public key to a file (base-uri)"
     ossl 'pkey -in $ECBASE2URI -pubout -out ${TMPPDIR}/ec-base-cert.pub'
-    diff ${TMPPDIR}/ec-base-cert.pub ${TMPPDIR}/ec-priv-cert.pub
+    diff "${TMPPDIR}/ec-base-cert.pub" "${TMPPDIR}/ec-priv-cert.pub"
 fi
 
 exit 0

--- a/tests/trand
+++ b/tests/trand
@@ -2,11 +2,12 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Test PKCS11 RNG"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed -e "s/#MORECONF/random = random\n\n[random]\nrandom = PKCS11-RAND/" ${OPENSSL_CONF} > ${OPENSSL_CONF}.failrandom
+sed -e "s/#MORECONF/random = random\n\n[random]\nrandom = PKCS11-RAND/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.failrandom"
 OPENSSL_CONF=${OPENSSL_CONF}.failrandom
 
 FAIL=0
@@ -17,8 +18,9 @@ if [ $FAIL -eq 0 ]; then
 fi
 
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-sed -e "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" ${OPENSSL_CONF}.failrandom > ${OPENSSL_CONF}.random
-OPENSSL_CONF=${OPENSSL_CONF}.random
+sed -e "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" \
+    "${OPENSSL_CONF}.failrandom" > "${OPENSSL_CONF}.random"
+OPENSSL_CONF="${OPENSSL_CONF}.random"
 
 ossl 'rand 1'
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}

--- a/tests/trsapss
+++ b/tests/trsapss
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "DigestSign and DigestVerify with RSA PSS"
 ossl '

--- a/tests/ttls
+++ b/tests/ttls
@@ -2,7 +2,7 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 SLEEP=0.5
 # with valgrind/asan, it might take a bit longer
@@ -14,28 +14,29 @@ title PARA "Test SSL_CTX creation"
 $CHECKER ./tlsctx
 
 title PARA "Test an actual TLS connection"
-rm -f ${TMPPDIR}/s_server_input
-rm -f ${TMPPDIR}/s_server_output
+rm -f "${TMPPDIR}/s_server_input"
+rm -f "${TMPPDIR}/s_server_output"
 
 # Set up command fifo
-mkfifo ${TMPPDIR}/s_server_input
-exec 3<>${TMPPDIR}/s_server_input
+mkfifo "${TMPPDIR}/s_server_input"
+exec 3<>"${TMPPDIR}/s_server_input"
 
-#Make sure we terminate programs if test fails in the middle
+# Make sure we terminate programs if test fails in the middle
+# shellcheck disable=SC2317  # Shellcheck for some reason does not follow trap
 kill_children_print() {
     kill_children
     echo "Server output:"
-    cat ${TMPPDIR}/s_server_output
+    cat "${TMPPDIR}/s_server_output"
 }
 trap kill_children_print EXIT
 PORT=23456
-$CHECKER openssl s_server -accept ${PORT} -key ${PRIURI} -cert ${CRTURI} <&3 &
+$CHECKER openssl s_server -accept "${PORT}" -key "${PRIURI}" -cert "${CRTURI}" <&3 &
 
 sleep $SLEEP
 
 # The client will error when the server drops the connection
 set +e
-$CHECKER openssl s_client -connect localhost:${PORT} -quiet > ${TMPPDIR}/s_server_output &
+$CHECKER openssl s_client -connect "localhost:${PORT}" -quiet > "${TMPPDIR}/s_server_output" &
 set -e
 
 # Wait to make sure client is connected
@@ -51,10 +52,10 @@ echo "Q" >&3
 
 # Tear down command fifo
 exec 3>&-
-rm -f ${TMPPDIR}/s_server_input
+rm -f "${TMPPDIR}/s_server_input"
 
 echo "Check message was successfully delivered over TLS"
-grep " TLS SUCCESSFUL " ${TMPPDIR}/s_server_output
+grep " TLS SUCCESSFUL " "${TMPPDIR}/s_server_output"
 
 title PARA "Kill any remaining children and wait for them"
 kill_children

--- a/tests/turi
+++ b/tests/turi
@@ -2,10 +2,10 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-source ${TESTSSRCDIR}/helpers.sh
+source "${TESTSSRCDIR}/helpers.sh"
 
 title PARA "Check that storeutl returns URIs"
-ossl 'storeutl -text pkcs11:' $helper_emit
+ossl 'storeutl -text pkcs11:' "$helper_emit"
 output="$helper_output"
 FAIL=0
 echo "$output" | grep "URI pkcs11:" > /dev/null 2>&1 || FAIL=1
@@ -15,14 +15,14 @@ if [ $FAIL -ne 0 ]; then
 fi
 
 URISonly=$(echo "$helper_output" | grep "^URI")
-URIS=(${URISonly//URI / })
+mapfile -t URIS <<< "${URISonly//URI /}"
 
 title PARA "Check returned URIs work to find objects"
-for uri in "${URIS[@]#URI }"; do
+for uri in "${URIS[@]}"; do
     echo "\$uri=${uri}"
-    ossl 'storeutl -text "$uri"' $helper_emit
+    ossl 'storeutl -text "$uri"' "$helper_emit"
     output="$helper_output"
-    matchURI=`echo "$output" | grep "URI pkcs11:" | cut -d ' ' -f 2`
+    matchURI=$(echo "$output" | grep "URI pkcs11:" | cut -d ' ' -f 2)
     if [[ "${uri}" != "${matchURI}" ]]; then
         echo "Unmatched URI returned by storeutl"
         echo "Expected $uri"
@@ -32,13 +32,13 @@ for uri in "${URIS[@]#URI }"; do
 done
 
 firstURI=${URIS[0]#URI pkcs11:}
-firstCMPS=(${firstURI//;/ })
+IFS=";" read -r -a firstCMPS <<< "$firstURI"
 
 title PARA "Check each URI component is tested"
 
 for cmp in "${firstCMPS[@]}"; do
     echo "\$cmp=${cmp}"
-    ossl 'storeutl -text "pkcs11:${cmp}"' $helper_emit
+    ossl 'storeutl -text "pkcs11:${cmp}"' "$helper_emit"
     output="$helper_output"
     echo "$output" | grep "URI pkcs11:" > /dev/null 2>&1 || FAIL=1
     if [ $FAIL -ne 0 ]; then

--- a/tests/turi
+++ b/tests/turi
@@ -15,7 +15,11 @@ if [ $FAIL -ne 0 ]; then
 fi
 
 URISonly=$(echo "$helper_output" | grep "^URI")
-mapfile -t URIS <<< "${URISonly//URI /}"
+# poor mans mapfile for bash 3 on macos
+declare -a URIS
+while read -r var; do
+    URIS+=("$var")
+done <<< "${URISonly//URI /}"
 
 title PARA "Check returned URIs work to find objects"
 for uri in "${URIS[@]}"; do


### PR DESCRIPTION
Follow-up to #254 where the shell did not do what it was supposed to be doing, I decided to take shellcheck into action and squash the warnings to keep the tests "clean". On the way I also reformatted they github yml files as the editor was going craze every time I had to touch them.