### PR TITLE
Fix CID 500198: Integer handling issues

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1461,6 +1461,10 @@ static const char *p11prov_ec_query_operation_name(int operation_id)
     return NULL;
 }
 
+#define CURVE_521_BITS 521
+#define MAX_CURVE_BITS CURVE_521_BITS
+#define MAX_CURVE_SIZE ((MAX_CURVE_BITS + 7) / 8)
+
 static int p11prov_ec_secbits(int bits)
 {
     /* common values from various NIST documents */
@@ -1517,6 +1521,10 @@ static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
     if (p) {
         /* add room for ECDSA Signature DER overhead */
         CK_ULONG size = p11prov_obj_get_key_size(key);
+        if (size > MAX_CURVE_SIZE) {
+            /* coverity started looking for silly integer overflows */
+            return RET_OSSL_ERR;
+        }
         ret = OSSL_PARAM_set_int(p, 3 + (size + 4) * 2);
         if (ret != RET_OSSL_OK) {
             return ret;


### PR DESCRIPTION
#### Description
Coverity seem to have updated its rules and is now more concerned about integer overflows than before. This place has no change of overflowing, but lets play ball and silence it with a check.
CID 500198: Integer handling issues (INTEGER_OVERFLOW)

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- ~[ ] Test suite updated with functionality tests~
- ~[ ] Test suite updated with negative tests~
- ~[ ] Documentation updated~


#### Reviewer's checklist:

- ~[ ] Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- ~[ ] This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- ~[x] Commits have short titles and sensible commit messages~
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
