### PR TITLE
Change how key export works, and add key import functionality as well as key match

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -130,8 +130,8 @@ static int p11prov_rsa_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         BIO_printf(out, "PKCS11 RSA Public Key (%lu bits)\n", keysize);
-        ret = p11prov_obj_export_public_rsa_key(
-            key, p11prov_rsa_print_public_key, out);
+        ret = p11prov_obj_export_public_key(key, CKK_RSA, true,
+                                            p11prov_rsa_print_public_key, out);
         if (ret != RET_OSSL_OK) {
             BIO_printf(out, "[Error: Failed to decode public key data]\n");
         }
@@ -219,8 +219,8 @@ static P11PROV_RSA_PUBKEY *p11prov_rsa_pubkey_to_asn1(P11PROV_OBJ *key)
         return NULL;
     }
 
-    ret = p11prov_obj_export_public_rsa_key(key, p11prov_rsa_set_asn1key_data,
-                                            asn1key);
+    ret = p11prov_obj_export_public_key(key, CKK_RSA, true,
+                                        p11prov_rsa_set_asn1key_data, asn1key);
 
     if (ret != RET_OSSL_OK) {
         P11PROV_RSA_PUBKEY_free(asn1key);
@@ -549,8 +549,8 @@ static X509_PUBKEY *p11prov_ec_pubkey_to_x509(P11PROV_OBJ *key)
     X509_PUBKEY *pubkey;
     int ret;
 
-    ret = p11prov_obj_export_public_ec_key(key, p11prov_ec_set_keypoint_data,
-                                           &keypoint);
+    ret = p11prov_obj_export_public_key(
+        key, CKK_EC, true, p11prov_ec_set_keypoint_data, &keypoint);
     if (ret != RET_OSSL_OK) {
         ecdsa_key_point_free(&keypoint);
         return NULL;
@@ -779,8 +779,8 @@ static int p11prov_ec_encoder_encode_text(void *inctx, OSSL_CORE_BIO *cbio,
 
     if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) {
         BIO_printf(out, "PKCS11 EC Public Key (%lu bits)\n", keysize);
-        ret = p11prov_obj_export_public_ec_key(key, p11prov_ec_print_public_key,
-                                               out);
+        ret = p11prov_obj_export_public_key(key, CKK_EC, true,
+                                            p11prov_ec_print_public_key, out);
         if (ret != RET_OSSL_OK) {
             BIO_printf(out, "[Error: Failed to decode public key data]\n");
         }

--- a/src/interface.c
+++ b/src/interface.c
@@ -154,6 +154,7 @@ static CK_RV p11prov_interface_init(P11PROV_MODULE *mctx)
 {
     /* Try to get 3.0 interface by default */
     P11PROV_INTERFACE *intf;
+    CK_UTF8CHAR_PTR intf_name = (CK_UTF8CHAR_PTR) "PKCS 11";
     CK_VERSION version = { 3, 0 };
     CK_INTERFACE *ck_interface;
     CK_RV ret;
@@ -174,7 +175,7 @@ static CK_RV p11prov_interface_init(P11PROV_MODULE *mctx)
         intf->GetInterface = p11prov_NO_GetInterface;
     }
 
-    ret = intf->GetInterface(NULL, &version, &ck_interface, 0);
+    ret = intf->GetInterface(intf_name, &version, &ck_interface, 0);
     if (ret != CKR_OK && ret != CKR_FUNCTION_NOT_SUPPORTED) {
         /* retry without asking for specific version */
         ret = intf->GetInterface(NULL, NULL, &ck_interface, 0);

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1192,6 +1192,48 @@ static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
             return ret;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_EC_PUB_X);
+    if (p) {
+        CK_ATTRIBUTE *pub_x;
+
+        if (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER) {
+            return RET_OSSL_ERR;
+        }
+        ret = p11prov_obj_get_ec_public_x_y(key, &pub_x, NULL);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+
+        p->return_size = pub_x->ulValueLen;
+        if (p->data) {
+            if (p->data_size < pub_x->ulValueLen) {
+                return RET_OSSL_ERR;
+            }
+            memcpy(p->data, pub_x->pValue, pub_x->ulValueLen);
+            p->data_size = pub_x->ulValueLen;
+        }
+    }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_EC_PUB_Y);
+    if (p) {
+        CK_ATTRIBUTE *pub_y;
+
+        if (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER) {
+            return RET_OSSL_ERR;
+        }
+        ret = p11prov_obj_get_ec_public_x_y(key, NULL, &pub_y);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+
+        p->return_size = pub_y->ulValueLen;
+        if (p->data) {
+            if (p->data_size < pub_y->ulValueLen) {
+                return RET_OSSL_ERR;
+            }
+            memcpy(p->data, pub_y->pValue, pub_y->ulValueLen);
+            p->data_size = pub_y->ulValueLen;
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -1204,6 +1246,8 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
         OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_DEFAULT_DIGEST, NULL, 0),
+        OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_X, NULL, 0),
+        OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_Y, NULL, 0),
         /*
          * OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY
          * OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAM
@@ -1221,8 +1265,6 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
          * OSSL_PKEY_PARAM_PRIV_KEY
          * OSSL_PKEY_PARAM_USE_COFACTOR_ECDH
          * OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC
-         * OSSL_PKEY_PARAM_EC_PUB_X
-         * OSSL_PKEY_PARAM_EC_PUB_Y
          */
         OSSL_PARAM_END,
     };

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -604,7 +604,7 @@ static int p11prov_rsa_export(void *keydata, int selection,
 
     /* if anything else is asked for we can't provide it, so be strict */
     if ((class == CKO_PUBLIC_KEY) || (selection & ~(PUBLIC_PARAMS)) == 0) {
-        return p11prov_obj_export_public_rsa_key(key, cb_fn, cb_arg);
+        return p11prov_obj_export_public_key(key, CKK_RSA, true, cb_fn, cb_arg);
     }
 
     return RET_OSSL_ERR;
@@ -1074,7 +1074,7 @@ static int p11prov_ec_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
 
     /* this will return the public EC_POINT as well as DOMAIN_PARAMTERS */
     if ((class == CKO_PUBLIC_KEY) || (selection & ~(PUBLIC_PARAMS)) == 0) {
-        return p11prov_obj_export_public_ec_key(key, cb_fn, cb_arg);
+        return p11prov_obj_export_public_key(key, CKK_EC, true, cb_fn, cb_arg);
     }
 
     return RET_OSSL_ERR;
@@ -1347,7 +1347,8 @@ static int p11prov_ed_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
 
     /* this will return the public EC_POINT */
     if ((class == CKO_PUBLIC_KEY) || (selection & ~(PUBLIC_PARAMS)) == 0) {
-        return p11prov_obj_export_public_ec_key(key, cb_fn, cb_arg);
+        return p11prov_obj_export_public_key(key, CKK_EC_EDWARDS, true, cb_fn,
+                                             cb_arg);
     }
 
     return RET_OSSL_ERR;

--- a/src/objects.h
+++ b/src/objects.h
@@ -60,6 +60,9 @@ int p11prov_obj_get_ec_public_x_y(P11PROV_OBJ *obj, CK_ATTRIBUTE **pub_x,
 int p11prov_obj_key_cmp(P11PROV_OBJ *obj1, P11PROV_OBJ *obj2, CK_KEY_TYPE type,
                         int cmp_type);
 
+CK_RV p11prov_obj_import_key(P11PROV_OBJ *key, CK_KEY_TYPE type,
+                             CK_OBJECT_CLASS class, const OSSL_PARAM params[]);
+
 #define ED25519 "ED25519"
 #define ED25519_BIT_SIZE 256
 #define ED25519_BYTE_SIZE ED25519_BIT_SIZE / 8

--- a/src/objects.h
+++ b/src/objects.h
@@ -51,6 +51,8 @@ const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj);
 int p11prov_obj_export_public_key(P11PROV_OBJ *obj, CK_KEY_TYPE key_type,
                                   bool search_related, OSSL_CALLBACK *cb_fn,
                                   void *cb_arg);
+int p11prov_obj_get_ec_public_x_y(P11PROV_OBJ *obj, CK_ATTRIBUTE **pub_x,
+                                  CK_ATTRIBUTE **pub_y);
 
 #define ED25519 "ED25519"
 #define ED25519_BIT_SIZE 256

--- a/src/objects.h
+++ b/src/objects.h
@@ -47,11 +47,10 @@ CK_RV p11prov_derive_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
 CK_RV p11prov_obj_set_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                                  P11PROV_OBJ *obj, CK_ATTRIBUTE *template,
                                  CK_ULONG tsize);
