### PR TITLE
Off-by-one error in pool consistency check

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -234,7 +234,7 @@ static void obj_rm_from_pool(P11PROV_OBJ *obj)
     }
 
     /* LOCKED SECTION ------------- */
-    if (obj->poolid > pool->size || pool->objects[obj->poolid] != obj) {
+    if (obj->poolid >= pool->size || pool->objects[obj->poolid] != obj) {
         ret = CKR_GENERAL_ERROR;
         P11PROV_raise(pool->provctx, ret, "Objects pool in inconsistent state");
         goto done;


### PR DESCRIPTION
I'm getting a segmentation fault on this line because pool->objects can be NULL. I suspect this > should be >=, though I'm not quite sure.

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
