### PR TITLE
Add CKA_DERIVE flag in server's private key template

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1289,6 +1289,7 @@ static void *p11prov_ec_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
 #define EC_PRIVKEY_TMPL_SIZE 5
     CK_ATTRIBUTE privkey_template[EC_PRIVKEY_TMPL_SIZE + COMMON_TMPL_SIZE] = {
         { CKA_TOKEN, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
+        { CKA_DERIVE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_PRIVATE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_SENSITIVE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_SIGN, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },


### PR DESCRIPTION

#### Description

 This commit adds CKA_DERIVE flag in server's private key template which gets checked by optee subsystem to derive shared secret. Tested TLS1.2 with the change.
Without this flag enabled, tls connection fails while deriving shared secret.
This change is in common code, please let me know where I can change instead of changing common code. 


<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature



#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
