### PR TITLE
Use a genereic mechanism to block calls to tokens

### DIFF
--- a/src/digests.c
+++ b/src/digests.c
@@ -191,13 +191,8 @@ static void *p11prov_digest_dupctx(void *ctx)
     dctx->session = NULL;
 
     /* NOTE: most tokens will probably return errors trying to do this on digest
-     * sessions. If the configuration indicates that GetOperationState will fail
-     * we don't even try to duplicate the context. */
-
-    if (p11prov_ctx_no_operation_state(dctx->provctx)) {
-        goto done;
-    }
-
+     * sessions. If GetOperationState fails we don't even try to duplicate the
+     * context. */
     ret = p11prov_GetOperationState(dctx->provctx, sess, NULL_PTR, &state_len);
     if (ret != CKR_OK) {
         goto done;

--- a/src/interface.gen.c
+++ b/src/interface.gen.c
@@ -9,6 +9,10 @@ CK_RV p11prov_Initialize(P11PROV_CTX *ctx, CK_VOID_PTR pInitArgs)
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Initialize)) {
+        P11PROV_debug("C_%s is blocked", "Initialize");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Initialize");
     ret = intf->Initialize(pInitArgs);
@@ -28,6 +32,10 @@ CK_RV p11prov_Finalize(P11PROV_CTX *ctx, CK_VOID_PTR pReserved)
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Finalize)) {
+        P11PROV_debug("C_%s is blocked", "Finalize");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Finalize");
     ret = intf->Finalize(pReserved);
@@ -46,6 +54,10 @@ CK_RV p11prov_GetInfo(P11PROV_CTX *ctx, CK_INFO_PTR pInfo)
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetInfo)) {
+        P11PROV_debug("C_%s is blocked", "GetInfo");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GetInfo");
@@ -68,6 +80,10 @@ CK_RV p11prov_GetInterface(P11PROV_CTX *ctx, CK_UTF8CHAR_PTR pInterfaceName,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetInterface)) {
+        P11PROV_debug("C_%s is blocked", "GetInterface");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetInterface");
     ret = intf->GetInterface(pInterfaceName, pVersion, ppInterface, flags);
@@ -87,6 +103,10 @@ CK_RV p11prov_GetFunctionList(P11PROV_CTX *ctx,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetFunctionList)) {
+        P11PROV_debug("C_%s is blocked", "GetFunctionList");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GetFunctionList");
@@ -108,6 +128,10 @@ CK_RV p11prov_GetSlotList(P11PROV_CTX *ctx, CK_BBOOL tokenPresent,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetSlotList)) {
+        P11PROV_debug("C_%s is blocked", "GetSlotList");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetSlotList");
     ret = intf->GetSlotList(tokenPresent, pSlotList, pulCount);
@@ -128,6 +152,10 @@ CK_RV p11prov_GetSlotInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetSlotInfo)) {
+        P11PROV_debug("C_%s is blocked", "GetSlotInfo");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetSlotInfo");
     ret = intf->GetSlotInfo(slotID, pInfo);
@@ -147,6 +175,10 @@ CK_RV p11prov_GetTokenInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetTokenInfo)) {
+        P11PROV_debug("C_%s is blocked", "GetTokenInfo");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GetTokenInfo");
@@ -169,6 +201,10 @@ CK_RV p11prov_GetMechanismList(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetMechanismList)) {
+        P11PROV_debug("C_%s is blocked", "GetMechanismList");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetMechanismList");
     ret = intf->GetMechanismList(slotID, pMechanismList, pulCount);
@@ -189,6 +225,10 @@ CK_RV p11prov_GetMechanismInfo(P11PROV_CTX *ctx, CK_SLOT_ID slotID,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetMechanismInfo)) {
+        P11PROV_debug("C_%s is blocked", "GetMechanismInfo");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GetMechanismInfo");
@@ -211,6 +251,10 @@ CK_RV p11prov_OpenSession(P11PROV_CTX *ctx, CK_SLOT_ID slotID, CK_FLAGS flags,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_OpenSession)) {
+        P11PROV_debug("C_%s is blocked", "OpenSession");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "OpenSession");
     ret = intf->OpenSession(slotID, flags, pApplication, Notify, phSession);
