### PR TITLE
Add --with-openssl info to BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,7 @@ This package requires the following:
 
 The usual command to build are:
 - autoreconf -fi (if needed)
-- ./configure (--with-openssl if needed)
+- ./configure (--with-openssl=/path/to/openssl if needed)
 - make
 - make check
 


### PR DESCRIPTION
I am not very familiar with GNU Autotools, so it wasn't clear to me that I need to pass a path to --with-openssl. Running `./configure --with-openssl` will result in the following error:
~~~
libtool:   error: cannot determine absolute directory name of 'yes'
~~~
Because the missing path is just replaced with 'yes'.

Clarify that --with-openssl must be passed a path, e.g., `--with-openssl=/usr/lib64`.