### PR TITLE
Use a cached version of the URI to refresh objects

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -57,10 +57,16 @@ P11PROV_URI *p11prov_parse_uri(P11PROV_CTX *ctx, const char *uri);
 char *p11prov_key_to_uri(P11PROV_CTX *ctx, P11PROV_OBJ *key);
 void p11prov_uri_free(P11PROV_URI *parsed_uri);
 CK_OBJECT_CLASS p11prov_uri_get_class(P11PROV_URI *uri);
+void p11prov_uri_set_class(P11PROV_URI *uri, CK_OBJECT_CLASS class);
 CK_ATTRIBUTE p11prov_uri_get_id(P11PROV_URI *uri);
+void p11prov_uri_set_id(P11PROV_URI *uri, CK_ATTRIBUTE *id);
 CK_ATTRIBUTE p11prov_uri_get_label(P11PROV_URI *uri);
+void p11prov_uri_set_label(P11PROV_URI *uri, CK_ATTRIBUTE *label);
 char *p11prov_uri_get_serial(P11PROV_URI *uri);
 char *p11prov_uri_get_pin(P11PROV_URI *uri);
+CK_SLOT_ID p11prov_uri_get_slot_id(P11PROV_URI *uri);
+void p11prov_uri_set_slot_id(P11PROV_URI *uri, CK_SLOT_ID slot_id);
+P11PROV_URI *p11prov_copy_uri(P11PROV_URI *uri);
 CK_RV p11prov_uri_match_token(P11PROV_URI *uri, CK_SLOT_ID slot_id,
                               CK_SLOT_INFO *slot, CK_TOKEN_INFO *token);
 int p11prov_get_pin(P11PROV_CTX *ctx, const char *in, char **out);


### PR DESCRIPTION
This allows us to retain better information about the object and critically things like a PIN passed in the URI to be able to login to the token after a fork when the PIN is not specified in the token configuration.

Fixes #313