### PR TITLE
Fix session count types

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -26,10 +26,10 @@ struct p11prov_session_pool {
     P11PROV_CTX *provctx;
     CK_SLOT_ID slotid;
 
-    int num_sessions;
-    int max_sessions;
-    int open_sessions;
-    int max_cached_sessions;
+    CK_ULONG num_sessions;
+    CK_ULONG max_sessions;
+    CK_ULONG open_sessions;
+    CK_ULONG max_cached_sessions;
 
     P11PROV_SESSION **sessions;
 
@@ -274,7 +274,7 @@ static CK_RV session_new(P11PROV_SESSION_POOL *pool, P11PROV_SESSION **_session)
 
     if (pool->num_sessions >= pool->max_sessions) {
         ret = CKR_SESSION_COUNT;
-        P11PROV_raise(pool->provctx, ret, "Max sessions (%d) exceeded",
+        P11PROV_raise(pool->provctx, ret, "Max sessions (%lu) exceeded",
                       pool->max_sessions);
         return ret;
     }
@@ -304,7 +304,7 @@ static CK_RV session_new(P11PROV_SESSION_POOL *pool, P11PROV_SESSION **_session)
 
     pool->sessions[pool->num_sessions] = session;
     pool->num_sessions++;
-    P11PROV_debug("Total sessions: %d", pool->num_sessions);
+    P11PROV_debug("Total sessions: %lu", pool->num_sessions);
 
     *_session = session;
     return CKR_OK;


### PR DESCRIPTION
#### Description

Since commit f1e85afeb0fe ("Session locking fixes") the session count variables are int. This is wrong since max_sessions is initialized by the token ulMaxSessionCount member so it of type CK_ULONG. Interpreting it as int is wrong since all values >= BIT(31) are interpreted as negative value.

Fix this by converting all session counting vars back to CK_ULONG.

#### Reviewer's checklist:

- [x] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
