### PR TITLE
Allow setting OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY for EC keys

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1003,6 +1003,8 @@ DISPATCH_KEYMGMT_FN(ec, export_types);
 DISPATCH_KEYMGMT_FN(ec, query_operation_name);
 DISPATCH_KEYMGMT_FN(ec, get_params);
 DISPATCH_KEYMGMT_FN(ec, gettable_params);
+DISPATCH_KEYMGMT_FN(ec, set_params);
+DISPATCH_KEYMGMT_FN(ec, settable_params);
 
 static void *p11prov_ec_new(void *provctx)
 {
@@ -1373,6 +1375,40 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
     return params;
 }
 
+static int p11prov_ec_set_params(void *keydata, const OSSL_PARAM params[])
+{
+    P11PROV_OBJ *key = (P11PROV_OBJ *)keydata;
+    const OSSL_PARAM *p;
+
+    P11PROV_debug("ec set params %p", keydata);
+
+    if (key == NULL) {
+        return RET_OSSL_ERR;
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
+    if (p) {
+        if (p->data_type != OSSL_PARAM_OCTET_STRING) {
+            return RET_OSSL_ERR;
+        }
+        if (p11prov_obj_set_ec_encoded_public_key(key, p->data, p->data_size)
+            != CKR_OK) {
+            return RET_OSSL_ERR;
+        }
+    }
+
+    return RET_OSSL_OK;
+}
+
+static const OSSL_PARAM *p11prov_ec_settable_params(void *provctx)
+{
+    static const OSSL_PARAM params[] = {
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return params;
+}
+
 const OSSL_DISPATCH p11prov_ec_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ec, NEW, new),
     DISPATCH_KEYMGMT_ELEM(ec, GEN_INIT, gen_init),
@@ -1391,6 +1427,8 @@ const OSSL_DISPATCH p11prov_ec_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ec, QUERY_OPERATION_NAME, query_operation_name),
     DISPATCH_KEYMGMT_ELEM(ec, GET_PARAMS, get_params),
     DISPATCH_KEYMGMT_ELEM(ec, GETTABLE_PARAMS, gettable_params),
+    DISPATCH_KEYMGMT_ELEM(ec, SET_PARAMS, set_params),
+    DISPATCH_KEYMGMT_ELEM(ec, SETTABLE_PARAMS, settable_params),
     { 0, NULL },
 };
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -63,6 +63,10 @@ int p11prov_obj_key_cmp(P11PROV_OBJ *obj1, P11PROV_OBJ *obj2, CK_KEY_TYPE type,
 CK_RV p11prov_obj_import_key(P11PROV_OBJ *key, CK_KEY_TYPE type,
                              CK_OBJECT_CLASS class, const OSSL_PARAM params[]);
 
+CK_RV p11prov_obj_set_ec_encoded_public_key(P11PROV_OBJ *key,
+                                            const void *pubkey,
+                                            size_t pubkey_len);
+
 #define ED25519 "ED25519"
 #define ED25519_BIT_SIZE 256
 #define ED25519_BYTE_SIZE ED25519_BIT_SIZE / 8

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,7 +62,8 @@ tmp.softhsm:
 dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
 	test-wrapper tbasic tcerts tecc tecdh tedwards tdemoca thkdf \
-	toaepsha2 trsapss tdigest ttls tpubkey tfork turi trand tecxc
+	toaepsha2 trsapss tdigest ttls tpubkey tfork turi trand tecxc \
+	tcms
 
 test_LIST = \
 	basic-softokn.t basic-softhsm.t \
@@ -82,7 +83,9 @@ test_LIST = \
 	rand-softokn.t rand-softhsm.t \
 	readkeys-softokn.t readkeys-softhsm.t \
 	tls-softokn.t tls-softhsm.t \
-	uri-softokn.t uri-softhsm.t ecxc-softhsm.t
+	uri-softokn.t uri-softhsm.t \
+	ecxc-softhsm.t \
+	cms-softokn.t
 
 .PHONY: $(test_LIST)
 

--- a/tests/tcms
+++ b/tests/tcms
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "${TESTSSRCDIR}/helpers.sh"
+
+MESSAGEFILE=${TMPPDIR}/cms-message.txt
+echo "CMS Test Message" > "${MESSAGEFILE}"
+
+title PARA "Encrypt CMS with EC"
+ossl '
+cms -encrypt -in "${MESSAGEFILE}"
+             -out "${TMPPDIR}/cms-message.ec.enc"
+             -aes-256-cbc
+             -recip ${ECCRTURI}
+             -binary'
+
+title PARA "Decrypt CMS with EC"
+ossl '
+cms -decrypt -in "${TMPPDIR}/cms-message.ec.enc"
+             -out "${TMPPDIR}/cms-message.ec.dec"
+             -inkey ${ECPRIURI}
+             -recip ${ECCRTURI}
+             -binary'
+
+cmp "${MESSAGEFILE}" "${TMPPDIR}/cms-message.ec.dec"
+
+exit 0


### PR DESCRIPTION
This PR implements `set_params` method for EC keys that allows assigning `OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY` parameter. This parameter is required for `EVP_PKEY_set1_encoded_public_key` to function properly. This function is in turn used by `CMS_decrypt_set1_pkey_and_peer` so without this decrypting a CMS does not work at all.

This PR also adds a test to check CMS encrypt/decrypt using an EC key. Since decrypting a CMS uses `CKM_ECDH1_DERIVE` mechanism with shared data the test is being run on nss-softokn only. Although SoftHSM2 also supports ECDH1 derivation mechanism it currently (https://github.com/opendnssec/SoftHSMv2/pull/599) only does when no shared data is specified.