### PR TITLE
CKK_EC_EDWARDS: EC_PARAMS containing oID

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -708,7 +708,26 @@ static CK_RV pre_process_ec_key_data(P11PROV_OBJ *key)
             key->data.key.bit_size = ED448_BIT_SIZE;
             key->data.key.size = ED448_BYTE_SIZE;
         } else {
-            return CKR_KEY_INDIGESTIBLE;
+            const unsigned char *p = attr->pValue;
+            ASN1_OBJECT *asn1_obj = d2i_ASN1_OBJECT(NULL, &p, attr->ulValueLen);
+            if (asn1_obj == NULL) {
+                return CKR_KEY_INDIGESTIBLE;
+            }
+            int nid = OBJ_obj2nid(asn1_obj);
+            ASN1_OBJECT_free(asn1_obj);
+            if (nid == NID_ED25519) {
+                curve_name = ED25519;
+                curve_nid = NID_ED25519;
+                key->data.key.bit_size = ED25519_BIT_SIZE;
+                key->data.key.size = ED25519_BYTE_SIZE;
+            } else if (nid == NID_ED448) {
+                curve_name = ED448;
+                curve_nid = NID_ED448;
+                key->data.key.bit_size = ED448_BIT_SIZE;
+                key->data.key.size = ED448_BYTE_SIZE;
+            } else {
+                return CKR_KEY_INDIGESTIBLE;
+            }
         }
     } else {
         return CKR_KEY_INDIGESTIBLE;


### PR DESCRIPTION
I have a token where the EC_PARAMS describe the curve using the oID  as specified in RFC 8410.

I imagine that the proposed solution is fairly inefficient compared to the memcmp that is currently done for the PrintableString representation. Would you recommend to introduce new constants for the oId  instead? 
Or do you know of an efficient solution that supports both/all valid representations?