### PR TITLE
implement more tests with EdDSA keys (export and comparison)

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -169,7 +169,7 @@ static int p11prov_pem_decoder_p11prov_der_decode(
         return RET_OSSL_CARRY_ON_DECODING;
     }
 
-    P11PROV_debug("PEM_read_pio (fpos:%u)", BIO_tell(bin));
+    P11PROV_debug("PEM_read_bio (fpos:%u)", BIO_tell(bin));
 
     if (PEM_read_bio(bin, &pem_label, &pem_header, &der_data, &der_len) > 0
         && strcmp(pem_label, P11PROV_PEM_LABEL) == 0) {

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -40,5 +40,6 @@ extern const OSSL_DISPATCH p11prov_ec_encoder_spki_der_functions[];
 extern const OSSL_DISPATCH p11prov_ec_encoder_priv_key_info_pem_functions[];
 extern const OSSL_DISPATCH
     p11prov_ec_edwards_encoder_priv_key_info_pem_functions[];
+extern const OSSL_DISPATCH p11prov_ec_edwards_encoder_text_functions[];
 
 #endif /* _ENCODER_H */

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1839,7 +1839,7 @@ const OSSL_DISPATCH p11prov_ed25519_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ed, GETTABLE_PARAMS, gettable_params),
     DISPATCH_KEYMGMT_ELEM(ed, SET_PARAMS, set_params),
     DISPATCH_KEYMGMT_ELEM(ed, SETTABLE_PARAMS, settable_params),
-    /* TODO: match, validate, dup? */
+    /* TODO: validate, dup? */
     { 0, NULL },
 };
 
@@ -1863,7 +1863,7 @@ const OSSL_DISPATCH p11prov_ed448_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ed, GETTABLE_PARAMS, gettable_params),
     DISPATCH_KEYMGMT_ELEM(ed, SET_PARAMS, set_params),
     DISPATCH_KEYMGMT_ELEM(ed, SETTABLE_PARAMS, settable_params),
-    /* TODO: match, validate, dup? */
+    /* TODO: validate, dup? */
     { 0, NULL },
 };
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -1997,7 +1997,7 @@ int p11prov_obj_get_ed_pub_key(P11PROV_OBJ *obj, CK_ATTRIBUTE **pub)
 {
     CK_ATTRIBUTE *a;
 
-    P11PROV_debug("get ed pubkey %p", *obj);
+    P11PROV_debug("get ed pubkey %p", obj);
 
     if (!obj) {
         return RET_OSSL_ERR;

--- a/src/provider.c
+++ b/src/provider.c
@@ -1083,6 +1083,10 @@ static CK_RV operations_init(P11PROV_CTX *ctx)
     ADD_ALGO_EXT(EC, encoder,
                  "provider=pkcs11,output=der,structure=SubjectPublicKeyInfo",
                  p11prov_ec_encoder_spki_der_functions);
+    ADD_ALGO_EXT(ED25519, encoder, "provider=pkcs11,output=text",
+                 p11prov_ec_edwards_encoder_text_functions);
+    ADD_ALGO_EXT(ED448, encoder, "provider=pkcs11,output=text",
+                 p11prov_ec_edwards_encoder_text_functions);
     if (ctx->encode_pkey_as_pk11_uri) {
         ADD_ALGO_EXT(RSA, encoder,
                      "provider=pkcs11,output=pem,structure=PrivateKeyInfo",

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -247,12 +247,14 @@ pkcs11-tool --keypairgen --key-type="EC:edwards25519" --login --pin=$PINVALUE --
 	--label="${EDCRTN}" --id="$KEYID"
 ca_sign $EDCRT $EDCRTN "My ED25519 Cert" $KEYID
 
+EDBASEURIWITHPIN="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
 EDBASEURI="pkcs11:id=${URIKEYID}"
 EDPUBURI="pkcs11:type=public;id=${URIKEYID}"
 EDPRIURI="pkcs11:type=private;id=${URIKEYID}"
 EDCRTURI="pkcs11:type=cert;object=${EDCRTN}"
 
 title LINE "ED25519 PKCS11 URIS"
+echo "${EDBASEURIWITHPIN}"
 echo "${EDBASEURI}"
 echo "${EDPUBURI}"
 echo "${EDPRIURI}"
@@ -407,6 +409,7 @@ export ECPEERPUBURI="${ECPEERPUBURI}"
 export ECPEERPRIURI="${ECPEERPRIURI}"
 export ECPEERCRTURI="${ECPEERCRTURI}"
 
+export EDBASEURIWITHPIN="${EDBASEURIWITHPIN}"
 export EDBASEURI="${EDBASEURI}"
 export EDPUBURI="${EDPUBURI}"
 export EDPRIURI="${EDPRIURI}"

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -121,11 +121,13 @@ OPENSSL_CONF=${OPENSSL_CONF}.nopin
 ossl 'pkey -in $PUBURI -pubin -pubout -out ${TMPPDIR}/rsa.pub.nopin.pem'
 ossl 'pkey -in $ECPUBURI -pubin -pubout -out ${TMPPDIR}/ec.pub.nopin.pem'
 [[ -n $ECXPUBURI ]] && ossl 'pkey -in $ECXPUBURI -pubin -pubout -out ${TMPPDIR}/ecx.pub.nopin.pem'
+[[ -n $EDPUBURI ]] && ossl 'pkey -in $EDPUBURI -pubin -pubout -out ${TMPPDIR}/ed.pub.nopin.pem'
 
 title PARA "Test fetching public keys with a PIN in URI"
 ossl 'pkey -in $BASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/rsa.pub.uripin.pem'
 ossl 'pkey -in $ECBASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/ec.pub.uripin.pem'
 [[ -n $ECXBASEURIWITHPIN ]] && ossl 'pkey -in $ECXBASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/ecx.pub.uripin.pem'
+[[ -n $EDBASEURIWITHPIN ]] && ossl 'pkey -in $EDBASEURIWITHPIN -pubin -pubout -out ${TMPPDIR}/ed.pub.uripin.pem'
 
 title PARA "Test prompting without PIN in config files"
 output=$(expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PRIURI}\" -text -noout;

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -11,7 +11,7 @@ title LINE "Print ED25519 Public key from private"
 ossl 'pkey -in $EDPRIURI -pubout -text' $helper_emit
 output="$helper_output"
 FAIL=0
-echo "$output" | grep "ED25519 Public-Key" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "ED25519 Public Key" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Could not extract public key from private"
     echo

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -39,6 +39,9 @@ req -new -batch -key "${EDPRIURI}" -out ${TMPPDIR}/ed25519_csr.pem'
 ossl '
 req -in ${TMPPDIR}/ed25519_csr.pem -verify -noout'
 
+title PARA "Test EVP_PKEY_eq on public Edwards key both on token"
+$CHECKER ./tcmpkeys "$EDPUBURI" "$EDPUBURI"
+
 title PARA "Test EVP_PKEY_eq on public ED key via import"
 $CHECKER ./tcmpkeys "$EDPUBURI" "${TMPPDIR}"/edout.pub
 title PARA "Match private ED key against public key"


### PR DESCRIPTION
Fixes #272.

Now, it fails though. If I read it right, the OpenSSL returns `OSSL_STORE_INFO_PARAMS` type from the STORE API when I read the public PEM file exported from the provider, while I do not see anything missing in there so I will just drop it here and hope to get back to investigate the issue later.