### PR TITLE
Smarten up handling of login session

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -96,6 +96,10 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
         || login_behavior == PUBKEY_LOGIN_ALWAYS) {
         login = true;
     }
+    if (p11prov_uri_get_class(ctx->parsed_uri) == CKO_PUBLIC_KEY
+        && login_behavior != PUBKEY_LOGIN_ALWAYS) {
+        login = false;
+    }
 
     /* error stack mark so we can unwind in case of repeat to avoid
      * returning bogus errors */


### PR DESCRIPTION
Although we want to ensure a login session is available for certain operations, we also do not want to unnecessarily fail them when mutliple operations are running concurrently.
As login status is token global, all we need to ensure is that a login session exist. This can be reasonably easily determined by session status as well.
So where we do not actually need to use the login_session directly we can simply check the status and return positively.

The only place that really wants to use a login_session directly is the caching layer which is tolerant to failure already.