### PR TITLE
tests: Fix expected output and fix Debian package name

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -38,7 +38,7 @@ jobs:
             apt-get -q update
             apt-get -yq install git gcc clang make automake \
               libtool pkg-config autoconf-archive libssl-dev openssl expect \
-              procps libnss3 libnss3-tools libnss3-dev softhsm opensc p11-kit \
+              procps libnss3 libnss3-tools libnss3-dev softhsm2 opensc p11-kit \
               libp11-kit-dev p11-kit-modules gnutls-bin \
               openssl-dbgsym libssl3-dbgsym
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
               if [ "${{ matrix.token }}" = "softokn" ]; then
                 apt-get -yq install libnss3 libnss3-tools libnss3-dev
               elif [ "${{ matrix.token }}" = "softhsm" ]; then
-                apt-get -yq install softhsm opensc p11-kit libp11-kit-dev \
+                apt-get -yq install softhsm2 opensc p11-kit libp11-kit-dev \
                   p11-kit-modules gnutls-bin
               fi
             fi

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -33,7 +33,8 @@ jobs:
               apt-get -yq install git gcc make automake expect \
                 libtool pkg-config autoconf-archive libssl-dev openssl \
                 xz-utils libnss3 libnss3-tools libnss3-dev \
-                softhsm opensc p11-kit libp11-kit-dev p11-kit-modules gnutls-bin
+                softhsm2 opensc p11-kit libp11-kit-dev p11-kit-modules \
+                gnutls-bin
             fi
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -134,7 +134,7 @@ output=$(expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PRIURI}\" -text 
                    expect \"Key ID:\";")
 echo "$output" | grep "Enter pass phrase for PKCS#11 Token (Slot .*):" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 0 ]; then
-    echo "$output" | grep "PKCS11 RSA Public Key" > /dev/null 2>&1 || FAIL=2
+    echo "$output" | grep "PKCS11 RSA Private Key" > /dev/null 2>&1 || FAIL=2
 fi
 if [ $FAIL -eq 1 ]; then
     echo "Failed to obtain expected prompt"


### PR DESCRIPTION
After Debian pulled fixed NSS version, we started getting the failure where the basic test expected public key data to be printed when we selected private key. This was probably the case in some openssl versions, but given that the test reads explicitly private key uri, I think checking for the private key information makes more sense.