@@ -229,6 +273,10 @@ CK_RV p11prov_CloseSession(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession)
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_CloseSession)) {
+        P11PROV_debug("C_%s is blocked", "CloseSession");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "CloseSession");
@@ -250,6 +298,10 @@ CK_RV p11prov_GetSessionInfo(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetSessionInfo)) {
+        P11PROV_debug("C_%s is blocked", "GetSessionInfo");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetSessionInfo");
     ret = intf->GetSessionInfo(hSession, pInfo);
@@ -270,6 +322,10 @@ CK_RV p11prov_GetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetOperationState)) {
+        P11PROV_debug("C_%s is blocked", "GetOperationState");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GetOperationState");
@@ -295,6 +351,10 @@ CK_RV p11prov_SetOperationState(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SetOperationState)) {
+        P11PROV_debug("C_%s is blocked", "SetOperationState");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "SetOperationState");
     ret =
@@ -318,6 +378,10 @@ CK_RV p11prov_Login(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Login)) {
+        P11PROV_debug("C_%s is blocked", "Login");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Login");
     ret = intf->Login(hSession, userType, pPin, ulPinLen);
@@ -338,6 +402,10 @@ CK_RV p11prov_CreateObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_CreateObject)) {
+        P11PROV_debug("C_%s is blocked", "CreateObject");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "CreateObject");
@@ -360,6 +428,10 @@ CK_RV p11prov_CopyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_CopyObject)) {
+        P11PROV_debug("C_%s is blocked", "CopyObject");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "CopyObject");
     ret = intf->CopyObject(hSession, hObject, pTemplate, ulCount, phNewObject);
@@ -379,6 +451,10 @@ CK_RV p11prov_DestroyObject(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DestroyObject)) {
+        P11PROV_debug("C_%s is blocked", "DestroyObject");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "DestroyObject");
@@ -401,6 +477,10 @@ CK_RV p11prov_GetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GetAttributeValue)) {
+        P11PROV_debug("C_%s is blocked", "GetAttributeValue");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "GetAttributeValue");
     ret = intf->GetAttributeValue(hSession, hObject, pTemplate, ulCount);
@@ -422,6 +502,10 @@ CK_RV p11prov_SetAttributeValue(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SetAttributeValue)) {
+        P11PROV_debug("C_%s is blocked", "SetAttributeValue");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "SetAttributeValue");
     ret = intf->SetAttributeValue(hSession, hObject, pTemplate, ulCount);
@@ -441,6 +525,10 @@ CK_RV p11prov_FindObjectsInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_FindObjectsInit)) {
+        P11PROV_debug("C_%s is blocked", "FindObjectsInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "FindObjectsInit");
@@ -464,6 +552,10 @@ CK_RV p11prov_FindObjects(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_FindObjects)) {
+        P11PROV_debug("C_%s is blocked", "FindObjects");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "FindObjects");
     ret =
@@ -484,6 +576,10 @@ CK_RV p11prov_FindObjectsFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession)
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_FindObjectsFinal)) {
+        P11PROV_debug("C_%s is blocked", "FindObjectsFinal");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "FindObjectsFinal");
     ret = intf->FindObjectsFinal(hSession);
