### PR TITLE
Skip login if token does not require login

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -677,6 +677,12 @@ done:
     return ret;
 }
 
+static bool check_skip_login(P11PROV_CTX *ctx, P11PROV_SLOT *slot)
+{
+    return p11prov_ctx_login_behavior(ctx) != PUBKEY_LOGIN_ALWAYS
+           && !p11prov_slot_check_req_login(slot);
+}
+
 /* There are three possible ways to call this function.
  * 1. One shot call on a specific slot
  *      slotid must point to a specific slot number
@@ -734,7 +740,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
         if (ret != CKR_OK) {
             goto done;
         }
-        if (reqlogin) {
+        if (reqlogin && !check_skip_login(provctx, slot)) {
             ret = slot_login(slot, uri, pw_cb, pw_cbarg, NULL);
             if (ret != CKR_OK) {
                 goto done;
@@ -768,7 +774,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                 /* keep going */
                 continue;
             }
-            if (reqlogin) {
+            if (reqlogin && !check_skip_login(provctx, slot)) {
                 ret = slot_login(slot, uri, pw_cb, pw_cbarg, NULL);
                 if (ret != CKR_OK) {
                     /* keep going */

--- a/src/slot.c
+++ b/src/slot.c
@@ -516,3 +516,8 @@ P11PROV_SESSION_POOL *p11prov_slot_get_session_pool(P11PROV_SLOT *slot)
 {
     return slot->pool;
 }
+
+bool p11prov_slot_check_req_login(P11PROV_SLOT *slot)
+{
+    return slot->token.flags & CKF_LOGIN_REQUIRED;
+}

--- a/src/slot.h
+++ b/src/slot.h
@@ -28,5 +28,6 @@ CK_RV p11prov_slot_set_bad_pin(P11PROV_SLOT *slot, const char *bad_pin);
 const char *p11prov_slot_get_cached_pin(P11PROV_SLOT *slot);
 CK_RV p11prov_slot_set_cached_pin(P11PROV_SLOT *slot, const char *cached_pin);
 P11PROV_SESSION_POOL *p11prov_slot_get_session_pool(P11PROV_SLOT *slot);
+bool p11prov_slot_check_req_login(P11PROV_SLOT *slot);
 
 #endif /* _SLOT_H */


### PR DESCRIPTION
Encountered an issue with tokens that don't require login while using this provider with https://github.com/tpm2-software/tpm2-pkcs11 where sign operations would not complete properly and always produced an error due to login error.

This is a proposal to just skip the token login if the flag CKF_LOGIN_REQUIRED is not present.

I'm not sure if there are any side effects to this but it at least solved my issue.