### PR TITLE
Set the value for CRYPTO_LIBS flag correctly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,12 @@ AC_ARG_WITH([openssl],
   [
       # Checks for libraries.
       PKG_CHECK_MODULES(
+        [CRYPTO],
+        [libcrypto >= 3.0.7],
+        ,
+        [AC_MSG_ERROR([libcrypto >= 3.0.7 is required])]
+      )
+      PKG_CHECK_MODULES(
         [OPENSSL],
         [libcrypto >= 3.0.7, libssl],
         ,


### PR DESCRIPTION
Currently value for CRYPTO_LIBS  has a bogus value.

PKG_CHECK_MODULES automatically creates _LIBS flag ([See](https://developer-old.gnome.org/anjuta-build-tutorial/stable/library-autotools.html.en) ). This was missing for [CRYPTO].

Due do this, rpmlint -i test on the [rpm](https://download.copr.fedorainfracloud.org/results/saprasad/pkcs11-provider/fedora-rawhide-x86_64/06125202-pkcs11-provider/pkcs11-provider-0.1-1.fc39.x86_64.rpm) had 106 warning like:

pkcs11-provider.x86_64: W: undefined-non-weak-symbol /usr/lib64/ossl-modules/pkcs11.so ASN1_INTEGER_it»·(/usr/lib64/ossl-modules/pkcs11.so)

And libcrypto.so was missing in Requires

Requires

pkcs11-provider (rpmlib, GLIBC filtered):
    libc.so.6()(64bit)
    rtld(GNU_HASH)


This PR fixes the above issues.

[root@vm-10-0-187-0 packaging]# ldd /usr/lib64/ossl-modules/pkcs11.so 
    linux-vdso.so.1 (0x00007fffecf29000)
    libcrypto.so.3 => /lib64/libcrypto.so.3 (0x00007f109b000000)
    libc.so.6 => /lib64/libc.so.6 (0x00007f109ac00000)
    libz.so.1 => /lib64/libz.so.1 (0x00007f109b5f6000)
    /lib64/ld-linux-x86-64.so.2 (0x00007f109b65f000)
[root@vm-10-0-187-0 packaging]# rpmlint -i pkcs11-provider
======================================================================================================== rpmlint session starts =======================================================================================================
rpmlint: 2.4.0
configuration:
    /usr/lib/python3.11/site-packages/rpmlint/configdefaults.toml
    /etc/xdg/rpmlint/fedora-legacy-licenses.toml
    /etc/xdg/rpmlint/fedora-spdx-licenses.toml
    /etc/xdg/rpmlint/fedora.toml
    /etc/xdg/rpmlint/scoring.toml
    /etc/xdg/rpmlint/users-groups.toml
    /etc/xdg/rpmlint/warn-on-functions.toml
checks: 31, packages: 1

========================================================================= 1 packages and 0 specfiles checked; 0 errors, 0 warnings, 0 badness; has taken 0.0 s 


