### PR TITLE
Integration tests (libssh, httpd, bind)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,53 +7,80 @@ on:
   pull_request:
     branches: ["main"]
 
-env:
-    P_LIBSSH_DEBUG: /tmp/libssh-provider-debug.log
-
 jobs:
-  build:
-    name: libssh
+  libssh:
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: docker.io/dokken/fedora-40
     steps:
-      - name: Install Dependencies
-        run: |
-          dnf -y install gcc g++ git cmake libcmocka libcmocka-devel \
-          autoconf automake autoconf-archive libtool softhsm nss-tools \
-          gnutls-utils p11-kit p11-kit-devel p11-kit-server opensc \
-          softhsm-devel socket_wrapper nss_wrapper uid_wrapper \
-          pam_wrapper priv_wrapper openssh-server zlib-devel
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install Build Requirements
+        run: |
+          dnf -y install git autoconf autoconf-archive automake libtool \
+            openssl-devel
+
       - name: Setup, Build and Install pkcs11-provider
         run: |
           autoreconf -fiv
           ./configure --libdir=/usr/lib64
           make
           make install
-      - name: Clone, Setup and Build libssh
+
+      - name: Test
         run: |
-          git clone https://gitlab.com/libssh/libssh-mirror.git
-          cd libssh-mirror/
-          mkdir build
-          cd build/
-          cmake \
-            -DUNIT_TESTING=ON \
-            -DCLIENT_TESTING=ON \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DWITH_PKCS11_URI=ON \
-            -DWITH_PKCS11_PROVIDER=ON \
-            -DPKCS11_PROVIDER=/usr/lib64/ossl-modules/pkcs11.so ..
+          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+          pushd tests/integration
+          bash -e libssh.sh
+
+  httpd:
+    runs-on: ubuntu-22.04
+    # TODO: Change to fedora:latest once F40 is released
+    container: docker.io/dokken/fedora-40
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Build Requirements
+        run: |
+          dnf -y install autoconf autoconf-archive automake libtool \
+            openssl-devel
+
+      - name: Setup, Build and Install pkcs11-provider
+        run: |
+          autoreconf -fiv
+          ./configure --libdir=/usr/lib64
           make
-      - name: Run libssh pkcs11-provider tests
+          make install
+
+      - name: Test
         run: |
-          cd libssh-mirror/build
-          ! test -e $P_LIBSSH_DEBUG && \
-            echo "Provider log $P_LIBSSH_DEBUG does not exist yet (expected)"
-          PKCS11_PROVIDER_DEBUG=file:$P_LIBSSH_DEBUG ctest \
-            --output-on-failure -R \
-            '(torture_auth_pkcs11|torture_pki_rsa_uri|torture_pki_ecdsa_uri)' \
-            | tee testout.log 2>&1
-          grep -q "100% tests passed, 0 tests failed out of 3" testout.log
-          test -e $P_LIBSSH_DEBUG && \
-            echo "Provider log $P_LIBSSH_DEBUG exists (expected)"
+          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+          pushd tests/integration
+          bash -e httpd.sh
+
+  bind:
+    runs-on: ubuntu-22.04
+    # TODO: Change to fedora:latest once F40 is released
+    container: docker.io/dokken/fedora-40
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Build Requirements
+        run: |
+          dnf -y install autoconf autoconf-archive automake libtool \
+            openssl-devel
+
+      - name: Setup, Build and Install pkcs11-provider
+        run: |
+          autoreconf -fiv
+          ./configure --libdir=/usr/lib64
+          make
+          make install
+
+      - name: Test
+        run: |
+          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+          pushd tests/integration
+          bash -e bind.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,79 +8,30 @@ on:
     branches: ["main"]
 
 jobs:
-  libssh:
+  test:
     runs-on: ubuntu-22.04
-    container: docker.io/dokken/fedora-40
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [libssh, httpd, bind]
+    name: ${{ matrix.test }}
+    container: fedora:rawhide
+    env:
+      PKCS11_MODULE: /usr/lib64/ossl-modules/pkcs11.so
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
       - name: Install Build Requirements
         run: |
           dnf -y install git autoconf autoconf-archive automake libtool \
             openssl-devel