-int p11prov_obj_export_public_rsa_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
-                                      void *cb_arg);
-int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj, OSSL_CALLBACK *cb_fn,
-                                     void *cb_arg);
 const char *p11prov_obj_get_ec_group_name(P11PROV_OBJ *obj);
+int p11prov_obj_export_public_key(P11PROV_OBJ *obj, CK_KEY_TYPE key_type,
+                                  bool search_related, OSSL_CALLBACK *cb_fn,
+                                  void *cb_arg);
 
 #define ED25519 "ED25519"
 #define ED25519_BIT_SIZE 256

--- a/src/objects.h
+++ b/src/objects.h
@@ -54,6 +54,12 @@ int p11prov_obj_export_public_key(P11PROV_OBJ *obj, CK_KEY_TYPE key_type,
 int p11prov_obj_get_ec_public_x_y(P11PROV_OBJ *obj, CK_ATTRIBUTE **pub_x,
                                   CK_ATTRIBUTE **pub_y);
 
+#define OBJ_CMP_KEY_TYPE 0x00
+#define OBJ_CMP_KEY_PUBLIC 0x01
+#define OBJ_CMP_KEY_PRIVATE 0x02
+int p11prov_obj_key_cmp(P11PROV_OBJ *obj1, P11PROV_OBJ *obj2, CK_KEY_TYPE type,
+                        int cmp_type);
+
 #define ED25519 "ED25519"
 #define ED25519_BIT_SIZE 256
 #define ED25519_BYTE_SIZE ED25519_BIT_SIZE / 8

--- a/src/slot.c
+++ b/src/slot.c
@@ -458,6 +458,33 @@ CK_RV p11prov_slot_get_obj_pool(P11PROV_CTX *ctx, CK_SLOT_ID id,
     return ret;
 }
 
+CK_RV p11prov_slot_find_obj_pool(P11PROV_CTX *ctx, slot_pool_callback cb,
+                                 void *cb_ctx)
+{
+    P11PROV_SLOT *slot = NULL;
+    P11PROV_SLOTS_CTX *sctx;
+    bool found = false;
+    CK_RV ret;
+
+    ret = p11prov_take_slots(ctx, &sctx);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    for (int s = 0; s < sctx->num; s++) {
+        slot = sctx->slots[s];
+        if (slot->objects) {
+            found = cb(cb_ctx, slot->objects);
+        }
+        if (found) {
+            break;
+        }
+    }
+
+    p11prov_return_slots(sctx);
+    return CKR_OK;
+}
+
 CK_SLOT_ID p11prov_slot_get_slot_id(P11PROV_SLOT *slot)
 {
     return slot->id;

--- a/src/slot.h
+++ b/src/slot.h
@@ -19,6 +19,9 @@ int p11prov_check_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID id,
                             CK_MECHANISM_TYPE mechtype);
 CK_RV p11prov_slot_get_obj_pool(P11PROV_CTX *provctx, CK_SLOT_ID id,
                                 P11PROV_OBJ_POOL **pool);
+typedef bool (*slot_pool_callback)(void *, P11PROV_OBJ_POOL *);
+CK_RV p11prov_slot_find_obj_pool(P11PROV_CTX *ctx, slot_pool_callback cb,
+                                 void *cb_ctx);
 CK_SLOT_ID p11prov_slot_get_slot_id(P11PROV_SLOT *slot);
 CK_SLOT_INFO *p11prov_slot_get_slot(P11PROV_SLOT *slot);
 CK_TOKEN_INFO *p11prov_slot_get_token(P11PROV_SLOT *slot);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ testssrcdir=@abs_srcdir@
 #VALGRIND_SUPPRESSIONS_FILES = $(top_srcdir)/tests/pkcs11-provider.supp
 VALGRIND_FLAGS = --num-callers=30 -q --keep-debuginfo=yes
 
-check_PROGRAMS = tsession tgenkey tlsctx tdigests treadkeys tfork pincache
+check_PROGRAMS = tsession tgenkey tlsctx tdigests treadkeys tcmpkeys tfork pincache
 
 tsession_SOURCES = tsession.c
 tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -31,6 +31,10 @@ tdigests_LDADD = $(OPENSSL_LIBS)
 treadkeys_SOURCES = treadkeys.c
 treadkeys_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 treadkeys_LDADD = $(OPENSSL_LIBS)
+
+tcmpkeys_SOURCES = tcmpkeys.c
+tcmpkeys_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tcmpkeys_LDADD = $(OPENSSL_LIBS)
 
 tfork_SOURCES = tfork.c
 tfork_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -152,6 +152,11 @@ fi
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 rm -f "${OPENSSL_CONF}.nopin"
 
+title PARA "Test EVP_PKEY_eq on public RSA key"
+$CHECKER ./tcmpkeys $PUBURI ${TMPPDIR}/rsa.pub.uripin.pem
+title PARA "Test EVP_PKEY_eq on public EC key"
+$CHECKER ./tcmpkeys $ECPUBURI ${TMPPDIR}/ec.pub.uripin.pem
+
 title PARA "Test PIN caching"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
 sed "s/^pkcs11-module-token-pin.*$/pkcs11-module-cache-pins = cache/" \

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -107,7 +107,6 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-rm -f "${OPENSSL_CONF}.noexport"
 
 title PARA "Test CSR generation from RSA private keys"
 ossl '
@@ -150,12 +149,25 @@ if [ $FAIL -ne 0 ]; then
 fi
 
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-rm -f "${OPENSSL_CONF}.nopin"
 
-title PARA "Test EVP_PKEY_eq on public RSA key"
-$CHECKER ./tcmpkeys $PUBURI ${TMPPDIR}/rsa.pub.uripin.pem
-title PARA "Test EVP_PKEY_eq on public EC key"
-$CHECKER ./tcmpkeys $ECPUBURI ${TMPPDIR}/ec.pub.uripin.pem
+title PARA "Test EVP_PKEY_eq on public RSA key both on token"
+$CHECKER ./tcmpkeys "$PUBURI" "$PUBURI"
+title PARA "Test EVP_PKEY_eq on public EC key both on token"
+$CHECKER ./tcmpkeys "$ECPUBURI" "$ECPUBURI"
+
+title PARA "Test EVP_PKEY_eq on public RSA key via import"
+$CHECKER ./tcmpkeys "$PUBURI" "${TMPPDIR}"/rsa.pub.uripin.pem
+title PARA "Test EVP_PKEY_eq on public EC key via import"
+$CHECKER ./tcmpkeys "$ECPUBURI" "${TMPPDIR}"/ec.pub.uripin.pem
+
+title PARA "Test EVP_PKEY_eq with key exporting disabled"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+OPENSSL_CONF=${OPENSSL_CONF}.noexport
+title PARA "Test RSA key"
+$CHECKER ./tcmpkeys "$PUBURI" "$PUBURI"
+title PARA "Test EC key"
+$CHECKER ./tcmpkeys "$ECPUBURI" "$ECPUBURI"
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 
 title PARA "Test PIN caching"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}

