### PR TITLE
Quirk: no-operation-state

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -29,6 +29,7 @@ jobs:
             test-wrapper
             thkdf
             toaepsha2
+            top_state
             tpubkey
             trand
             trsapss

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tests/openssl.cnf.softhsm
 tests/tmp.softhsm
 tests/tmp.softokn
 tests/tdigests
+tests/tdigest_dupctx
 tests/tsession
 tests/tgenkey
 tests/treadkeys

--- a/docs/provider-pkcs11.7
+++ b/docs/provider-pkcs11.7
@@ -170,17 +170,25 @@ immediately at application startup)
 .PP
 Workarounds that may be needed to deal with some tokens and cannot be
 autodetcted yet are not appropriate defaults.
+.SS no-deinit
 .PP
-The only quirk currently implemented is \[lq]no-deinit\[rq] It prevent
-de-initing when OpenSSL winds down the provider.
+It prevents de-initing when OpenSSL winds down the provider.
 NOTE this option may leak memory and may cause some modules to misbehave
 if the application intentionally unloads and reloads them.
+.SS no-operation-state
+.PP
+OpenSSL by default assumes contexts with operations in flight can be
+easily duplicated.
+That is only possible if the tokens support getting and setting the
+operation state.
+If the quirk is enabled the context duplication is not performed.
 .PP
 Default: none
 .PP
 Example:
 .PP
-\f[C]pkcs11-module-quirks = no-deinit\f[R] (Disables deinitialization)
+\f[C]pkcs11-module-quirks = no-deinit no-operation-state\f[R] (Disables
+deinitialization)
 .SH ENVIRONMENT VARIABLES
 .PP
 Environment variables recognized by the provider

--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -178,16 +178,22 @@ Example:
 Workarounds that may be needed to deal with some tokens and cannot be
 autodetcted yet are not appropriate defaults.
 
-The only quirk currently implemented is "no-deinit"
-It prevent de-initing when OpenSSL winds down the provider.
+### no-deinit
+It prevents de-initing when OpenSSL winds down the provider.
 NOTE this option may leak memory and may cause some modules to
 misbehave if the application intentionally unloads and reloads them.
+
+### no-operation-state
+OpenSSL by default assumes contexts with operations in flight can be
+easily duplicated. That is only possible if the tokens support getting
+and setting the operation state. If the quirk is enabled the context
+duplication is not performed.
 
 Default: none
 
 Example:
 
-```pkcs11-module-quirks = no-deinit```
+```pkcs11-module-quirks = no-deinit no-operation-state```
 (Disables deinitialization)
 
 

--- a/src/digests.c
+++ b/src/digests.c
@@ -191,7 +191,12 @@ static void *p11prov_digest_dupctx(void *ctx)
     dctx->session = NULL;
 
     /* NOTE: most tokens will probably return errors trying to do this on digest
-     * sessions */
+     * sessions. If the configuration indicates that GetOperationState will fail
+     * we don't even try to duplicate the context. */
+
+    if (p11prov_ctx_no_operation_state(dctx->provctx)) {
+        goto done;
+    }
 
     ret = p11prov_GetOperationState(dctx->provctx, sess, NULL_PTR, &state_len);
     if (ret != CKR_OK) {

--- a/src/provider.c
+++ b/src/provider.c
@@ -35,6 +35,7 @@ struct p11prov_ctx {
     /* cfg quirks */
     bool no_deinit;
     bool no_allowed_mechanisms;
+    bool no_operation_state;
 
     /* module handles and data */
     P11PROV_MODULE *module;
@@ -607,6 +608,11 @@ int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx)
 {
     P11PROV_debug("cache_sessions = %d", ctx->cache_sessions);
     return ctx->cache_sessions;
+}
+
+bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx)
+{
+    return ctx->no_operation_state;
 }
 
 static void p11prov_teardown(void *ctx)
@@ -1456,6 +1462,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
                 ctx->no_deinit = true;
             } else if (strncmp(str, "no-allowed-mechanisms", toklen) == 0) {
                 ctx->no_allowed_mechanisms = true;
+            } else if (strncmp(str, "no-operation-state", toklen) == 0) {
+                ctx->no_operation_state = true;
             }
             len -= toklen;
             if (sep) {

--- a/src/provider.h
+++ b/src/provider.h
@@ -115,6 +115,8 @@ enum p11prov_cache_keys {
 int p11prov_ctx_cache_keys(P11PROV_CTX *ctx);
 int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx);
 
+bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx);
+
 #include "debug.h"
 
 /* Errors */

--- a/src/signature.c
+++ b/src/signature.c
@@ -141,6 +141,14 @@ static void *p11prov_sig_dupctx(void *ctx)
     newctx->session = sigctx->session;
     sigctx->session = NULL;
 