-
       - name: Setup, Build and Install pkcs11-provider
         run: |
           autoreconf -fiv
           ./configure --libdir=/usr/lib64
           make
           make install
-
       - name: Test
         run: |
-          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
           pushd tests/integration
-          bash -e libssh.sh
-
-  httpd:
-    runs-on: ubuntu-22.04
-    # TODO: Change to fedora:latest once F40 is released
-    container: docker.io/dokken/fedora-40
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Install Build Requirements
-        run: |
-          dnf -y install autoconf autoconf-archive automake libtool \
-            openssl-devel
-
-      - name: Setup, Build and Install pkcs11-provider
-        run: |
-          autoreconf -fiv
-          ./configure --libdir=/usr/lib64
-          make
-          make install
-
-      - name: Test
-        run: |
-          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
-          pushd tests/integration
-          bash -e httpd.sh
-
-  bind:
-    runs-on: ubuntu-22.04
-    # TODO: Change to fedora:latest once F40 is released
-    container: docker.io/dokken/fedora-40
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Install Build Requirements
-        run: |
-          dnf -y install autoconf autoconf-archive automake libtool \
-            openssl-devel
-
-      - name: Setup, Build and Install pkcs11-provider
-        run: |
-          autoreconf -fiv
-          ./configure --libdir=/usr/lib64
-          make
-          make install
-
-      - name: Test
-        run: |
-          export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
-          pushd tests/integration
-          bash -e bind.sh
+          bash -e ${{ matrix.test }}.sh

