### PR TITLE
ci: Switch to macOS 14 on M series chips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         token: [softokn, softhsm]
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
#### Description
macOS 12 was released in October 21, and since then 13 has been out in October 22, and 14 in September 23. Switch to a more recent Mac operating system since that's likely what users will be running.

See [\[1\]][1] for GitHub's list of available shared runners. From the macos-12 label to the macos-14 label, the number of CPU cores stays the same (3), but the CPU architecture switches from x86_64 to arm64. All other parameters stay the same except for RAM, which changes from 14 GB to 7 GB. Since pkcs11-provider is not a memory intensive project, this likely has negligible impact on us. The new CPU architecture can be helpful to identify hardware-specific issues, so is probably a net positive. The M series chips are also typically much faster than the older Intel counterparts.

[1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

#### Checklist

- [x] Code modified for feature
- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
