### PR TITLE
 fixing Covscan PR target

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -59,13 +59,10 @@ jobs:
                 openssl-devel openssl \
                 nss-softokn nss-tools nss-softokn-devel \
                 gh
-      - name: Find PR
-        uses: suzuki-shunsuke/get-pr-action@v0.1.0
-        id: pr
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{steps.get-pr.outputs.merge_commit_sha}}
+          ref: ${{github.event.pull_request.head.sha}}
       - name: Setup
         run: |
           meson setup builddir
@@ -84,3 +81,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
+
+  on-no-covscan-labeled-pr:
+    if: ${{ contains(github.event.*.labels.*.name, 'no-covscan') }}
+    name: Coverity Scan on PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coverity Scan not needed
+        run: echo "Dummy action to report all ok and mark covscan as handled"


### PR DESCRIPTION
#### Description
The Coverity Scan job that runs on PRs is supposed to pull the PR code when running in the pull_request_target case, but it is sourcing the incorrect ref.

Also The Coverity Scan is blocking, but we do not want to run it when there are no code changes, so add a new no-covscan label that makes the test pass w/o running one of the 4 covscan jobs/day we are allowed.

#### Checklist

- [x] Test suite updated

#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