+    /* NOTE: most tokens will probably return errors trying to do this on sign
+     * sessions. If the configuration indicates that GetOperationState will fail
+     * we don't even try to duplicate the context. */
+
+    if (p11prov_ctx_no_operation_state(sigctx->provctx)) {
+        goto done;
+    }
+
     if (slotid != CK_UNAVAILABLE_INFORMATION && handle != CK_INVALID_HANDLE) {
         CK_SESSION_HANDLE newsess = p11prov_session_handle(newctx->session);
         CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,7 @@ testssrcdir=@abs_srcdir@
 #VALGRIND_SUPPRESSIONS_FILES = $(top_srcdir)/tests/pkcs11-provider.supp
 VALGRIND_FLAGS = --num-callers=30 -q --keep-debuginfo=yes
 
-check_PROGRAMS = tsession tgenkey tlsctx tdigests treadkeys tcmpkeys tfork pincache
+check_PROGRAMS = tsession tgenkey tlsctx tdigests tdigest_dupctx treadkeys tcmpkeys tfork pincache
 
 tsession_SOURCES = tsession.c
 tsession_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -27,6 +27,10 @@ tlsctx_LDADD = $(OPENSSL_LIBS)
 tdigests_SOURCES = tdigests.c
 tdigests_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
 tdigests_LDADD = $(OPENSSL_LIBS)
+
+tdigest_dupctx_SOURCES = tdigest_dupctx.c
+tdigest_dupctx_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
+tdigest_dupctx_LDADD = $(OPENSSL_LIBS)
 
 treadkeys_SOURCES = treadkeys.c
 treadkeys_CFLAGS = $(STD_CFLAGS) $(OPENSSL_CFLAGS)
@@ -63,7 +67,7 @@ dist_check_SCRIPTS = \
 	helpers.sh setup-softhsm.sh setup-softokn.sh softhsm-proxy.sh \
 	test-wrapper tbasic tcerts tecc tecdh tedwards tdemoca thkdf \
 	toaepsha2 trsapss tdigest ttls tpubkey tfork turi trand tecxc \
-	tcms
+	tcms top_state
 
 test_LIST = \
 	basic-softokn.t basic-softhsm.t \
@@ -85,7 +89,8 @@ test_LIST = \
 	tls-softokn.t tls-softhsm.t \
 	uri-softokn.t uri-softhsm.t \
 	ecxc-softhsm.t \
-	cms-softokn.t
+	cms-softokn.t \
+	op_state-softhsm.t
 
 .PHONY: $(test_LIST)
 

--- a/tests/tdigest_dupctx.c
+++ b/tests/tdigest_dupctx.c
@@ -1,0 +1,54 @@
+/* Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/provider.h>
+
+#define EXIT_TEST_SKIPPED 77
+
+int main(int argc, char *argv[])
+{
+    const char *propq = "provider=pkcs11";
+    const char *digest = "sha256";
+    const char *provname;
+    const OSSL_PROVIDER *pk11prov;
+
+    EVP_MD *pk11md = EVP_MD_fetch(NULL, digest, propq);
+    if (!pk11md) {
+        fprintf(stderr, "%s: Unsupported by pkcs11 token\n", digest);
+        exit(EXIT_FAILURE);
+    }
+
+    pk11prov = EVP_MD_get0_provider(pk11md);
+    provname = OSSL_PROVIDER_get0_name(pk11prov);
+
+    if (strcmp(provname, "pkcs11") != 0) {
+        fprintf(stderr, "%s: Not a pkcs11 method, provider=%s\n", digest,
+                provname);
+        EVP_MD_free(pk11md);
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(mdctx, pk11md, NULL);
+
+    EVP_MD_CTX *mdctx_dup = EVP_MD_CTX_new();
+    EVP_MD_CTX_copy(mdctx_dup, mdctx);
+
+    char error_string[2048];
+    ERR_error_string_n(ERR_peek_last_error(), error_string,
+                       sizeof error_string);
+    printf("%s\n", error_string);
+
+    EVP_MD_CTX_free(mdctx);
+    EVP_MD_CTX_free(mdctx_dup);
+
+    EVP_MD_free(pk11md);
+
+    exit(EXIT_SUCCESS);
+}

--- a/tests/top_state
+++ b/tests/top_state
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+# Copyright (C) 2022 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "${TESTSSRCDIR}/helpers.sh"
+
+title PARA "OSSL error stack has error from failing C_Get/SetOperationState"
+# We need to configure early loading otherwise no digests are loaded,
+# and all checks are skipped
+sed "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.op_state.early_load"
+OPENSSL_CONF=${OPENSSL_CONF}.op_state.early_load
+
+$CHECKER ./tdigest_dupctx | grep -e "error:.*:pkcs11::reason(84)"
+
+
+title PARA "No error is logged when quirk no-operation-state is enabled"
+sed "s/pkcs11-module-quirks = /pkcs11-module-quirks = no-operation-state /" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.no_op_state"
+OPENSSL_CONF=${OPENSSL_CONF}.no_op_state
+
+title PARA "Test Digests support"
+$CHECKER ./tdigest_dupctx | grep -e "error:.*:lib(0)::reason(0)"
+
+exit 0


### PR DESCRIPTION
Configuration property to indicate whether the PKCS11 provider supports getting/setting the operation state. If it is not supported, no attempts will be made to duplicate the context.

I already mentioned it in the discussion (https://github.com/latchset/pkcs11-provider/discussions/320) that the current approach leaves traces in the SSL error stack.

Please let me know what you think of this change.

(Tests will follow)