### PR TITLE
Fix: enable cross compilation by removing the AC_CHECK_FILE macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,11 +128,13 @@ PKG_CHECK_EXISTS(
         )]
 )
 
-AC_CHECK_FILE($SOFTOKENDIR/libsoftokn3$SHARED_EXT, [],
-    [AC_CHECK_FILE($SOFTOKENDIR/nss/libsoftokn3$SHARED_EXT,
-        [AC_SUBST([SOFTOKEN_SUBDIR], "nss/")],
-        [AC_MSG_WARN([Softoken library missing, tests will fail!])])
-    ])
+if ! test -f $SOFTOKENDIR/libsoftokn3$SHARED_EXT; then
+    if test -f $SOFTOKENDIR/nss/libsoftokn3$SHARED_EXT; then
+        AC_SUBST([SOFTOKEN_SUBDIR], "nss/")
+    else
+        AC_MSG_WARN([Softoken library missing, tests will fail!])
+    fi
+fi
 
 # find p11-kit-client to separate softhsm openssl context from our tests
 PKG_CHECK_EXISTS([p11-kit-1],


### PR DESCRIPTION
From the man-page on the `AC_CHECK_FILE` macro, we can read that:

```
You might also need to check for the existence of files. Before using these macros, ask yourself whether a runtime test might not be a better solution. Be aware that, like most Autoconf macros, they test a feature of the host machine, and therefore, they die when cross-compiling.
```

Therefore, move to using a simple shell if/else as the replacement.