### PR TITLE
Return OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1590,6 +1590,27 @@ static int p11prov_ec_get_params(void *keydata, OSSL_PARAM params[])
             p->data_size = pub_y->ulValueLen;
         }
     }
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
+    if (p) {
+        CK_ATTRIBUTE *pub_key;
+
+        if (p->data_type != OSSL_PARAM_OCTET_STRING) {
+            return RET_OSSL_ERR;
+        }
+
+        pub_key = p11prov_obj_get_ec_public_raw(key);
+        if (!pub_key) {
+            return RET_OSSL_ERR;
+        }
+
+        p->return_size = pub_key->ulValueLen;
+        if (p->data) {
+            if (p->data_size < pub_key->ulValueLen) {
+                return RET_OSSL_ERR;
+            }
+            memcpy(p->data, pub_key->pValue, pub_key->ulValueLen);
+        }
+    }
 
     return RET_OSSL_OK;
 }
@@ -1604,8 +1625,8 @@ static const OSSL_PARAM *p11prov_ec_gettable_params(void *provctx)
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_DEFAULT_DIGEST, NULL, 0),
         OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_X, NULL, 0),
         OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_Y, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
         /*
-         * OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY
          * OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAM
          * OSSL_PKEY_PARAM_EC_ENCODING
          * OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT

--- a/src/objects.c
+++ b/src/objects.c
@@ -2180,17 +2180,17 @@ CK_ATTRIBUTE *p11prov_obj_get_ec_public_raw(P11PROV_OBJ *key)
     CK_ATTRIBUTE *pub_key;
 
     if (!key) {
-        return RET_OSSL_ERR;
+        return NULL;
     }
 
     if (key->data.key.type != CKK_EC) {
         P11PROV_raise(key->ctx, CKR_GENERAL_ERROR, "Unsupported key type");
-        return RET_OSSL_ERR;
+        return NULL;
     }
 
     if (key->class != CKO_PRIVATE_KEY && key->class != CKO_PUBLIC_KEY) {
         P11PROV_raise(key->ctx, CKR_GENERAL_ERROR, "Invalid Object Class");
-        return RET_OSSL_ERR;
+        return NULL;
     }
 
     pub_key = p11prov_obj_get_attr(key, CKA_P11PROV_PUB_KEY);


### PR DESCRIPTION
We already have the value and a function to compute it from EC_POINT if needed, just return it when requested. It is sometimes used by openssl to get the public point for ECDH.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
