### PR TITLE
Change names of the two covscan jobs

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   scheduled:
     if: ${{ github.event_name == 'schedule' }}
-    name: Coverity Scan
+    name: Recurrent Coverity Scan
     runs-on: ubuntu-22.04
     container: fedora:latest
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   on-labeled-pr:
     if: ${{ contains(github.event.*.labels.*.name, 'covscan') }}
-    name: Coverity Scan
+    name: Coverity Scan on PR
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
#### Description

Otherwise Github thinks both are required to pass a PR, but actually only the PR one is as the scheduled scan only runs on a schedule.

#### Reviewer's checklist:

- [x] Commits have short titles and sensible commit messages
