### PR TITLE
Enable gpg signature verification in spec file

### DIFF
--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -1,3 +1,6 @@
+#Enable gpg signature verification
+%bcond_with gpgcheck
+
 Name:          pkcs11-provider
 Version:       0.2
 Release:       1%{?dist}
@@ -5,6 +8,10 @@ Summary:       A PKCS#11 provider for OpenSSL 3.0+
 License:       Apache-2.0
 URL:           https://github.com/latchset/pkcs11-provider
 Source0:       %{url}/releases/download/v%{version}/%{name}-%{version}.tar.xz
+%if %{with gpgcheck}
+Source1:       %{url}/releases/download/v%{version}/%{name}-%{version}.tar.xz.asc
+Source2:       https://people.redhat.com/~ssorce/simo_redhat.asc
+%endif
 
 BuildRequires: openssl-devel >= 3.0.7
 BuildRequires: gcc
@@ -12,6 +19,10 @@ BuildRequires: autoconf-archive
 BuildRequires: automake
 BuildRequires: libtool
 BuildRequires: make
+%if %{with gpgcheck}
+BuildRequires: gnupg2
+%endif
+
 # for tests
 BuildRequires: nss-devel
 BuildRequires: nss-softokn
@@ -35,6 +46,10 @@ compatible to previous versions as well.
 
 
 %prep
+%if %{with gpgcheck}
+%{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
+%endif
+
 %autosetup -p1
 
 


### PR DESCRIPTION
Enable gpg signature verification in spec file with option gpgcheck

to enable this in rpmbuilds, use

rpmbuild -ba --with=gpgcheck pkcs11-provider.spec

(It is disabled by default in  upstream CI)

Test logs:

[root@vm-10-0-184-239 packaging]# rpmbuild -ba --with=gpgcheck pkcs11-provider.spec 
setting SOURCE_DATE_EPOCH=1688947200
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.BRyc8l
+ umask 022
+ cd /root/rpmbuild/BUILD
+ /usr/lib/rpm/redhat/gpgverify --keyring=/root/rpmbuild/SOURCES/simo_redhat.asc --signature=/root/rpmbuild/SOURCES/pkcs11-provider-0.2.tar.xz.asc --data=/root/rpmbuild/SOURCES/pkcs11-provider-0.2.tar.xz
gpgv: Signature made Fri Jul  7 06:11:53 2023 EDT
gpgv:                using RSA key 7C7BD146943B206BB645B64594EAD67E004B65AB
gpgv:                issuer "simo@redhat.com"
gpgv: Good signature from "Simo Sorce <simo@redhat.com>"
gpgv:                 aka "Simo Sorce <s@ssimo.org>"
+ cd /root/rpmbuild/BUILD