@@ -503,6 +599,10 @@ CK_RV p11prov_EncryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_EncryptInit)) {
+        P11PROV_debug("C_%s is blocked", "EncryptInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "EncryptInit");
@@ -526,6 +626,10 @@ CK_RV p11prov_Encrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Encrypt)) {
+        P11PROV_debug("C_%s is blocked", "Encrypt");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Encrypt");
     ret = intf->Encrypt(hSession, pData, ulDataLen, pEncryptedData,
@@ -546,6 +650,10 @@ CK_RV p11prov_DecryptInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DecryptInit)) {
+        P11PROV_debug("C_%s is blocked", "DecryptInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "DecryptInit");
@@ -568,6 +676,10 @@ CK_RV p11prov_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Decrypt)) {
+        P11PROV_debug("C_%s is blocked", "Decrypt");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Decrypt");
     ret = intf->Decrypt(hSession, pEncryptedData, ulEncryptedDataLen, pData,
@@ -589,6 +701,10 @@ CK_RV p11prov_DigestInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DigestInit)) {
+        P11PROV_debug("C_%s is blocked", "DigestInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "DigestInit");
     ret = intf->DigestInit(hSession, pMechanism);
@@ -608,6 +724,10 @@ CK_RV p11prov_DigestUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DigestUpdate)) {
+        P11PROV_debug("C_%s is blocked", "DigestUpdate");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "DigestUpdate");
@@ -629,6 +749,10 @@ CK_RV p11prov_DigestFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DigestFinal)) {
+        P11PROV_debug("C_%s is blocked", "DigestFinal");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "DigestFinal");
     ret = intf->DigestFinal(hSession, pDigest, pulDigestLen);
@@ -648,6 +772,10 @@ CK_RV p11prov_SignInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SignInit)) {
+        P11PROV_debug("C_%s is blocked", "SignInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "SignInit");
@@ -670,6 +798,10 @@ CK_RV p11prov_Sign(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Sign)) {
+        P11PROV_debug("C_%s is blocked", "Sign");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Sign");
     ret = intf->Sign(hSession, pData, ulDataLen, pSignature, pulSignatureLen);
@@ -689,6 +821,10 @@ CK_RV p11prov_SignUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SignUpdate)) {
+        P11PROV_debug("C_%s is blocked", "SignUpdate");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "SignUpdate");
@@ -710,6 +846,10 @@ CK_RV p11prov_SignFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SignFinal)) {
+        P11PROV_debug("C_%s is blocked", "SignFinal");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "SignFinal");
     ret = intf->SignFinal(hSession, pSignature, pulSignatureLen);
@@ -729,6 +869,10 @@ CK_RV p11prov_VerifyInit(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_VerifyInit)) {
+        P11PROV_debug("C_%s is blocked", "VerifyInit");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "VerifyInit");
@@ -751,6 +895,10 @@ CK_RV p11prov_Verify(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_Verify)) {
+        P11PROV_debug("C_%s is blocked", "Verify");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "Verify");
     ret = intf->Verify(hSession, pData, ulDataLen, pSignature, ulSignatureLen);
@@ -771,6 +919,10 @@ CK_RV p11prov_VerifyUpdate(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_VerifyUpdate)) {
+        P11PROV_debug("C_%s is blocked", "VerifyUpdate");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "VerifyUpdate");
     ret = intf->VerifyUpdate(hSession, pPart, ulPartLen);
@@ -790,6 +942,10 @@ CK_RV p11prov_VerifyFinal(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_VerifyFinal)) {
+        P11PROV_debug("C_%s is blocked", "VerifyFinal");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "VerifyFinal");
@@ -813,6 +969,10 @@ CK_RV p11prov_GenerateKeyPair(
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GenerateKeyPair)) {
+        P11PROV_debug("C_%s is blocked", "GenerateKeyPair");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GenerateKeyPair");
@@ -839,6 +999,10 @@ CK_RV p11prov_DeriveKey(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_DeriveKey)) {
+        P11PROV_debug("C_%s is blocked", "DeriveKey");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "DeriveKey");
     ret = intf->DeriveKey(hSession, pMechanism, hBaseKey, pTemplate,
@@ -860,6 +1024,10 @@ CK_RV p11prov_SeedRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
     }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SeedRandom)) {
+        P11PROV_debug("C_%s is blocked", "SeedRandom");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
     P11PROV_debug("Calling C_"
                   "SeedRandom");
     ret = intf->SeedRandom(hSession, pSeed, ulSeedLen);
@@ -879,6 +1047,10 @@ CK_RV p11prov_GenerateRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     if (!intf) {
         P11PROV_raise(ctx, ret, "Can't get module interfaces");
         return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_GenerateRandom)) {
+        P11PROV_debug("C_%s is blocked", "GenerateRandom");
+        return CKR_FUNCTION_NOT_SUPPORTED;
     }
     P11PROV_debug("Calling C_"
                   "GenerateRandom");

