### PR TITLE
Extend the ttls test to be able to test different configurations

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           meson compile -C builddir
           meson test --num-processes 1 -C builddir
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Address sanitizer logs on ${{ matrix.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           meson compile -C builddir
           meson test --num-processes 1 -C builddir
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Test logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
@@ -79,7 +79,7 @@ jobs:
             if [ "${{ matrix.compiler }}" = "gcc" ]; then
               meson test --num-processes 1 -C builddir --setup=valgrind
             fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Test valgrind logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
@@ -126,7 +126,7 @@ jobs:
 
           meson compile -j$(sysctl -n hw.ncpu || echo 2) -C builddir
           meson test --num-processes 1 -C builddir
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Test logs on macOS-12 with ${{ matrix.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Test logs on macOS-12 with ${{ matrix.token }}
+          name: Test logs on macOS-14 with ${{ matrix.token }}
           path: |
             builddir/meson-logs/*
             builddir/tests/*.log

--- a/.github/workflows/kryoptic.yml
+++ b/.github/workflows/kryoptic.yml
@@ -89,7 +89,7 @@ jobs:
           KRYOPTIC: ${{ steps.kryoptic_setup.outputs.KRYOPTIC }}
         run:
           meson test --num-processes 1 -C builddir
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Test logs kryoptic

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Scan Build
         run: |
           SCANBUILD=$PWD/.github/scan-build.sh ninja -C builddir scan-build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Scan Build logs

--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -109,6 +109,7 @@ expiration_days = 365
 email = "testcert@example.org"
 signing_key
 encryption_key
+cert_signing_key
 HEREDOC
 export GNUTLS_PIN=$PINVALUE
 SERIAL=1
@@ -135,6 +136,9 @@ pkcs11-tool ${P11DEFARGS} --write-object "${CACRT}.crt" --type=cert \
 
 # the organization identification is not in the CA
 echo 'organization = "PKCS11 Provider"' >> "${TMPPDIR}/cert.cfg"
+# the cert_signing_key and "ca" should be only on the CA
+sed -i -e "/cert_signing_key/d" "${TMPPDIR}/cert.cfg"
+
 
 ca_sign() {
     CRT=$1

--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -395,7 +395,6 @@ sed -e "s|@libtoollibs@|${LIBSPATH}|g" \
 title LINE "Export test variables to ${TMPPDIR}/testvars"
 cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
 export P11LIB=${P11LIB}
-export P11KITCLIENTPATH=${P11KITCLIENTPATH}
 export PKCS11_PROVIDER_MODULE=${P11LIB}
 export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug.log"
 export OPENSSL_CONF="${OPENSSL_CONF}"

--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -392,7 +392,6 @@ sed -e "s|@libtoollibs@|${LIBSPATH}|g" \
     -e "s|@testsdir@|${TMPPDIR}|g" \
     -e "s|@SHARED_EXT@|${SHARED_EXT}|g" \
     -e "s|@PINFILE@|${PINFILE}|g" \
-    -e "s|##QUIRKS|pkcs11-module-quirks = no-deinit|g" \
     -e "/pkcs11-module-init-args/d" \
     "${TESTSSRCDIR}/openssl.cnf.in" > "${OPENSSL_CONF}"
 

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -39,11 +39,6 @@ else
 	sed_inplace=("-i" "")
 fi
 
-if [ "$P11KITCLIENTPATH" = "" ]; then
-    echo "Missing P11KITCLIENTPATH env variable"
-    exit 0
-fi
-
 find_softhsm() {
     for _lib in "$@" ; do
         if test -f "$_lib" ; then
@@ -392,7 +387,6 @@ sed -e "s|@libtoollibs@|${LIBSPATH}|g" \
 title LINE "Export test variables to ${TMPPDIR}/testvars"
 cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
 export P11LIB=${P11LIB}
-export P11KITCLIENTPATH=${P11KITCLIENTPATH}
 export PKCS11_PROVIDER_MODULE=${P11LIB}
 export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug.log"
 export OPENSSL_CONF="${OPENSSL_CONF}"

--- a/tests/setup-softhsm.sh
+++ b/tests/setup-softhsm.sh
@@ -116,6 +116,7 @@ expiration_days = 365
 email = "testcert@example.org"
 signing_key
 encryption_key
+cert_signing_key
 HEREDOC
 export GNUTLS_PIN=$PINVALUE
 SERIAL=1
@@ -140,6 +141,8 @@ pkcs11-tool --write-object "${CACRT}.crt" --type=cert --id=$KEYID \
 
 # the organization identification is not in the CA
 echo 'organization = "PKCS11 Provider"' >> "${TMPPDIR}/cert.cfg"
+# the cert_signing_key and "ca" should be only on the CA
+sed -e "/^cert_signing_key$/d" -e "/^ca$/d" "${sed_inplace[@]}" "${TMPPDIR}/cert.cfg"
 
 ca_sign() {
     CRT=$1

--- a/tests/setup-softokn.sh
+++ b/tests/setup-softokn.sh
@@ -42,7 +42,8 @@ certutil -N -d "${TOKDIR}" -f "${PINFILE}"
 
 title LINE "Creating new Self Sign CA"
 ((SERIAL+=1))
-certutil -S -s "CN=Issuer" -n selfCA -x -t "C,C,C" \
+CACRTN="selfCA"
+certutil -S -s "CN=Issuer" -n "${CACRTN}" -x -t "C,C,C" \
     -m "${SERIAL}" -1 -2 -5 --keyUsage certSigning,crlSigning \
     --nsCertType sslCA,smimeCA,objectSigningCA \
     -f "${PINFILE}" -d "${TOKDIR}" -z "${SEEDFILE}" >/dev/null 2>&1 <<CERTSCRIPT
@@ -50,6 +51,10 @@ y
 
 n
 CERTSCRIPT
+
+CACRT="${TMPPDIR}/CAcert.crt"
+title LINE "Read CA cert of of the token"
+certutil -L -a -n "${CACRTN}" -d "${TOKDIR}" -o "$CACRT"
 
 # RSA
 TSTCRT="${TMPPDIR}/testcert"
@@ -180,6 +185,8 @@ export TMPPDIR="${TMPPDIR}"
 export PINVALUE="${PINVALUE}"
 export SEEDFILE="${TMPPDIR}/noisefile.bin"
 export RAND64FILE="${TMPPDIR}/64krandom.bin"
+
+export CACRT="${CACRT}"
 
 export BASEURIWITHPINVALUE="${BASEURIWITHPINVALUE}"
 export BASEURIWITHPINSOURCE="${BASEURIWITHPINSOURCE}"

--- a/tests/softhsm-proxy.sh
+++ b/tests/softhsm-proxy.sh
@@ -9,6 +9,11 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
     export XDG_RUNTIME_DIR=$PWD
 fi
 
+if [ "$P11KITCLIENTPATH" = "" ]; then
+    echo "Missing P11KITCLIENTPATH env variable"
+    exit 0
+fi
+
 title PARA "Start the p11-kit server and check if it works"
 # shellcheck disable=SC2046 # we want to split these for eval
 eval $(p11-kit server --provider "$P11LIB" "pkcs11:")

--- a/tests/ttls
+++ b/tests/ttls
@@ -25,38 +25,64 @@ trap 'wait_for_server_at_exit $SERVER_PID;' EXIT
 
 PORT=23456
 
-expect -c "spawn $CHECKER openssl s_server -accept \"${PORT}\" -naccept 1 -key \"${PRIURI}\" -cert \"${CRTURI}\";
-    set timeout 60;
-    expect {
-        \"ACCEPT\" {};
-        default {exit 1;};
-    }
-    set server_ready [open \"${TMPPDIR}/s_server_ready\" w+];
-    puts \$server_ready \"READY\n\";
-    close \$server_ready;
-    expect {
-        \"END SSL SESSION PARAMETERS\" {};
-        default {exit 1;};
-    }
-    send \" TLS SUCCESSFUL \n\"
-    send \"Q\n\"
-    expect {
-        eof {exit 0;};
-        default {exit 1;};
-    }" > "${TMPPDIR}/s_server_output" &
-SERVER_PID=$!
+run_test() {
+    KEY="$1"
+    CERT="$2"
+    SRV_ARGS=$3
+    CLNT_ARGS=$4
+    expect -c "spawn $CHECKER openssl s_server -accept \"${PORT}\" -naccept 1 -key \"${KEY}\" -cert \"${CERT}\" $SRV_ARGS;
+        set timeout 60;
+        expect {
+            \"ACCEPT\" {};
+            default {exit 1;};
+        }
+        set server_ready [open \"${TMPPDIR}/s_server_ready\" w+];
+        puts \$server_ready \"READY\n\";
+        close \$server_ready;
+        expect {
+            \"END SSL SESSION PARAMETERS\" {};
+            default {exit 1;};
+        }
+        send \" TLS SUCCESSFUL \n\"
+        send \"Q\n\"
+        expect {
+            eof {exit 0;};
+            default {exit 1;};
+        }" > "${TMPPDIR}/s_server_output" &
+    SERVER_PID=$!
 
-read -r < "${TMPPDIR}/s_server_ready"
+    read -r < "${TMPPDIR}/s_server_ready"
 
-expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\";
-    set timeout 60;
-    expect {
-        \" TLS SUCCESSFUL \" {};
-        default {exit 1;};
-    }
-    expect {
-        eof {exit 0;};
-        default {exit 1;};
-    }"
+    expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\" $CLNT_ARGS;
+        set timeout 60;
+        expect {
+            \" TLS SUCCESSFUL \" {};
+            default {exit 1;};
+        }
+        expect {
+            eof {exit 0;};
+            default {exit 1;};
+        }"
+
+    wait_for_server_at_exit $SERVER_PID
+}
+
+title PARA "Run sanity test with default values (RSA)"
+run_test "$PRIURI" "$CRTURI"
+
+title PARA "Run sanity test with default values (ECDSA)"
+run_test "$ECPRIURI" "$ECCRTURI"
+
+title PARA "Run test with TLS 1.2"
+run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
+
+title PARA "Run test with explicit TLS 1.3"
+run_test "$PRIURI" "$CRTURI" "" "-tls1_3"
+
+title PARA "Run test with TLS 1.2 (ECDSA)"
+run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2"
+
+title PARA "Run test with TLS 1.2 and ECDH"
+run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
 
 exit 0;

--- a/tests/ttls
+++ b/tests/ttls
@@ -53,7 +53,7 @@ run_test() {
 
     read -r < "${TMPPDIR}/s_server_ready"
 
-    expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\" $CLNT_ARGS;
+    expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
         set timeout 60;
         expect {
             \" TLS SUCCESSFUL \" {};


### PR DESCRIPTION
#### Description

The TLS tests now tests just the default parameters with RSA key. This PR extends it to test also TLS 1.2, ECDSA keys and specific ciphersuites.

#### Checklist

- [X] Test suite updated with functionality tests

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