--- a/tests/integration/bind.sh
+++ b/tests/integration/bind.sh
@@ -1,0 +1,180 @@
+#!/bin/bash -e
+# Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "../helpers.sh"
+
+BASEDIR=$PWD
+WORKDIR=$(mktemp -d)
+PIN="123456"
+PKCS11_DEBUG_FILE="${WORKDIR}/pkcs11-bind-test.log"
+
+install_dependencies()
+{
+    title PARA "Install dependencies" 
+
+    FEDORA_VERSION=$(rpm -q --qf "%{V}" fedora-release-common)
+    if [ "$FEDORA_VERSION" -lt 39 ]; then
+        echo "ERROR: This test requires at least Fedora 39!"
+        exit 1
+    elif [ "$FEDORA_VERSION" -eq 39 ]; then
+        releasever="--releasever=40"
+    fi
+    dnf install -y $releasever --skip-broken \
+        autoconf automake autoconf-archive libtool \
+        p11-kit httpd mod_ssl openssl-devel gnutls-utils nss-tools \
+        p11-kit-devel p11-kit-server opensc softhsm-devel procps-ng \
+        openssl util-linux bind9-next opensc
+}
+
+softhsm_token_setup()
+{    
+    title PARA "Softhsm token setup"
+    
+    cp -rnp /var/lib/softhsm/tokens{,.bck}
+    export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/libsofthsm2.so"
+    softhsm2-util --init-token --free --label softhsm --pin $PIN --so-pin $PIN
+    pkcs11-tool --module $PKCS11_PROVIDER_MODULE \
+                --login --pin $PIN \
+                --keypairgen --key-type rsa:2048 --label localhost-ksk
+    pkcs11-tool --module $PKCS11_PROVIDER_MODULE \
+                --login --pin $PIN \
+                --keypairgen --key-type rsa:2048 --label localhost-zsk
+
+    title SECTION "List token content"
+    TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
+    p11tool --login --set-pin $PIN --list-all $TOKENURL 
+    title ENDSECTION
+}
+
+pkcs11_provider_setup()
+{
+    title PARA "Get, compile and install pkcs11-provider"
+
+    if [ "$GITHUB_ACTIONS" == "true" ]; then
+        if [ -z "$PKCS11_MODULE" ]; then
+            echo "ERROR: Missing PKCS11_MODULE variable!"
+            exit 1
+        fi
+        echo "Skipped (running in Github Actions)"
+    else
+        git clone ${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"} \
+          ${WORKDIR}/pkcs11-provider
+        pushd $WORKDIR/pkcs11-provider
+        git checkout ${GIT_REF:-"main"}
+        autoreconf -fiv
+        ./configure --libdir=/usr/lib64
+        make
+        make install
+        popd
+        export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+    fi
+    test -e $PKCS11_MODULE
+}
+
+p11kit_server_setup()
+{
+    title PARA "Proxy module driver through p11-kit server"
+
+    export XDG_RUNTIME_DIR=$PWD
+    eval $(p11-kit server --provider $PKCS11_PROVIDER_MODULE "pkcs11:")
+    test -n "$P11_KIT_SERVER_PID"
+    export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/p11-kit-client.so"
+}
+
+openssl_setup()
+{
+    title PARA "OpenSSL setup"
+
+    sed \
+      -e "s|\(default = default_sect\)|\1\npkcs11 = pkcs11_sect\n|" \
+      -e "s|\(\[default_sect\]\)|\[pkcs11_sect\]\n\1|" \
+      -e "s|\(\[default_sect\]\)|module = $PKCS11_MODULE\n\1|" \
+      -e "s|\(\[default_sect\]\)|pkcs11-module-load-behavior = early\n\1|" \
+      -e "s|\(\[default_sect\]\)|activate = 1\n\n\1|" \
+      /etc/pki/tls/openssl.cnf >${WORKDIR}/openssl.cnf
+
+    title SECTION "openssl.cnf"
+    cat ${WORKDIR}/openssl.cnf
+    title ENDSECTION
+}
+
+bind_setup()
+{
+    title PARA "Bind setup"
+
+    cp /var/named/named.localhost ${WORKDIR}/localhost
+}
+
+bind_test()
+{
+    title PARA "Bind test"
+
+    TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
+    KSKURL="$(p11tool --login --set-pin $PIN --list-keys $TOKENURL \
+        | grep 'URL:.*object=localhost-ksk' \
+        | awk '{ print $NF }' \
+        | sed "s/type=.*\$/pin-value=$PIN/")"
+    ZSKURL="$(p11tool --login --set-pin $PIN --list-keys $TOKENURL \
+        | grep 'URL:.*object=localhost-zsk' \
+        | awk '{ print $NF }' \
+        | sed "s/type=.*\$/pin-value=$PIN/")"
+
+    pushd $WORKDIR
+
+    title PARA "Test 1: Extract KSK and ZSK keys from PKCS11 URIs"
+    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.extract \
+    OPENSSL_CONF=openssl.cnf \
+        dnssec-keyfromlabel -a RSASHA256 -l "$ZSKURL" localhost
+    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.extract \
+    OPENSSL_CONF=openssl.cnf \
+        dnssec-keyfromlabel -a RSASHA256 -l "$KSKURL" -f KSK localhost
+    for K in *.key; do
+        cat $K >>localhost
+    done
+    test -s ${PKCS11_DEBUG_FILE}.extract
+    
+    title PARA "Test 2: Sign zone"
+    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.sign \
+    OPENSSL_CONF=openssl.cnf \
+        dnssec-signzone -o localhost localhost
+    test -s ${PKCS11_DEBUG_FILE}.sign
+
+    popd
+    echo "Test passed"
+}
+
+cleanup() 
+{
+    title PARA "Clean-up"
+
+    for L in ${PKCS11_DEBUG_FILE}.*; do
+        title SECTION "$L"
+        cat $L
+        title ENDSECTION
+    done
+
+    pushd $BASEDIR >/dev/null
+    rm -rf $WORKDIR
+    if [ -e /var/lib/softhsm/tokens.bck ]; then
+        rm -rf /var/lib/softhsm/tokens
+        mv /var/lib/softhsm/tokens.bck /var/lib/softhsm/tokens
+    fi
+    cleanup_server "p11-kit" "$P11_KIT_SERVER_PID"
+
+    title LINE "Done"
+}
+
+
+trap "cleanup" EXIT
+
+# Setup.
+install_dependencies
+softhsm_token_setup
+p11kit_server_setup
+pkcs11_provider_setup
+openssl_setup
+bind_setup
+
+# Test.
+bind_test

--- a/tests/integration/bind.sh
+++ b/tests/integration/bind.sh
@@ -2,6 +2,7 @@
 # Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
+# shellcheck disable=SC1091
 source "../helpers.sh"
 
 BASEDIR=$PWD
@@ -20,7 +21,7 @@ install_dependencies()
     elif [ "$FEDORA_VERSION" -eq 39 ]; then
         releasever="--releasever=40"
     fi
-    dnf install -y $releasever --skip-broken \
+    dnf install -y "$releasever" --skip-broken \
         autoconf automake autoconf-archive libtool \
         p11-kit httpd mod_ssl openssl-devel gnutls-utils nss-tools \
         p11-kit-devel p11-kit-server opensc softhsm-devel procps-ng \
@@ -43,7 +44,7 @@ softhsm_token_setup()
 
     title SECTION "List token content"
     TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
-    p11tool --login --set-pin $PIN --list-all $TOKENURL 
+    p11tool --login --set-pin "$PIN" --list-all "$TOKENURL"
     title ENDSECTION
 }
 
