### PR TITLE
Try to run Coverity Scan on demand

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,3 +26,4 @@ want to know about year later when sorting thorough as commits are the changelog
 - [ ] This feature/change has adequate documentation added
 - [ ] Code conform to coding style that today cannot yet be enforced via the check style test
 - [ ] Commits have short titles and sensible commit messages
+- [ ] Coverity Scan has run if needed (code PR) and no new defects were found

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -2,13 +2,16 @@
 name: Coverity Scan
 
 on:
-  push:
+  pull_request_target:
     branches: ["main"]
+    types:
+      - labeled
   schedule:
     - cron: '41 3 * * 0'
 
 jobs:
-  coverity:
+  scheduled:
+    if: ${{ github.event_name == 'schedule' }}
     name: Coverity Scan
     runs-on: ubuntu-22.04
     container: fedora:latest
@@ -19,7 +22,7 @@ jobs:
                 autoconf-archive openssl-devel openssl \
                 nss-softokn nss-tools nss-softokn-devel
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         run: |
           autoreconf -fiv
@@ -40,3 +43,42 @@ jobs:
           project: "PKCS%2311+Provider"
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+  on-labeled-pr:
+    if: ${{ contains(github.event.*.labels.*.name, 'covscan') }}
+    name: Coverity Scan
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    container: fedora:latest
+    steps:
+      - name: Install Dependencies
+        run: |
+            dnf -y install git gcc automake libtool pkgconf-pkg-config \
+                autoconf-archive openssl-devel openssl \
+                nss-softokn nss-tools nss-softokn-devel \
+                gh
+      - name: Find PR
+        uses: suzuki-shunsuke/get-pr-action@v0.1.0
+        id: pr
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{steps.get-pr.outputs.merge_commit_sha}}
+      - name: Setup
+        run: |
+          autoreconf -fiv
+          ./configure
+      - name: Coverity Scan
+        uses: vapier/coverity-scan-action@v1
+        with:
+          project: "PKCS%2311+Provider"
+          email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      - name: Remove Label
+        if: always()
+        run: gh pr edit "$NUMBER" --remove-label "covscan"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
#### Description

PR to change Coverity Scan to run on demand (by setting the covscan label) instead of running it after merge to main.
This way we can run the scan when the PR is still open and catch issues before merging.

#### Checklist

N/A

#### Reviewer's checklist:

- [x] Commits have short titles and sensible commit messages
