### PR TITLE
build: Install provider in correct path

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -34,5 +34,5 @@ pkcs11_provider = shared_module(
   link_depends: [pkcs11_provider_map],
   link_args: pkcs11_provider_ldflags,
   install: true,
-  install_dir: get_option('libdir') / 'ossl-modules',
+  install_dir: provider_path,
 )


### PR DESCRIPTION
#### Description

OpenSSL's `libcrypto.pc` file does expose the correct path for providers in the `modulesdir` pkg-config variable (queryable using `pkg-config --variable=modulesdir libcrypto`), and we do obtain that path in `./meson.build`.

However, that variable is unused at the moment, and instead `src/meson.build` "guesses" that path as `$libdir/ossl-modules`, which may not actually be correct.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] ~Test suite updated with functionality tests~
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
