### PR TITLE
feat: RSA_PKCS1_WITH_TLS_PADDING padding developped in the provider

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -655,10 +655,11 @@ static int p11prov_ec_set_keypoint_data(const OSSL_PARAM *params, void *key)
 
 static X509_PUBKEY *p11prov_ec_pubkey_to_x509(P11PROV_OBJ *key)
 {
-    struct ecdsa_key_point keypoint = { 0 };
+    struct ecdsa_key_point keypoint;
     X509_PUBKEY *pubkey;
     int ret;
-
+    
+    memset (&keypoint, 0, sizeof (keypoint));
     ret = p11prov_obj_export_public_key(
         key, CKK_EC, true, p11prov_ec_set_keypoint_data, &keypoint);
     if (ret != RET_OSSL_OK) {

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -349,7 +349,11 @@ static int p11prov_hkdf_get_ctx_params(void *ctx, OSSL_PARAM *params)
     if (p) {
         size_t ret_size = 0;
         if (hkdfctx->params.bExpand != CK_FALSE) {
-            ret_size = SIZE_MAX;
+#ifndef SIZE_MAX
+           ret_size = 0xffffffff;
+#else
+           ret_size = SIZE_MAX;
+#endif
         } else {
             CK_RV rv;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -980,7 +980,7 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
     CK_OBJECT_CLASS class = p11prov_uri_get_class(uri);
     CK_ATTRIBUTE id = p11prov_uri_get_id(uri);
     CK_ATTRIBUTE label = p11prov_uri_get_label(uri);
-    CK_ATTRIBUTE template[3] = { 0 };
+    CK_ATTRIBUTE template[3];
     CK_OBJECT_HANDLE *objects = NULL;
     CK_ULONG tsize = 0;
     CK_ULONG objcount = 0;
@@ -991,7 +991,8 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
     P11PROV_debug("Find objects [class=%lu, id-len=%lu, label=%s]", class,
                   id.ulValueLen,
                   label.type == CKA_LABEL ? (char *)label.pValue : "None");
-
+    
+    memset (template, 0, sizeof (template));
     switch (class) {
     case CKO_CERTIFICATE:
     case CKO_PUBLIC_KEY:
@@ -1081,7 +1082,7 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
 static P11PROV_OBJ *find_associated_obj(P11PROV_CTX *provctx, P11PROV_OBJ *obj,
                                         CK_OBJECT_CLASS class)
 {
-    CK_ATTRIBUTE template[2] = { 0 };
+    CK_ATTRIBUTE template[2];
     CK_ATTRIBUTE *id;
     CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
     P11PROV_SESSION *session = NULL;
@@ -1092,7 +1093,8 @@ static P11PROV_OBJ *find_associated_obj(P11PROV_CTX *provctx, P11PROV_OBJ *obj,
     CK_RV ret, fret;
 
     P11PROV_debug("Find associated object");
-
+    
+    memset (template, 0, sizeof (template));
     id = p11prov_obj_get_attr(obj, CKA_ID);
     if (!id || id->ulValueLen == 0) {
         P11PROV_raise(provctx, CKR_GENERAL_ERROR, "No CKA_ID in source object");
@@ -1153,7 +1155,7 @@ static void p11prov_obj_refresh(P11PROV_OBJ *obj)
     CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
     P11PROV_SESSION *session = NULL;
     CK_SESSION_HANDLE sess = CK_INVALID_HANDLE;
-    CK_ATTRIBUTE template[3] = { 0 };
+    CK_ATTRIBUTE template[3];
     CK_ATTRIBUTE *attr;
     int anum;
     CK_OBJECT_HANDLE handle;
@@ -1183,7 +1185,8 @@ static void p11prov_obj_refresh(P11PROV_OBJ *obj)
     }
 
     sess = p11prov_session_handle(session);
-
+    
+    memset (template, 0, sizeof(template));
     anum = 0;
     CKATTR_ASSIGN(template[anum], CKA_CLASS, &(obj->class), sizeof(obj->class));
     anum++;
@@ -1416,7 +1419,7 @@ CK_RV p11prov_obj_set_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
 #define MAX_KEY_ATTRS 2
 static CK_RV get_all_from_cert(P11PROV_OBJ *crt, CK_ATTRIBUTE *attrs, int num)
 {
-    OSSL_PARAM params[MAX_KEY_ATTRS + 1] = { 0 };
+    OSSL_PARAM params[MAX_KEY_ATTRS + 1];
     CK_ATTRIBUTE_TYPE types[MAX_KEY_ATTRS];
     CK_ATTRIBUTE *type;
     CK_ATTRIBUTE *value;
@@ -1427,6 +1430,7 @@ static CK_RV get_all_from_cert(P11PROV_OBJ *crt, CK_ATTRIBUTE *attrs, int num)
     int ret;
     CK_RV rv;
 
+    memset (params, 0, sizeof (params));
     /* if CKA_CERTIFICATE_TYPE is not present assume CKC_X_509 */
     type = p11prov_obj_get_attr(crt, CKA_CERTIFICATE_TYPE);
     if (type) {
@@ -1663,11 +1667,12 @@ static CK_RV get_public_attrs(P11PROV_OBJ *obj, CK_ATTRIBUTE *attrs, int num)
 static int p11prov_obj_export_public_rsa_key(P11PROV_OBJ *obj,
                                              OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    CK_ATTRIBUTE attrs[RSA_PUB_ATTRS] = { 0 };
+    CK_ATTRIBUTE attrs[RSA_PUB_ATTRS];
     OSSL_PARAM params[RSA_PUB_ATTRS + 1];
     CK_RV rv;
     int ret;
 
+    memset (attrs, 0, sizeof (attrs));
     if (p11prov_obj_get_key_type(obj) != CKK_RSA) {
         return RET_OSSL_ERR;
     }
@@ -1856,8 +1861,8 @@ static int ec_group_explicit_to_params(P11PROV_OBJ *obj, const EC_GROUP *group,
 static int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj,
                                             OSSL_CALLBACK *cb_fn, void *cb_arg)
 {
-    CK_ATTRIBUTE attrs[EC_MAX_PUB_ATTRS] = { 0 };
-    OSSL_PARAM params[EC_MAX_OSSL_PARAMS + 1] = { 0 };
+    CK_ATTRIBUTE attrs[EC_MAX_PUB_ATTRS];
+    OSSL_PARAM params[EC_MAX_OSSL_PARAMS + 1];
     CK_KEY_TYPE key_type;
     int nattr = 0;
     int nparam = 0;
@@ -1866,6 +1871,8 @@ static int p11prov_obj_export_public_ec_key(P11PROV_OBJ *obj,
     EC_GROUP *group = NULL;
     int curve_nid = NID_undef;
 
+    memset (attrs, 0, sizeof (attrs));
+    memset (params, 0, sizeof (params));
     key_type = p11prov_obj_get_key_type(obj);
     switch (key_type) {
     case CKK_EC:

--- a/src/provider.c
+++ b/src/provider.c
@@ -626,7 +626,8 @@ bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx)
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx)
 {
     if (!ctx->module) {
-        CK_INFO info = { 0 };
+        CK_INFO info;
+        memset (&info, 0, sizeof(info));
         return info;
     }
     return p11prov_module_ck_info(ctx->module);
@@ -1358,6 +1359,16 @@ static struct p11prov_cfg_names {
     { "pkcs11-module-encode-provider-uri-to-pem" },
 };
 
+static void pkcs11prov_dbg_init (void)
+{
+    /* for debugging only
+     * Do nothing else than giving the possibility to set a breakpoint
+     * NOTE: don't compile with '-g -Og', use either '-g' or '-g -O0'
+     *       with -Og, the optimizer remove this call witch does nothing
+     */
+    return ;
+}
+
 int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out, void **provctx)
 {
@@ -1366,6 +1377,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
     P11PROV_CTX *ctx;
     int ret;
 
+    pkcs11prov_dbg_init ();
     *provctx = NULL;
 
     p11prov_get_core_dispatch_funcs(in);


### PR DESCRIPTION
Hi,  

I work in a company and for these 3 last months, we have worked on the embedding of the opensslv3 functions in our application.  
The aim of these implementation is to access to our HSM (Eviden) via opensslv3 functions in PKCS11 using your provider.  

Unfortunately, a test failed due to a function not implemented in your provider.  

# Missing function in the provider

When we connect an openssl s_client to an openssl s_server using these 2 commands :  
`./openssl s_server -port 4456 -provider pkcs11 -key "pkcs11:object=nom;id=1122334455-000000000000000000000000-98" -cert /int1/pki/store/user/crt/C2P_HSM_20261205.crt`  
and  
`./openssl s_client -connect 127.0.0.1:4456 -CApath /int1/pki/store/ac/crt_rehash -cipher AES128-GCM-SHA256`

We get the following error coming from Openssl libraries :

```c++
-----------------------------------------------------------------
Using default temp DH parameters
ACCEPT
ERROR
0011F0435A7F0000:error:1C8000A5:Provider routines:p11prov_rsaenc_set_ctx_params:illegal or unsupported padding mode:asymmetric_cipher.c:491:
0011F0435A7F0000:error:0A000093:SSL routines:tls_process_cke_rsa:decryption failed:ssl/statem/statem_srvr.c:2946:
CONNECTION CLOSED

In the openssl sources, this error comes from the function : 

openssl-3.0.11/ssl/statem/statem_srvr.c:tls_process_cke_rsa:2909
    if (EVP_PKEY_decrypt_init(ctx) <= 0
            || EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_WITH_TLS_PADDING) <= 0) {
        SLfatal(s, SSL_AD_DECRYPT_ERROR, SSL_R_DECRYPTION_FAILED);
        goto err;
    }
-----------------------------------------------------------------
```

After inverstigating on this issue, it appears that ciphers using RSA key exchange type involves to use the padding : RSA_PKCS1_WITH_TLS_PADDING, which is not supported by your provider.
hence this error raises by your provider :

```c++
-----------------------------------------------------------------
0011F0435A7F0000:error:1C8000A5:Provider routines:p11prov_rsaenc_set_ctx_params:illegal or unsupported padding mode:asymmetric_cipher.c:491:

if (mechtype == CK_UNAVAILABLE_INFORMATION) {
    P11PROV_debug("mechtype == CK_UNAVAILABLE_INFORMATION");
    ERR_raise(ERR_LIB_PROV, PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE);
    return RET_OSSL_ERR;
}
-----------------------------------------------------------------
```

Then, we have implemented this unsupported padding (mandatory for our needs) in order to continue using you provider.  

It's now 1 month our improved provider runs under our UAT environment without error anymore.  
Of course we would like to share you our implementation and to know if you could integrate it in your sources in a near futur ?  

Thanks,
Kind regards,