### PR TITLE
tests: Fix ASAN build on macOS

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -76,7 +76,7 @@ if get_option('b_sanitize') == 'address'
   endif
 
   # Avoids closing dlopened libraries for ASan to be able to print usable traces
-  fake_dlclose = shared_module(
+  fake_dlclose = shared_library(
     'fake_dlclose',
     'fake_dlclose.c',
     name_prefix: '',
@@ -85,12 +85,18 @@ if get_option('b_sanitize') == 'address'
   test_env.set('ASAN_OPTIONS', 'fast_unwind_on_malloc=0')
   test_env.set('LSAN_OPTIONS', 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()))
   test_env.set('FAKE_DLCLOSE', fake_dlclose.full_path())
+
+  preload_env_var = 'LD_PRELOAD'
+  if host_machine.system() == 'darwin'
+    preload_env_var = 'DYLD_INSERT_LIBRARIES'
+  endif
+
   # LD_PRELOAD is needed before invoking openssl as it is not instrumented with
   # asan and asan needs to be loaded as a first dynamic library of the process.
   if preload_libasan != 'no'
-    test_env.set('CHECKER', 'env LD_PRELOAD=@0@:@1@'.format(preload_libasan, fake_dlclose.full_path()))
+    test_env.set('CHECKER', 'env @0@=@1@:@2@'.format(preload_env_var, preload_libasan, fake_dlclose.full_path()))
   else
-    test_env.set('CHECKER', 'env LD_PRELOAD=@0@'.format(fake_dlclose.full_path()))
+    test_env.set('CHECKER', 'env @0@=@1@'.format(preload_env_var, fake_dlclose.full_path()))
   endif
 endif
 


### PR DESCRIPTION
#### Description
On macOS, the variable for library preloading is DYLD_INSERT_LIBRARIES, not LD_PRELOAD. Adjust the CHECKER env variable to use that on macOS machines.

Change fake_dlclose to a library rather than a shared module. This doesn't make a difference on Linux, but on macOS, dyld(1) refuses to insert a shared module into a processes address space using DYLD_INSERT_LIBRARIES, but allows a library in the same place.

#### Checklist

- [x] Code modified for feature
- [ ] ~~Test suite updated with functionality tests~~
- [ ] ~~Test suite updated with negative tests~~
- [ ] ~~Documentation updated~~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
