### PR TITLE
tests: Run TLS tests also when forcing all server operations on token

### DIFF
--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -28,6 +28,7 @@ pkcs11-module-token-pin = file:@PINFILE@
 #pkcs11-module-allow-export
 #pkcs11-module-load-behavior
 #pkcs11-module-block-operations
+#pkcs11-module-cache-keys
 ##QUIRKS
 activate = 1
 

--- a/tests/ttls
+++ b/tests/ttls
@@ -48,11 +48,13 @@ run_test() {
         expect {
             eof {exit 0;};
             default {exit 1;};
-        }" > "${TMPPDIR}/s_server_output" &
+        }" 2>&1 | tee "${TMPPDIR}/s_server_output" &
     SERVER_PID=$!
 
     read -r < "${TMPPDIR}/s_server_ready"
 
+    # The point is to force the server to use the pkcs11-provider for all operations, not the client now
+    OPENSSL_CONF="${ORIG_OPENSSL_CONF}" \
     expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
         set timeout 60;
         expect {
@@ -67,22 +69,47 @@ run_test() {
     wait_for_server_at_exit $SERVER_PID
 }
 
-title PARA "Run sanity test with default values (RSA)"
-run_test "$PRIURI" "$CRTURI"
+run_tests() {
 
-title PARA "Run sanity test with default values (ECDSA)"
-run_test "$ECPRIURI" "$ECCRTURI"
+    title PARA "Run sanity test with default values (RSA)"
+    run_test "$PRIURI" "$CRTURI"
 
-title PARA "Run test with TLS 1.2"
-run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
+    title PARA "Run sanity test with default values (ECDSA)"
+    run_test "$ECPRIURI" "$ECCRTURI"
 
-title PARA "Run test with explicit TLS 1.3"
-run_test "$PRIURI" "$CRTURI" "" "-tls1_3"
+    title PARA "Run test with TLS 1.2"
+    run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
 
-title PARA "Run test with TLS 1.2 (ECDSA)"
-run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2"
+    title PARA "Run test with explicit TLS 1.3"
+    run_test "$PRIURI" "$CRTURI" "" "-tls1_3"
 
-title PARA "Run test with TLS 1.2 and ECDH"
-run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
+    title PARA "Run test with TLS 1.2 (ECDSA)"
+    run_test "$ECPRIURI" "$ECCRTURI" "-tls1_2" "-tls1_2"
+
+    title PARA "Run test with TLS 1.2 and ECDH"
+    run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
+}
+
+title SECTION "TLS with key in provider"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+run_tests
+title ENDSECTION
+
+title SECTION "Forcing the provider for all server operations"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed \
+    -e "s/^#pkcs11-module-cache-keys.*$/pkcs11-module-cache-keys = false/" \
+    -e "s/^#pkcs11-module-block-operations.*$/pkcs11-module-block-operations = digest/" \
+    -e "s/pkcs11-module-quirks = /pkcs11-module-quirks = no-operation-state /" \
+    -e "s/^##QUIRKS$/pkcs11-module-quirks = no-operation-state/" \
+    -e "s/#MORECONF/alg_section = algorithm_sect/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.force"
+echo "[algorithm_sect]" >> "${OPENSSL_CONF}.force"
+echo "default_properties = ?provider=pkcs11" >> "${OPENSSL_CONF}.force"
+OPENSSL_CONF=${OPENSSL_CONF}.force
+
+run_tests
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+title ENDSECTION
 
 exit 0;


### PR DESCRIPTION
#### Description

This is likely the missing bit we had when trying to reproduce the issue #395. These are changes forcing all the TLS operations on token for the s_server. The s_client fails the basic key verification, because it is likely not correctly imported to the provider (?).

With this configuration the TLS 1.3 with RSA and ECDSA host certs work ok, TLS 1.2 with RSA too, but TLS 1.2 with ECDSA fails with 
```
00EE1FD59A7F0000:error:0A0000C1:SSL routines:tls_post_process_client_hello:no shared cipher:ssl/statem/statem_srvr.c:2220:^M
```
I was not able to figure out what OpenSSL needs at this point. I did not see any failures on the pkcs11 nor on the pkcs11 provider layer.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [X] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
