### PR TITLE
Use a single tool for setting up the token

### DIFF
--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -87,25 +87,16 @@ if [ -d "${TOKDIR}" ]; then
 fi
 mkdir "${TOKDIR}"
 
-# Kryoptic configuration
-export KRYOPTIC_CONF="$TMPPDIR/tokens/kryoptic.sql"
-
 title LINE "Creating Kyroptic database"
 
-export GNUTLS_SO_PIN=${PINVALUE}
-p11tool --provider="${P11LIB}" --initialize \
-    --label="Test" \
-    "pkcs11:manufacturer=Kryoptic%20Project" 2>&1
-unset GNUTLS_SO_PIN
-
-title LINE "Setting User PIN"
-# For some reason currently p11tool requires adding extraneous %00 termination
-# marks at the end of the manufacturer and token names when using the
-# --initialize-pin option
-export GNUTLS_PIN=${PINVALUE}
-p11tool --provider="${P11LIB}" --initialize-pin \
-    "pkcs11:manufacturer=Kryoptic%20Project%00;token=Test%00" 2>&1
-
+# Kryoptic configuration
+export KRYOPTIC_CONF="$TMPPDIR/tokens/kryoptic.sql"
+# init token
+pkcs11-tool --module "${P11LIB}" --init-token \
+    --label "Pkcs11 Provider Tests" --so-pin "${PINVALUE}" 2>&1
+# set user pin
+pkcs11-tool --module "${P11LIB}" --so-pin "${PINVALUE}" \
+    --login --login-type so --init-pin --pin "${PINVALUE}" 2>&1
 
 P11DEFARGS="--module=${P11LIB} --login --pin=${PINVALUE}"
 
@@ -119,6 +110,7 @@ email = "testcert@example.org"
 signing_key
 encryption_key
 HEREDOC
+export GNUTLS_PIN=$PINVALUE
 SERIAL=1
 
 


### PR DESCRIPTION
#### Description

pkcs11-tool is well capable of initializing a token, so just use it for everything and drop use of p11tool which is quirkier.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- ~[ ] Code modified for feature~
- [x] Test suite updated with functionality tests
- ~[ ] Test suite updated with negative tests~
- ~[ ] Documentation updated~


#### Reviewer's checklist:

- ~[ ] Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- ~[ ] This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- ~[ ] Coverity Scan has run if needed (code PR) and no new defects were found~
