### PR TITLE
Plug a small race in token login operations

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -364,7 +364,7 @@ static void cache_key(P11PROV_OBJ *obj)
     }
 
     ret = p11prov_take_login_session(obj->ctx, obj->slotid, &session);
-    if (ret != CKR_OK) {
+    if (ret != CKR_OK || session == NULL) {
         P11PROV_debug("Failed to get login session. Error %lx", ret);
         return;
     }


### PR DESCRIPTION
Some code really need to obatin a session from a login. Some other code just need to attempt but can fail. If a login session is in use cycle again until we have a login session for sure if the calling code really requires a logged in token.

Fixes #287