--- a/src/interface.h
+++ b/src/interface.h
@@ -135,4 +135,63 @@ CK_RV side_channel_free_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
 
 CK_INFO p11prov_module_ck_info(P11PROV_MODULE *mctx);
 
+/* The following defines are needed for a generic mask for any of the functions
+ * we generate via interface.pre, however there is no need to assign a blocking
+ * value until we'll have a configuration option that allows to set blocks, so
+ * most of these are defined to 0 which won't block anything.
+ * Additionally we reserve the lower 4 bits to future "group" blocking. For
+ * example we may introduce a way to block all the PCS#11 v3 function calls to
+ * simulate a 2.40 token */
+#define P11PROV_BLOCK_Initialize 0b0000000000000000
+#define P11PROV_BLOCK_Finalize 0b0000000000000000
+#define P11PROV_BLOCK_GetInfo 0b0000000000000000
+#define P11PROV_BLOCK_GetFunctionList 0b0000000000000000
+#define P11PROV_BLOCK_GetSlotList 0b0000000000000000
+#define P11PROV_BLOCK_GetSlotInfo 0b0000000000000000
+#define P11PROV_BLOCK_GetTokenInfo 0b0000000000000000
+#define P11PROV_BLOCK_GetMechanismList 0b0000000000000000
+#define P11PROV_BLOCK_GetMechanismInfo 0b0000000000000000
+#define P11PROV_BLOCK_OpenSession 0b0000000000000000
+#define P11PROV_BLOCK_CloseSession 0b0000000000000000
+#define P11PROV_BLOCK_GetSessionInfo 0b0000000000000000
+#define P11PROV_BLOCK_GetOperationState 0b0000000000001000
+#define P11PROV_BLOCK_SetOperationState 0b0000000000001000
+#define P11PROV_BLOCK_Login 0b0000000000000000
+#define P11PROV_BLOCK_Logout 0b0000000000000000
+#define P11PROV_BLOCK_CreateObject 0b0000000000000000
+#define P11PROV_BLOCK_CopyObject 0b0000000000000000
+#define P11PROV_BLOCK_DestroyObject 0b0000000000000000
+#define P11PROV_BLOCK_GetAttributeValue 0b0000000000000000
+#define P11PROV_BLOCK_SetAttributeValue 0b0000000000000000
+#define P11PROV_BLOCK_FindObjectsInit 0b0000000000000000
+#define P11PROV_BLOCK_FindObjects 0b0000000000000000
+#define P11PROV_BLOCK_FindObjectsFinal 0b0000000000000000
+#define P11PROV_BLOCK_EncryptInit 0b0000000000000000
+#define P11PROV_BLOCK_Encrypt 0b0000000000000000
+#define P11PROV_BLOCK_EncryptUpdate 0b0000000000000000
+#define P11PROV_BLOCK_EncryptFinal 0b0000000000000000
+#define P11PROV_BLOCK_DecryptInit 0b0000000000000000
+#define P11PROV_BLOCK_Decrypt 0b0000000000000000
+#define P11PROV_BLOCK_DecryptUpdate 0b0000000000000000
+#define P11PROV_BLOCK_DecryptFinal 0b0000000000000000
+#define P11PROV_BLOCK_DigestInit 0b0000000000000000
+#define P11PROV_BLOCK_Digest 0b0000000000000000
+#define P11PROV_BLOCK_DigestUpdate 0b0000000000000000
+#define P11PROV_BLOCK_DigestKey 0b0000000000000000
+#define P11PROV_BLOCK_DigestFinal 0b0000000000000000
+#define P11PROV_BLOCK_SignInit 0b0000000000000000
+#define P11PROV_BLOCK_Sign 0b0000000000000000
+#define P11PROV_BLOCK_SignUpdate 0b0000000000000000
+#define P11PROV_BLOCK_SignFinal 0b0000000000000000
+#define P11PROV_BLOCK_VerifyInit 0b0000000000000000
+#define P11PROV_BLOCK_Verify 0b0000000000000000
+#define P11PROV_BLOCK_VerifyUpdate 0b0000000000000000
+#define P11PROV_BLOCK_VerifyFinal 0b0000000000000000
+#define P11PROV_BLOCK_GenerateKeyPair 0b0000000000000000
+#define P11PROV_BLOCK_DeriveKey 0b0000000000000000
+#define P11PROV_BLOCK_SeedRandom 0b0000000000000000
+#define P11PROV_BLOCK_GenerateRandom 0b0000000000000000
+/* 3.x  functions: */
+#define P11PROV_BLOCK_GetInterface 0b0000000000000000
+
 #endif /* _INTERFACE_H */

