### PR TITLE
Reinit module only once after fork

### DIFF
--- a/src/interface.h
+++ b/src/interface.h
@@ -17,6 +17,7 @@ CK_RV p11prov_module_new(P11PROV_CTX *ctx, const char *path,
 CK_RV p11prov_module_init(P11PROV_MODULE *mctx);
 P11PROV_INTERFACE *p11prov_module_get_interface(P11PROV_MODULE *mctx);
 void p11prov_module_free(P11PROV_MODULE *mctx);
+void p11prov_module_mark_reinit(P11PROV_MODULE *mctx);
 CK_RV p11prov_module_reinit(P11PROV_MODULE *mctx);
 CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs);
 CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved);

--- a/src/provider.c
+++ b/src/provider.c
@@ -121,6 +121,7 @@ static void fork_child(void)
         if (ctx_pool.contexts[i]->status == P11PROV_INITIALIZED) {
             /* can't re-init in the fork handler, mark it */
             ctx_pool.contexts[i]->status = P11PROV_NEEDS_REINIT;
+            p11prov_module_mark_reinit(ctx_pool.contexts[i]->module);
             p11prov_slot_fork_reset(ctx_pool.contexts[i]->slots);
         }
     }


### PR DESCRIPTION
This prevent multiple threads from stomping on each other and reinit the module multiple times.

Fixes #281