### PR TITLE
Fix types for old 32 bit systems

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -251,12 +251,12 @@ static int p11prov_rsaenc_decrypt_init(void *ctx, void *provkey,
 static int
 p11prov_tls_constant_time_depadding(struct p11prov_rsaenc_ctx *encctx,
                                     unsigned char *out, unsigned char *buf,
-                                    size_t *out_size, CK_ULONG *ret_cond)
+                                    CK_ULONG *out_size, CK_ULONG *ret_cond)
 {
     unsigned char randbuf[SSL_MAX_MASTER_KEY_LENGTH];
     CK_ULONG ver_cond = 0;
     CK_ULONG cond = 0;
-    size_t length = SSL_MAX_MASTER_KEY_LENGTH;
+    CK_ULONG length = SSL_MAX_MASTER_KEY_LENGTH;
     int err;
 
     /* always generate a random buffer, to constant_time swap in

--- a/src/util.h
+++ b/src/util.h
@@ -120,7 +120,7 @@ static inline int constant_select_int(CK_ULONG cond, int a, int b)
     return (int)((A & mask) | (B & ~mask));
 }
 
-static inline void constant_select_buf(CK_ULONG cond, size_t size,
+static inline void constant_select_buf(CK_ULONG cond, CK_ULONG size,
                                        unsigned char *dst, unsigned char *a,
                                        unsigned char *b)
 {


### PR DESCRIPTION
#### Description

On x86 CK_ULONG and size_t have different sizes, ensure we use compatible types on our helper functions.

#### Checklist

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
