### PR TITLE
Added an option to set NULL callbacks for C_OpenSession

### DIFF
--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -189,6 +189,11 @@ easily duplicated. That is only possible if the tokens support getting
 and setting the operation state. If the quirk is enabled the context
 duplication is not performed.
 
+### no-session-callbacks
+Some implementatations of PKCS11 don't allow setting `pApplication` and
+`Notify` callback functions in `C_OpenSession`.
+This option sets NULL values for both callbacks.
+
 Default: none
 
 Example:

--- a/src/provider.c
+++ b/src/provider.c
@@ -36,6 +36,7 @@ struct p11prov_ctx {
     bool no_deinit;
     bool no_allowed_mechanisms;
     bool no_operation_state;
+    bool no_session_callbacks;
 
     /* module handles and data */
     P11PROV_MODULE *module;
@@ -613,6 +614,11 @@ int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx)
 bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx)
 {
     return ctx->no_operation_state;
+}
+
+bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx)
+{
+    return ctx->no_session_callbacks;
 }
 
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx)
@@ -1473,6 +1479,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
                 ctx->no_allowed_mechanisms = true;
             } else if (strncmp(str, "no-operation-state", toklen) == 0) {
                 ctx->no_operation_state = true;
+            } else if (strncmp(str, "no-session-callbacks", toklen) == 0) {
+                ctx->no_session_callbacks = true;
             }
             len -= toklen;
             if (sep) {

--- a/src/provider.h
+++ b/src/provider.h
@@ -116,6 +116,7 @@ int p11prov_ctx_cache_keys(P11PROV_CTX *ctx);
 int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx);
 
 bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx);
+bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx);
 
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx);
 

--- a/src/session.c
+++ b/src/session.c
@@ -67,9 +67,16 @@ static CK_RV token_session_open(P11PROV_SESSION *session, CK_FLAGS flags)
     CK_RV ret;
 
     do {
-        ret = p11prov_OpenSession(session->provctx, session->slotid, flags,
-                                  session, token_session_callback,
-                                  &session->session);
+        if (p11prov_ctx_no_session_callbacks(session->provctx)) {
+            P11PROV_debug("Opening session without callbacks %lu",
+                          session->session);
+            ret = p11prov_OpenSession(session->provctx, session->slotid, flags,
+                                      NULL, NULL, &session->session);
+        } else {
+            ret = p11prov_OpenSession(session->provctx, session->slotid, flags,
+                                      session, token_session_callback,
+                                      &session->session);
+        }
         P11PROV_debug("C_OpenSession ret:%lu (session: %lu)", ret,
                       session->session);
         if (ret != CKR_SESSION_COUNT) {

--- a/tests/top_state
+++ b/tests/top_state
@@ -22,4 +22,11 @@ OPENSSL_CONF=${OPENSSL_CONF}.no_op_state
 title PARA "Test Digests support"
 $CHECKER ./tdigest_dupctx | grep -e "error:.*:lib(0)::reason(0)"
 
+title PARA "No errors occur with no-session-callbacks quirk enabled"
+sed "s/pkcs11-module-quirks = /pkcs11-module-quirks = no-session-callbacks /" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.no_callbacks"
+OPENSSL_CONF=${OPENSSL_CONF}.no_callbacks
+
+$CHECKER ./tdigest_dupctx | grep -e "error:.*:lib(0)::reason(0)"
+
 exit 0


### PR DESCRIPTION
Fixes https://github.com/latchset/pkcs11-provider/issues/342

More details in the issue description. 

I'm not really a C developer so any suggestions for improvements will be highly appreciated