--- a/tests/tcmpkeys.c
+++ b/tests/tcmpkeys.c
@@ -1,0 +1,67 @@
+/* Copyright (C) 2023 Timo Teräs <timo.teras@iki.fi>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/store.h>
+#include <openssl/core_names.h>
+
+static EVP_PKEY *load_key(const char *uri)
+{
+    OSSL_STORE_CTX *store;
+    OSSL_STORE_INFO *info;
+    EVP_PKEY *key = NULL;
+
+    store = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL);
+    if (store == NULL) {
+        fprintf(stderr, "Failed to open store: %s\n", uri);
+        exit(EXIT_FAILURE);
+    }
+
+    for (info = OSSL_STORE_load(store); info != NULL;
+         info = OSSL_STORE_load(store)) {
+        int type = OSSL_STORE_INFO_get_type(info);
+
+        if (key != NULL) {
+            fprintf(stderr, "Multiple keys matching URI: %s\n", uri);
+            exit(EXIT_FAILURE);
+        }
+
+        switch (type) {
+        case OSSL_STORE_INFO_PUBKEY:
+            key = OSSL_STORE_INFO_get1_PUBKEY(info);
+            break;
+        case OSSL_STORE_INFO_PKEY:
+            key = OSSL_STORE_INFO_get1_PKEY(info);
+            break;
+        }
+        OSSL_STORE_INFO_free(info);
+    }
+
+    if (key == NULL) {
+        fprintf(stderr, "Failed to load key from URI: %s\n", uri);
+        exit(EXIT_FAILURE);
+    }
+    OSSL_STORE_close(store);
+
+    return key;
+}
+
+int main(int argc, char *argv[])
+{
+    EVP_PKEY *a, *b;
+    int rc = EXIT_FAILURE;
+
+    if (argc != 3) {
+        fprintf(stderr, "Usage: tcmpkeys [keyuri-a] [keyuri-b]\n");
+        exit(EXIT_FAILURE);
+    }
+    a = load_key(argv[1]);
+    b = load_key(argv[2]);
+    if (EVP_PKEY_eq(a, b) == 1) {
+        rc = EXIT_SUCCESS;
+    }
+    EVP_PKEY_free(a);
+    EVP_PKEY_free(b);
+    return rc;
+}

--- a/tests/tgenkey.c
+++ b/tests/tgenkey.c
@@ -89,6 +89,26 @@ static void check_keys(OSSL_STORE_CTX *store, const char *key_type)
             BN_free(tmp);
             tmp = NULL;
         }
+    } else if (strcmp(key_type, "EC") == 0) {
+        BIGNUM *tmp = NULL;
+        int ret;
+
+        ret = EVP_PKEY_get_bn_param(pubkey, OSSL_PKEY_PARAM_EC_PUB_X, &tmp);
+        if (ret != 1) {
+            fprintf(stderr, "Failed to get X param from public key");
+            exit(EXIT_FAILURE);
+        } else {
+            BN_free(tmp);
+            tmp = NULL;
+        }
+        ret = EVP_PKEY_get_bn_param(pubkey, OSSL_PKEY_PARAM_EC_PUB_Y, &tmp);
+        if (ret != 1) {
+            fprintf(stderr, "Failed to get Y param from public key");
+            exit(EXIT_FAILURE);
+        } else {
+            BN_free(tmp);
+            tmp = NULL;
+        }
     }
 
     EVP_PKEY_free(privkey);


### PR DESCRIPTION
This are various fixes to small things I had in my tree and to recent issues reported in #265 and #266 

Note that I changed how export work, including an attempt to re-enable direct export from store and then again disable it.