### PR TITLE
Address various issues with meson builds

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -63,6 +63,7 @@ jobs:
           name: Address sanitizer logs on ${{ matrix.name }}
           path: |
             builddir/meson-logs/
+            builddir/tests/*.log
             builddir/tests/tmp.${{ matrix.token }}/p11prov-debug.log
             builddir/tests/tmp.${{ matrix.token }}/testvars
             builddir/tests/tmp.${{ matrix.token }}/openssl.cnf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
           name: Test logs on macOS-12 with ${{ matrix.token }}
           path: |
             builddir/meson-logs/*
+            builddir/tests/*.log
             builddir/tests/tmp.${{ matrix.token }}/p11prov-debug.log
             builddir/tests/tmp.${{ matrix.token }}/testvars
             builddir/tests/tmp.${{ matrix.token }}/openssl.cnf

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: all check check-style check-style-show check-style-fix clean generate-code generate-docs
 
 all:
-	meson setup builddir
-	meson compile -C builddir
+	if [ ! -d "builddir" ]; then \
+		meson setup builddir; \
+	fi; \
+	meson compile -C builddir pkcs11
 
 check:
 	meson test -C builddir

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -148,7 +148,7 @@ foreach t, extra_args : tests
       suite: suite,
       env: test_env,
       depends: test_executables,
-      is_parallel: is_parallel,
+      is_parallel: false,
     )
   endforeach
 endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -104,10 +104,13 @@ test_programs = [
   'pincache',
 ]
 
+test_executables = []
 foreach t : test_programs
-  executable(t, '@0@.c'.format(t),
-             include_directories: [configinc],
-             dependencies: [libcrypto, libssl])
+  t = executable(t, '@0@.c'.format(t),
+                 build_by_default: false,
+                 include_directories: [configinc],
+                 dependencies: [libcrypto, libssl])
+  test_executables += [t]
 endforeach
 
 tests = {
@@ -144,6 +147,7 @@ foreach t, extra_args : tests
       args: '@0@-@1@.t'.format(t, suite),
       suite: suite,
       env: test_env,
+      depends: test_executables,
       is_parallel: is_parallel,
     )
   endforeach

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,25 +30,20 @@ if nss_softokn.found()
   endif
 endif
 
-softoken_conf = custom_target(
-  'generate softoken configuration',
-  output: 'tmp.softokn.log',
-  env: conf_env,
-  command: [
-    find_program('setup-softokn.sh'),
-  ],
-  capture: true,
-)
+test_setup = {
+  'setup_softokn': {'suite': 'softokn', 'exe': find_program('setup-softokn.sh')},
+  'setup_softhsm': {'suite': 'softhsm', 'exe': find_program('setup-softhsm.sh')},
+}
 
-softhsm_conf = custom_target(
-  'generate softhsm configuration',
-  output: 'tmp.softhsm.log',
-  env: conf_env,
-  command: [
-    find_program('setup-softhsm.sh'),
-  ],
-  capture: true,
-)
+foreach name, targs : test_setup
+  test(
+    name,
+    targs.get('exe'),
+    suite: targs.get('suite'),
+    env: conf_env,
+    is_parallel: false,
+  )
+endforeach
 
 test_env = environment({
   'TEST_PATH': meson.current_source_dir(),
@@ -148,7 +143,6 @@ foreach t, extra_args : tests
       test_wrapper,
       args: '@0@-@1@.t'.format(t, suite),
       suite: suite,
-      depends: [softoken_conf, softhsm_conf],
       env: test_env,
       is_parallel: is_parallel,
     )

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -47,5 +47,10 @@ for option in "${TEST_PARAMS[@]}"; do
     fi
 done
 
+LOGFILE="${TESTBLDDIR}/${TEST_NAME}.${TOKEN_DRIVER}.log"
+
 echo "Executing ${COMMAND}"
-${COMMAND}
+(
+  set -o pipefail
+  ${COMMAND} | tee "${LOGFILE}"
+)


### PR DESCRIPTION
#### Description

The change to the meson build system regressed some minor things that I am attempting to fix here:
- Output also individual log files
  Meson defaults to a ginormous log file with the output of all tests mashed together, this works but makes looking at specific test failures harder.
- Turn the custom targets that werre setting up tests into "tests", this allows us to run them only during the tests phase and not during the compile phase, which is unwanted
- Add dependencies from tests to test executables so they are rebuilt if missing
- Change make targets so we only build pkcs11.so and not all of the tests as well, this prevents coverity from flagging stuff in the test suite among other things
- Do not run tests in parallel, there are some unstated dependencies between tests so they will flake randomly via race conditions. Until we can set proper dependencies between tests just disable parallel runs, it doesn't change the total run by much
- Restore collection of individual log files

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] ~Code modified for feature~
- [ ] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
