### PR TITLE
Small re-organization of documentation files

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,6 @@
-## Build Prerequisites
+## Build & Installation
+
+### Prerequisites
 
 This package requires the following:
 - OpenSSL 3.0.7+ libraries and development headers
@@ -9,10 +11,12 @@ This package requires the following:
 - pkg-config
 - p11-kit, p11-kit-server, p11-kit-devel, opensc and softhsm (for testing)
 
+### Build
+
 The usual command to build are:
-- meson setup builddir
-- meson compile -C builddir
-- meson test -C builddir
+- `meson setup builddir`
+- `meson compile -C builddir`
+- `meson test -C builddir`
 
 To link with OpenSSL installed in a custom path, set
 `PKG_CONFIG_PATH`, or `CFLAGS`/`LDFLAGS` envvars accordingly at the
@@ -27,3 +31,11 @@ where `libcrypto.pc` or `openssl.pc` can be found.
 Otherwise, you can set `CFLAGS`/`LDFLAGS`:
 
 - `CFLAGS="-I$OPENSSL_DIR/include" LDFLAGS="-L$OPENSSL_DIR/lib64" meson setup builddir`
+
+### Installation
+
+The usual command to install is:
+
+- `meson install -C builddir`
+
+Or simply copy the `src/pkcs11.so` (or `src/pkcs11.dylib` on Mac) in the appropriate directory for your OpenSSL installation.

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,18 +1,6 @@
 ## How To use the PKCS#11 provider
 
-The PKCS#11 provider is an OpenSSL module used to access Hardware and Software
-Tokens. Access to tokens depends on loading an appropriate PKCS#11 driver that
-knows how to talk to the specific token. The PKCS#11 provider is a connector
-that allows OpenSSL to make proper use of such drivers.
-
-## Installation
-
-After building the module (see BUILD.md) install it via
-- make install
-Or simply copy the pkcs11-provide.so (.dylib on Mac) in the appropriate directory
-for your OpenSSL installation.
-
-## Configuration via openssl.cnf
+### Configuration via openssl.cnf
 
 Once you have installed the module you need to change OpenSSL's configuration to
 be able to load the provider and a pkcs#11 driver.
@@ -57,7 +45,7 @@ activate = 1
 
 See CONFIG(5OSSL) manpage for more information on the openssl.cnf file.
 
-## Driver specification via environment variable
+### Driver specification via environment variable
 
 In some cases it may be preferable to specify the pkcs11-driver module via an
 environment variable instead of via openssl.cnf file. This may be useful when
@@ -74,7 +62,7 @@ $ export PKCS11_PROVIDER_MODULE=/path/to/pkcs11-driver.so
 $ openssl pkey -in pkcs11:id=%01 -pubin -pubout -text
 ```
 
-## Specifying keys
+### Specifying keys
 
 When the pkcs11-provider is in use keys are specified using pkcs11 URIs as
 defined in RFC7512. In general keys are either identified by a binary ID, or by
@@ -88,3 +76,9 @@ pkcs11:object=my-rsa-key;type=public
 A pkcs11 URI can also specify a User PIN used to unlock the key, this can be
 used instead of storing the PIN in the openssl.cnf file or using interactive
 prompting.
+
+### Key generation
+
+On some tokens it is possible to create on the token using openssl
+with non-standard parameters. Nevertheless, we recommend using tools working
+with pkcs11 directly such as p11tool.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 [![Build](https://github.com/latchset/pkcs11-provider/actions/workflows/build.yml/badge.svg)](https://github.com/latchset/pkcs11-provider/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This is an Openssl 3.x provider to access Hardware or Software Tokens
-using the PKCS#11 Cryptographic Token Interface.
+# pkcs11-provider
 
-This code targets PKCS#11 version 3.1 but is backwards compatible to
-version 3.0 and 2.40 as well.
-
-Spec:
-https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
+This is an OpenSSL 3.x provider to access Hardware and Software Tokens using
+the PKCS#11 Cryptographic Token Interface. Access to tokens depends
+on loading an appropriate PKCS#11 driver that knows how to talk to the specific
+token. The PKCS#11 provider is a connector that allows OpenSSL to make proper
+use of such drivers. This code targets PKCS#11 version 3.1 but is backwards
+compatible to version 3.0 and 2.40 as well.
 
 To report Security Vulnerabilities, please use the "Report a Security
 Vulnerability" template in the issues reporting page.
+
+### Installation
+
+See [BUILD](BUILD.md) for more details about building and installing the provider.
+
+### Usage
+
+Configuration directives for the provider are documented in [provider-pkcs11(7)](docs/provider-pkcs11.7.md)
+man page. Example configurations and basic use cases can be found in [HOWTO](HOWTO.md).
+
+### Notes
+
+ * [PKCS #11 Specification Version 3.1](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html)


### PR DESCRIPTION
#### Description

Currently, there are multiple documentation files that are not connected in any way.  This PR adds a brief project description (previously split into two places), licence badge and links to all the other documentation files (BUILD.md and HOWTO.md).  Small re-formatting was also applied to BUILD.md and HOWTO.md without removing existing or adding any new content. 

I considered adding more examples to HOWTO about key management. But once you configure openssl to use the provider (covered in HOWTO.md) the rest is really more about other tools (e.g. p11-kit) than the provider. 

I also did not cover tests but we can do that later if needed.

Resolves #301.

#### Checklist

Not applicable 

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [ ] ~There is a test suite reasonably covering new functionality or modifications~
- [x] This feature/change has adequate documentation added
- [ ] ~Code conform to coding style that today cannot yet be enforced via the check style test~
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
