### PR TITLE
Do not load profiles when they can't be available

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -469,3 +469,8 @@ CK_RV side_channel_free_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     return intf->Decrypt(hSession, pEncryptedData, ulEncryptedDataLen, pData,
                          pulDataLen);
 }
+
+CK_INFO p11prov_module_ck_info(P11PROV_MODULE *mctx)
+{
+    return mctx->ck_info;
+}

--- a/src/interface.h
+++ b/src/interface.h
@@ -133,4 +133,6 @@ CK_RV side_channel_free_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                                 CK_ULONG ulEncryptedDataLen, CK_BYTE_PTR pData,
                                 CK_ULONG_PTR pulDataLen);
 
+CK_INFO p11prov_module_ck_info(P11PROV_MODULE *mctx);
+
 #endif /* _INTERFACE_H */

--- a/src/provider.c
+++ b/src/provider.c
@@ -615,6 +615,15 @@ bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx)
     return ctx->no_operation_state;
 }
 
+CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx)
+{
+    if (!ctx->module) {
+        CK_INFO info = { 0 };
+        return info;
+    }
+    return p11prov_module_ck_info(ctx->module);
+}
+
 static void p11prov_teardown(void *ctx)
 {
     p11prov_ctx_free((P11PROV_CTX *)ctx);

--- a/src/provider.h
+++ b/src/provider.h
@@ -117,6 +117,8 @@ int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx);
 
 bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx);
 
+CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx);
+
 #include "debug.h"
 
 /* Errors */

--- a/src/slot.c
+++ b/src/slot.c
@@ -118,10 +118,13 @@ static const char slot_desc_fmt[] = "PKCS#11 Token (Slot %lu - %s)";
 CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
 {
     CK_ULONG num;
+    CK_INFO ck_info;
     CK_SLOT_ID *slotid = NULL;
     struct p11prov_slots_ctx *sctx;
     CK_RV ret;
     int err;
+
+    ck_info = p11prov_ctx_get_ck_info(ctx);
 
     sctx = OPENSSL_zalloc(sizeof(P11PROV_SLOTS_CTX));
     if (!sctx) {
@@ -215,7 +218,10 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
             goto done;
         }
 
-        get_slot_profiles(ctx, slot);
+        /* profiles not available before version 3 */
+        if (ck_info.cryptokiVersion.major >= 3) {
+            get_slot_profiles(ctx, slot);
+        }
         get_slot_mechanisms(ctx, slot);
 
         P11PROV_debug_slot(ctx, slot->id, &slot->slot, &slot->token,

--- a/tests/tgenkey.c
+++ b/tests/tgenkey.c
@@ -48,6 +48,12 @@ static void check_rsa_key(EVP_PKEY *pubkey)
         fprintf(stderr, "Failed to get N param from public key");
         exit(EXIT_FAILURE);
     } else {
+        int bits;
+        bits = EVP_PKEY_get_bits(pubkey);
+        if (bits < 3072) {
+            fprintf(stderr, "Expected 3072 bits key, got %d\n", bits);
+            exit(EXIT_FAILURE);
+        }
         BN_free(tmp);
         tmp = NULL;
     }
@@ -339,7 +345,8 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
     }
     params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_uri", uri, 0);
-    params[1] = OSSL_PARAM_construct_size_t("rsa_keygen_bits", &rsa_bits);
+    params[1] =
+        OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &rsa_bits);
     params[2] = OSSL_PARAM_construct_end();
 
     gen_keys("RSA", label, idhex, params, false);
@@ -365,7 +372,8 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
     }
     params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_uri", uri, 0);
-    params[1] = OSSL_PARAM_construct_size_t("rsa_keygen_bits", &rsa_bits);
+    params[1] =
+        OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &rsa_bits);
     params[2] = OSSL_PARAM_construct_utf8_string("rsa_pss_keygen_md",
                                                  (char *)"SHA256", 0);
     params[3] = OSSL_PARAM_construct_end();
@@ -422,7 +430,8 @@ int main(int argc, char *argv[])
     params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_uri", uri, 0);
     params[1] = OSSL_PARAM_construct_utf8_string("pkcs11_key_usage",
                                                  (char *)key_usage, 0);
-    params[2] = OSSL_PARAM_construct_size_t("rsa_keygen_bits", &rsa_bits);
+    params[2] =
+        OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &rsa_bits);
     params[3] = OSSL_PARAM_construct_end();
 
     gen_keys("RSA", label, idhex, params, false);


### PR DESCRIPTION
v2.40 (so anything be,low 3.0) spec did not have profiles.

Try to load them only for tokens that expose a 3+ version.