--- a/src/interface.pre
+++ b/src/interface.pre
@@ -10,6 +10,10 @@ BEGIN:
         P11PROV_raise(ctx, ret, "Can't get module interfaces"); \
         return ret; \
     } \
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_##name)) { \
+        P11PROV_debug("C_%s is blocked", #name); \
+        return CKR_FUNCTION_NOT_SUPPORTED; \
+    } \
     P11PROV_debug("Calling C_" #name);
 #define IMPL_CALL_EPILOG(name) \
     if (ret != CKR_OK) { \

--- a/src/pk11_uri.gen.c
+++ b/src/pk11_uri.gen.c
@@ -7,8 +7,9 @@ extern P11PROV_PK11_URI *
 d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a, const unsigned char **in, long len);
 extern int i2d_P11PROV_PK11_URI(const P11PROV_PK11_URI *a, unsigned char **out);
 extern const ASN1_ITEM *P11PROV_PK11_URI_it(void);
-P11PROV_PK11_URI *d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a,
-                                       const unsigned char **in, long len)
+
+P11PROV_PK11_URI
+*d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a, const unsigned char **in, long len)
 {
     return (P11PROV_PK11_URI *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
                                              (P11PROV_PK11_URI_it()));
@@ -17,7 +18,8 @@ int i2d_P11PROV_PK11_URI(const P11PROV_PK11_URI *a, unsigned char **out)
 {
     return ASN1_item_i2d((const ASN1_VALUE *)a, out, (P11PROV_PK11_URI_it()));
 }
-P11PROV_PK11_URI *P11PROV_PK11_URI_new(void)
+P11PROV_PK11_URI
+*P11PROV_PK11_URI_new(void)
 {
     return (P11PROV_PK11_URI *)ASN1_item_new((P11PROV_PK11_URI_it()));
 }
@@ -27,8 +29,10 @@ void P11PROV_PK11_URI_free(P11PROV_PK11_URI *a)
 }
 
 static const ASN1_TEMPLATE P11PROV_PK11_URI_seq_tt[] = {
+
     { (0), (0), __builtin_offsetof(P11PROV_PK11_URI, desc), "desc",
       (ASN1_VISIBLESTRING_it) },
+
     { (0), (0), __builtin_offsetof(P11PROV_PK11_URI, uri), "uri",
       (ASN1_UTF8STRING_it) },
 };