@@ -58,10 +59,11 @@ pkcs11_provider_setup()
         fi
         echo "Skipped (running in Github Actions)"
     else
-        git clone ${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"} \
-          ${WORKDIR}/pkcs11-provider
-        pushd $WORKDIR/pkcs11-provider
-        git checkout ${GIT_REF:-"main"}
+        git clone \
+            "${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"}" \
+            "${WORKDIR}"/pkcs11-provider
+        pushd "${WORKDIR}"/pkcs11-provider
+        git checkout "${GIT_REF:-"main"}"
         autoreconf -fiv
         ./configure --libdir=/usr/lib64
         make
@@ -69,7 +71,7 @@ pkcs11_provider_setup()
         popd
         export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
     fi
-    test -e $PKCS11_MODULE
+    test -e "$PKCS11_MODULE"
 }
 
 p11kit_server_setup()
@@ -77,7 +79,7 @@ p11kit_server_setup()
     title PARA "Proxy module driver through p11-kit server"
 
     export XDG_RUNTIME_DIR=$PWD
-    eval $(p11-kit server --provider $PKCS11_PROVIDER_MODULE "pkcs11:")
+    eval "$(p11-kit server --provider "$PKCS11_PROVIDER_MODULE" "pkcs11:")"
     test -n "$P11_KIT_SERVER_PID"
     export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/p11-kit-client.so"
 }
@@ -92,10 +94,10 @@ openssl_setup()
       -e "s|\(\[default_sect\]\)|module = $PKCS11_MODULE\n\1|" \
       -e "s|\(\[default_sect\]\)|pkcs11-module-load-behavior = early\n\1|" \
       -e "s|\(\[default_sect\]\)|activate = 1\n\n\1|" \
-      /etc/pki/tls/openssl.cnf >${WORKDIR}/openssl.cnf
+      /etc/pki/tls/openssl.cnf >"${WORKDIR}"/openssl.cnf
 
     title SECTION "openssl.cnf"
-    cat ${WORKDIR}/openssl.cnf
+    cat "${WORKDIR}"/openssl.cnf
     title ENDSECTION
 }
 
@@ -103,7 +105,7 @@ bind_setup()
 {
     title PARA "Bind setup"
 
-    cp /var/named/named.localhost ${WORKDIR}/localhost
+    cp /var/named/named.localhost "${WORKDIR}"/localhost
 }
 
 bind_test()
@@ -111,16 +113,16 @@ bind_test()
     title PARA "Bind test"
 
     TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
-    KSKURL="$(p11tool --login --set-pin $PIN --list-keys $TOKENURL \
+    KSKURL="$(p11tool --login --set-pin "$PIN" --list-keys "$TOKENURL" \
         | grep 'URL:.*object=localhost-ksk' \
         | awk '{ print $NF }' \
         | sed "s/type=.*\$/pin-value=$PIN/")"
-    ZSKURL="$(p11tool --login --set-pin $PIN --list-keys $TOKENURL \
+    ZSKURL="$(p11tool --login --set-pin "$PIN" --list-keys "$TOKENURL" \
         | grep 'URL:.*object=localhost-zsk' \
         | awk '{ print $NF }' \
         | sed "s/type=.*\$/pin-value=$PIN/")"
 
-    pushd $WORKDIR
+    pushd "$WORKDIR"
 
     title PARA "Test 1: Extract KSK and ZSK keys from PKCS11 URIs"
     PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.extract \
@@ -130,15 +132,15 @@ bind_test()
     OPENSSL_CONF=openssl.cnf \
         dnssec-keyfromlabel -a RSASHA256 -l "$KSKURL" -f KSK localhost
     for K in *.key; do
