### PR TITLE
Use correct strdup function in macro

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -322,7 +322,7 @@ done:
 
 #define COPY_STRUCT_MEMBER(dst, src, _name) \
     if ((src)->_name) { \
-        (dst)->_name = strdup((src)->_name); \
+        (dst)->_name = OPENSSL_strdup((src)->_name); \
         if (!(dst)->_name) { \
             p11prov_uri_free((dst)); \
             return NULL; \


### PR DESCRIPTION
Coverity disovered a mismatch between the function we used to allocated the strings and the function used to free them.
In practice this is not a problem on most systems, but there are those wehre free() and OPENSSL_free() may actually differ.

Fixes:
 CID 469502: Incorrect deallocator used (ALLOC_FREE_MISMATCH)
 CID 469503: Incorrect deallocator used (ALLOC_FREE_MISMATCH)