@@ -57,8 +61,10 @@ extern P11PROV_PK11_URI *PEM_read_bio_P11PROV_PK11_URI(BIO *out,
                                                        P11PROV_PK11_URI **x,
                                                        pem_password_cb *cb,
                                                        void *u);
-P11PROV_PK11_URI *PEM_read_bio_P11PROV_PK11_URI(BIO *bp, P11PROV_PK11_URI **x,
-                                                pem_password_cb *cb, void *u)
+
+P11PROV_PK11_URI
+*PEM_read_bio_P11PROV_PK11_URI(BIO *bp, P11PROV_PK11_URI **x,
+                               pem_password_cb *cb, void *u)
 {
     return PEM_ASN1_read_bio((d2i_of_void *)d2i_P11PROV_PK11_URI,
                              P11PROV_PEM_LABEL, bp, (void **)x, cb, u);

--- a/src/provider.c
+++ b/src/provider.c
@@ -37,8 +37,8 @@ struct p11prov_ctx {
     /* cfg quirks */
     bool no_deinit;
     bool no_allowed_mechanisms;
-    bool no_operation_state;
     bool no_session_callbacks;
+    uint64_t blocked_calls;
 
     /* module handles and data */
     P11PROV_MODULE *module;
@@ -613,9 +613,9 @@ int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx)
     return ctx->cache_sessions;
 }
 
-bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx)
+bool p11prov_ctx_is_call_blocked(P11PROV_CTX *ctx, uint64_t mask)
 {
-    return ctx->no_operation_state;
+    return (ctx->blocked_calls & mask) != 0;
 }
 
 bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx)
@@ -1532,7 +1532,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
             } else if (strncmp(str, "no-allowed-mechanisms", toklen) == 0) {
                 ctx->no_allowed_mechanisms = true;
             } else if (strncmp(str, "no-operation-state", toklen) == 0) {
-                ctx->no_operation_state = true;
+                ctx->blocked_calls |= P11PROV_BLOCK_GetOperationState;
             } else if (strncmp(str, "no-session-callbacks", toklen) == 0) {
                 ctx->no_session_callbacks = true;
             }

--- a/src/provider.h
+++ b/src/provider.h
@@ -116,7 +116,7 @@ enum p11prov_cache_keys {
 int p11prov_ctx_cache_keys(P11PROV_CTX *ctx);
 int p11prov_ctx_cache_sessions(P11PROV_CTX *ctx);
 
-bool p11prov_ctx_no_operation_state(P11PROV_CTX *ctx);
+bool p11prov_ctx_is_call_blocked(P11PROV_CTX *ctx, uint64_t mask);
 bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx);
 
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx);

--- a/src/signature.c
+++ b/src/signature.c
@@ -141,18 +141,13 @@ static void *p11prov_sig_dupctx(void *ctx)
     newctx->session = sigctx->session;
     sigctx->session = NULL;
 
-    /* NOTE: most tokens will probably return errors trying to do this on sign
-     * sessions. If the configuration indicates that GetOperationState will fail
-     * we don't even try to duplicate the context. */
-
-    if (p11prov_ctx_no_operation_state(sigctx->provctx)) {
-        goto done;
-    }
-
     if (slotid != CK_UNAVAILABLE_INFORMATION && handle != CK_INVALID_HANDLE) {
         CK_SESSION_HANDLE newsess = p11prov_session_handle(newctx->session);
         CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
 
+        /* NOTE: most tokens will probably return errors trying to do this on
+         * sign sessions. If GetOperationState fails we don't try to duplicate
+         * the context and just return. */
         ret = p11prov_GetOperationState(sigctx->provctx, newsess, NULL_PTR,
                                         &state_len);
         if (ret != CKR_OK) {


### PR DESCRIPTION
#### Description

Introduce a generic mechanism to block calls to a token.
Use this mechanism to reimplement the no_operation_state quirk.

Fixes #327 

#### Checklist

- [ ] Code modified for feature
- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