-        cat $K >>localhost
+        cat "$K" >>localhost
     done
-    test -s ${PKCS11_DEBUG_FILE}.extract
+    test -s "${PKCS11_DEBUG_FILE}".extract
     
     title PARA "Test 2: Sign zone"
     PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.sign \
     OPENSSL_CONF=openssl.cnf \
         dnssec-signzone -o localhost localhost
-    test -s ${PKCS11_DEBUG_FILE}.sign
+    test -s "${PKCS11_DEBUG_FILE}".sign
 
     popd
     echo "Test passed"
@@ -148,14 +150,14 @@ cleanup()
 {
     title PARA "Clean-up"
 
-    for L in ${PKCS11_DEBUG_FILE}.*; do
+    for L in "${PKCS11_DEBUG_FILE}".*; do
         title SECTION "$L"
-        cat $L
+        cat "$L"
         title ENDSECTION
     done
 
-    pushd $BASEDIR >/dev/null
-    rm -rf $WORKDIR
+    pushd "$BASEDIR" >/dev/null
+    rm -rf "$WORKDIR"
     if [ -e /var/lib/softhsm/tokens.bck ]; then
         rm -rf /var/lib/softhsm/tokens
         mv /var/lib/softhsm/tokens.bck /var/lib/softhsm/tokens

--- a/tests/integration/httpd.sh
+++ b/tests/integration/httpd.sh
@@ -1,0 +1,207 @@
+#!/bin/bash -e
+# Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "../helpers.sh"
+
+BASEDIR=$PWD
+WORKDIR=$(mktemp -d)
+PIN="123456"
+PIN_FILE="${WORKDIR}/pin.txt"
+PKCS11_DEBUG_FILE="${WORKDIR}/pkcs11-httpd-test.log"
+MOD_SSL_CONF="/etc/httpd/conf.d/ssl.conf"
+
+install_dependencies()
+{
+    title PARA "Install dependencies" 
+
+    FEDORA_VERSION=$(rpm -q --qf "%{V}" fedora-release-common)
+    if [ "$FEDORA_VERSION" -lt 39 ]; then
+        echo "ERROR: This test requires at least Fedora 39!"
+        exit 1
+    elif [ "$FEDORA_VERSION" -eq 39 ]; then
+        releasever="--releasever=40"
+    fi
+    dnf install -y $releasever --skip-broken \
+        autoconf automake autoconf-archive libtool \
+        p11-kit httpd mod_ssl openssl-devel gnutls-utils nss-tools \
+        p11-kit-devel p11-kit-server opensc softhsm-devel procps-ng \
+        openssl util-linux
+}
+
+softhsm_token_setup()
+{    
+    title PARA "Softhsm token setup"
+    
+    pushd $WORKDIR
+    mkdir ca server
+    openssl req -x509 -sha256 -newkey rsa:2048 -noenc -batch \
+        -keyout ca/key.pem -out ca/cert.pem
+    openssl req -newkey rsa:2048 -subj '/CN=localhost' -noenc -batch \
+        -keyout server/key.pem -out server/csr.pem
+    openssl x509 -req -CA ca/cert.pem -CAkey ca/key.pem \
+        -in server/csr.pem -out server/cert.pem -CAcreateserial
+    chown -R apache:apache $WORKDIR
+
+    usermod -a -G ods apache
+    cp -rnp /var/lib/softhsm/tokens{,.bck}
+    runuser -u apache -- \
+        softhsm2-util --init-token --free --label softtoken --pin $PIN --so-pin $PIN
+    TOKENURL=$(p11tool --list-token-urls | grep "softtoken")
+    runuser -u apache -- p11tool \
+        --write \
+        --load-privkey server/key.pem \
+        --label httpd \
+        --id=%01 \
+        --login \
+        --set-pin $PIN $TOKENURL
+    runuser -u apache -- p11tool \
+        --write \
+        --load-certificate server/cert.pem \
+        --label httpd \
+        --id=%01 \
+        --login \
+        --set-pin $PIN $TOKENURL
+    popd
+
+    export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/libsofthsm2.so"
+
+    title SECTION "List token content"
+    p11tool --login --set-pin $PIN --list-all $TOKENURL 
+    title ENDSECTION
+}
+
+pkcs11_provider_setup()
+{
+    title PARA "Get, compile and install pkcs11-provider"
+
+    export PKCS11_PROVIDER_DEBUG=file:$PKCS11_DEBUG_FILE
+    if [ "$GITHUB_ACTIONS" == "true" ]; then
+        if [ -z "$PKCS11_MODULE" ]; then
+            echo "ERROR: Missing PKCS11_MODULE variable!"
+            exit 1
+        fi
+        echo "Skipped (running in Github Actions)"
+    else
+        git clone ${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"} \
+          ${WORKDIR}/pkcs11-provider
+        pushd $WORKDIR/pkcs11-provider
+        git checkout ${GIT_REF:-"main"}
+        autoreconf -fiv
+        ./configure --libdir=/usr/lib64
+        make
+        make install
+        popd
+        export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+    fi
+    test -e $PKCS11_MODULE
+}
+
+openssl_setup()
+{
+    title PARA "OpenSSL setup"
+
+    echo "$PIN" >$PIN_FILE
+    sed \
+      -e "s|\(default = default_sect\)|\1\npkcs11 = pkcs11_sect\n|" \
+      -e "s|\(\[default_sect\]\)|\[pkcs11_sect\]\n\1|" \
+      -e "s|\(\[default_sect\]\)|module = $PKCS11_MODULE\n\1|" \
+      -e "s|\(\[default_sect\]\)|pkcs11-module-load-behavior = early\n\1|" \
+      -e "s|\(\[default_sect\]\)|pkcs11-module-token-pin = file:$PIN_FILE\n\1|" \
+      -e "s|\(\[default_sect\]\)|activate = 1\n\n\1|" \
+      /etc/pki/tls/openssl.cnf >${WORKDIR}/openssl.cnf
+
+    title SECTION "openssl.cnf"
+    cat ${WORKDIR}/openssl.cnf
+    title ENDSECTION
+}
+
+httpd_setup()
+{
+    title PARAM "Httpd setup"
+
+    TOKENURL=$(p11tool --list-token-urls | grep "softtoken")
+    KEYURL="$(p11tool --login --set-pin $PIN --list-keys $TOKENURL \
+        | grep 'URL:.*object=httpd;type=private' \
+        | awk '{ print $NF }')?pin-value=$PIN"
+    CERTURL=$(p11tool --list-all-certs $TOKENURL \
+        | grep "URL:.*object=httpd;type=cert" \
+        | awk '{ print $NF }')
+
+    cp -p $MOD_SSL_CONF{,.bck}
+    sed -i -e "/^SSLCryptoDevice/d" \
+           -e "s/^SSLCertificateFile.*\$/SSLCertificateFile \"$CERTURL\"/" \
+           -e "s/^SSLCertificateKeyFile.*\$/SSLCertificateKeyFile \"$KEYURL\"/" \
+           $MOD_SSL_CONF
+    # echo 'ServerName localhost:80' >>/etc/httpd/conf/httpd.conf
+           
+    title SECTION "$MOD_SSL_CONF"
+    cat $MOD_SSL_CONF
+    title ENDSECTION
+}
+
+httpd_test()
+{
+    title PARA "Httpd test"
+
+    title PARA "Test 1: Start httpd"
+    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.httpd_start \
+    OPENSSL_CONF=${WORKDIR}/openssl.cnf httpd -DFOREGROUND &
+    sleep 3
+    if ! pgrep httpd >/dev/null; then
+        echo "ERROR: Unable to start httpd!"
+        exit 1 
+    fi
+
+    title PARA "Test 2: Curl connects to httpd over TLS"
+    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.curl \
+    curl -v -sS --cacert ${WORKDIR}/ca/cert.pem https://localhost >/dev/null
+
+    echo "Test passed"
+}
+
+cleanup() 
+{
+    title PARA "Clean-up"
+
+    for L in ${PKCS11_DEBUG_FILE}.*; do
+        title SECTION "$L"
+        cat $L
+        title ENDSECTION
+    done
+    ssl_log="/var/log/httpd/ssl_error_log" 
+    if [ -e $ssl_log ]; then
+        title SECTION "$ssl_log"
+        cat $ssl_log
+        title ENDSECTION
+    fi
+
+    pushd $BASEDIR >/dev/null
+    rm -rf $WORKDIR
+    if pgrep httpd >/dev/null; then
+        pkill httpd
+    fi
+    if [ -e ${MOD_SSL_CONF}.bck ]; then
+        mv ${MOD_SSL_CONF}.bck $MOD_SSL_CONF
+    fi
+    if [ -e /var/lib/softhsm/tokens.bck ]; then
+        rm -rf /var/lib/softhsm/tokens
+        mv /var/lib/softhsm/tokens.bck /var/lib/softhsm/tokens
+    fi
+
+    title LINE "Done"
+}
+
+trap "cleanup" EXIT
+
+# Setup.
+install_dependencies
+softhsm_token_setup
+pkcs11_provider_setup
+openssl_setup
+httpd_setup
+
+# Test.
+httpd_test
+
+exit 0

--- a/tests/integration/libssh.sh
+++ b/tests/integration/libssh.sh
@@ -2,6 +2,7 @@
 # Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
+# shellcheck disable=SC1091
 source "../helpers.sh"
 
 BASEDIR=$PWD
@@ -30,10 +31,11 @@ pkcs11_provider_setup()
             exit 1
         fi
     else
-        git clone ${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"} \
-          ${WORKDIR}/pkcs11-provider
-        pushd $WORKDIR/pkcs11-provider
-        git checkout ${GIT_REF:-"main"}
+        git clone \
+          "${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"}" \
+          "${WORKDIR}"/pkcs11-provider
+        pushd "$WORKDIR"/pkcs11-provider
+        git checkout "${GIT_REF:-"main"}"
         autoreconf -fiv
         ./configure --libdir=/usr/lib64
         make
@@ -41,7 +43,7 @@ pkcs11_provider_setup()
         popd
         export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
     fi
-    test -e $PKCS11_MODULE
+    test -e "$PKCS11_MODULE"
 }
 
 libssh_setup()
@@ -49,17 +51,17 @@ libssh_setup()
     title PRAM "Clone, setup and build libssh"
 
     git clone https://gitlab.com/libssh/libssh-mirror.git \
-      ${WORKDIR}/libssh-mirror
+      "${WORKDIR}"/libssh-mirror
 
-    mkdir ${WORKDIR}/libssh-mirror/build
-    pushd ${WORKDIR}/libssh-mirror/build
+    mkdir "${WORKDIR}"/libssh-mirror/build
+    pushd "${WORKDIR}"/libssh-mirror/build
     cmake \
       -DUNIT_TESTING=ON \
       -DCLIENT_TESTING=ON \
       -DCMAKE_BUILD_TYPE=Debug \
       -DWITH_PKCS11_URI=ON \
       -DWITH_PKCS11_PROVIDER=ON \
-      -DPKCS11_PROVIDER=${PKCS11_MODULE} ..
+      -DPKCS11_PROVIDER="${PKCS11_MODULE}" ..
     make
     popd
 }
@@ -68,7 +70,7 @@ libssh_test()
 {
     title PARAM "Run libssh pkcs11 tests"
 
-    pushd ${WORKDIR}/libssh-mirror/build
+    pushd "${WORKDIR}"/libssh-mirror/build
     PKCS11_PROVIDER_DEBUG=file:$PKCS11_DEBUG_FILE ctest \
       --output-on-failure -R \
       '(torture_auth_pkcs11|torture_pki_rsa_uri|torture_pki_ecdsa_uri)' \
@@ -80,16 +82,17 @@ libssh_test()
     popd
 }
 
+# shellcheck disable=SC2317
 cleanup() 
 {
     title PARA "Clean-up"
 
     title SECTION "$PKCS11_DEBUG_FILE"
-    cat $PKCS11_DEBUG_FILE
+    cat "$PKCS11_DEBUG_FILE"
     title ENDSECTION
 
-    pushd $BASEDIR >/dev/null
-    rm -rf $WORKDIR
+    pushd "$BASEDIR" >/dev/null
+    rm -rf "$WORKDIR"
 
     title LINE "Done"
 }

--- a/tests/integration/libssh.sh
+++ b/tests/integration/libssh.sh
@@ -1,0 +1,105 @@
+#!/bin/bash -e
+# Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "../helpers.sh"
+
+BASEDIR=$PWD
+WORKDIR=$(mktemp -d)
+PKCS11_DEBUG_FILE="${WORKDIR}/pkcs11-libssh-test.log"
+
+install_dependencies()
+{
+    title PARA "Install dependencies" 
+    
+    dnf install -y --skip-broken cmake libcmocka libcmocka-devel softhsm \
+      nss-tools gnutls-utils p11-kit p11-kit-devel p11-kit-server opensc \
+      softhsm-devel socket_wrapper nss_wrapper uid_wrapper pam_wrapper \
+      priv_wrapper openssh-server zlib-devel git autoconf autoconf-archive \
+      automake libtool openssl-devel gcc g++ libcmocka-devel 
+}
+
+pkcs11_provider_setup()
+{
+    title PARA "Get, compile and install pkcs11-provider"
+
+    if [ "$GITHUB_ACTIONS" == "true" ]; then
+        echo "Skipped (running in Github Actions)"
+        if [ -z "$PKCS11_MODULE" ]; then
+            echo "ERROR: Missing PKCS11_MODULE variable!"
+            exit 1
+        fi
+    else
+        git clone ${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"} \
+          ${WORKDIR}/pkcs11-provider
+        pushd $WORKDIR/pkcs11-provider
+        git checkout ${GIT_REF:-"main"}
+        autoreconf -fiv
+        ./configure --libdir=/usr/lib64
+        make
+        make install
+        popd
+        export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
+    fi
+    test -e $PKCS11_MODULE
+}
+
+libssh_setup()
+{
+    title PRAM "Clone, setup and build libssh"
+
+    git clone https://gitlab.com/libssh/libssh-mirror.git \
+      ${WORKDIR}/libssh-mirror
+
+    mkdir ${WORKDIR}/libssh-mirror/build
+    pushd ${WORKDIR}/libssh-mirror/build
+    cmake \
+      -DUNIT_TESTING=ON \
+      -DCLIENT_TESTING=ON \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DWITH_PKCS11_URI=ON \
+      -DWITH_PKCS11_PROVIDER=ON \
+      -DPKCS11_PROVIDER=${PKCS11_MODULE} ..
+    make
+    popd
+}
+
+libssh_test()
+{
+    title PARAM "Run libssh pkcs11 tests"
+
+    pushd ${WORKDIR}/libssh-mirror/build
+    PKCS11_PROVIDER_DEBUG=file:$PKCS11_DEBUG_FILE ctest \
+      --output-on-failure -R \
+      '(torture_auth_pkcs11|torture_pki_rsa_uri|torture_pki_ecdsa_uri)' \
+     | tee testout.log 2>&1
+    grep -q "100% tests passed, 0 tests failed out of 3" testout.log
+    test -s "$PKCS11_DEBUG_FILE"
+   
+    echo "Test passed"
+    popd
+}
+
+cleanup() 
+{
+    title PARA "Clean-up"
+
+    title SECTION "$PKCS11_DEBUG_FILE"
+    cat $PKCS11_DEBUG_FILE
+    title ENDSECTION
+
+    pushd $BASEDIR >/dev/null
+    rm -rf $WORKDIR
+
+    title LINE "Done"
+}
+
+trap "cleanup" EXIT
+
+# Setup.
+install_dependencies
+pkcs11_provider_setup
+libssh_setup
+
+# Test.
+libssh_test


### PR DESCRIPTION
This PR adds two new tests (for httpd and bind) and re-factors previously added test for libssh. Tests are intended to run in CI (github actions) but they can be executed on any Fedora (39 and newer) as follows (`GIT_URL`  defaults to this repository and `GIT_REF` to the main branch):

```
# cd tests/integration
# GIT_URL=https://github.com/The-Mule/pkcs11-provider.git GIT_REF=integration-tests bash -e libssh.sh
```

Testing requires bash -e option. Non-zero exit code means failure. Provider debug logs are always printed out at the end (regardless of the result). All three tests uses softhsm token (bind test does so via p11-kit server proxy). Please notice that until Fedora 40 is released both httpd and bind test need to use a specific docker image.

