### PR TITLE
Enable Ed25519 tests (and other forgotten ones) for kryoptic

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -125,13 +125,13 @@ tests = {
   'pubkey': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'certs': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'ecc': {'suites': ['softokn', 'softhsm', 'kryoptic']},
-  'edwards': {'suites': ['softhsm']},
+  'edwards': {'suites': ['softhsm', 'kryoptic']},
   'ecdh': {'suites': ['softokn', 'kryoptic']},
   'democa': {'suites': ['softokn', 'softhsm', 'kryoptic'], 'is_parallel': false},
   'digest': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'fork': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'oaepsha2': {'suites': ['softokn', 'kryoptic']},
-  'hkdf': {'suites': ['softokn']},
+  'hkdf': {'suites': ['softokn', 'kryoptic']},
   'rsapss': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'rsapssam': {'suites': ['softhsm']},
   'genkey': {'suites': ['softokn', 'softhsm', 'kryoptic']},
@@ -141,7 +141,7 @@ tests = {
   'tls': {'suites': ['softokn', 'softhsm', 'kryoptic'], 'is_parallel': false},
   'uri': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'ecxc': {'suites': ['softhsm', 'kryoptic']},
-  'cms': {'suites': ['softokn']},
+  'cms': {'suites': ['softokn', 'kryoptic']},
 }
 
 test_wrapper = find_program('test-wrapper')

--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -243,32 +243,31 @@ echo "${ECPEERPRIURI}"
 echo "${ECPEERCRTURI}"
 echo ""
 
-# TODO: not supported yet by Kryoptic
-## generate ED25519
-#KEYID='0004'
-#URIKEYID="%00%04"
-#EDCRT="${TMPPDIR}/edcert"
-#EDCRTN="edCert"
-#
-## shellcheck disable=SC2086
-#pkcs11-tool ${P11DEFARGS} --keypairgen --key-type="EC:edwards25519" \
-#	--label="${EDCRTN}" --id="$KEYID"
-#ca_sign "$EDCRT" $EDCRTN "My ED25519 Cert" $KEYID
-#
-#EDBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
-#EDBASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
-#EDBASEURI="pkcs11:id=${URIKEYID}"
-#EDPUBURI="pkcs11:type=public;id=${URIKEYID}"
-#EDPRIURI="pkcs11:type=private;id=${URIKEYID}"
-#EDCRTURI="pkcs11:type=cert;object=${EDCRTN}"
-#
-#title LINE "ED25519 PKCS11 URIS"
-#echo "${EDBASEURIWITHPINVALUE}"
-#echo "${EDBASEURIWITHPINSOURCE}"
-#echo "${EDBASEURI}"
-#echo "${EDPUBURI}"
-#echo "${EDPRIURI}"
-#echo "${EDCRTURI}"
+# generate ED25519
+KEYID='0004'
+URIKEYID="%00%04"
+EDCRT="${TMPPDIR}/edcert"
+EDCRTN="edCert"
+
+# shellcheck disable=SC2086
+pkcs11-tool ${P11DEFARGS} --keypairgen --key-type="EC:edwards25519" \
+	--label="${EDCRTN}" --id="$KEYID"
+ca_sign "$EDCRT" $EDCRTN "My ED25519 Cert" $KEYID
+
+EDBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
+EDBASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
+EDBASEURI="pkcs11:id=${URIKEYID}"
+EDPUBURI="pkcs11:type=public;id=${URIKEYID}"
+EDPRIURI="pkcs11:type=private;id=${URIKEYID}"
+EDCRTURI="pkcs11:type=cert;object=${EDCRTN}"
+
+title LINE "ED25519 PKCS11 URIS"
+echo "${EDBASEURIWITHPINVALUE}"
+echo "${EDBASEURIWITHPINSOURCE}"
+echo "${EDBASEURI}"
+echo "${EDPUBURI}"
+echo "${EDPRIURI}"
+echo "${EDCRTURI}"
 
 
 title PARA "generate RSA key pair, self-signed certificate, remove public key"
@@ -353,33 +352,32 @@ else
     echo ""
 fi
 
-# TODO: ALWAYS_AUTHENTICATE behavior not supported yet
-#title PARA "generate EC key pair with ALWAYS AUTHENTICATE flag, self-signed certificate"
-#KEYID='0008'
-#URIKEYID="%00%08"
-#TSTCRT="${TMPPDIR}/eccert3"
-#TSTCRTN="ecCert3"
-#
-## shellcheck disable=SC2086
-#pkcs11-tool ${P11DEFARGS} --keypairgen --key-type="EC:secp521r1" \
-#	--label="${TSTCRTN}" --id="$KEYID" --always-auth
-#ca_sign "$TSTCRT" $TSTCRTN "My EC Cert 3" $KEYID
-#
-#ECBASE3URIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
-#ECBASE3URIWITHPINSOURCE="pkcs11:id=${URIKEYID}?pin-source=file:${PINFILE}"
-#ECBASE3URI="pkcs11:id=${URIKEYID}"
-#ECPUB3URI="pkcs11:type=public;id=${URIKEYID}"
-#ECPRI3URI="pkcs11:type=private;id=${URIKEYID}"
-#ECCRT3URI="pkcs11:type=cert;object=${TSTCRTN}"
-#
-#title LINE "EC3 PKCS11 URIS"
-#echo "${ECBASE3URIWITHPINVALUE}"
-#echo "${ECBASE3URIWITHPINSOURCE}"
-#echo "${ECBASE3URI}"
-#echo "${ECPUB3URI}"
-#echo "${ECPRI3URI}"
-#echo "${ECCRT3URI}"
-#echo ""
+title PARA "generate EC key pair with ALWAYS AUTHENTICATE flag, self-signed certificate"
+KEYID='0008'
+URIKEYID="%00%08"
+TSTCRT="${TMPPDIR}/eccert3"
+TSTCRTN="ecCert3"
+
+# shellcheck disable=SC2086
+pkcs11-tool ${P11DEFARGS} --keypairgen --key-type="EC:secp521r1" \
+	--label="${TSTCRTN}" --id="$KEYID" --always-auth
+ca_sign "$TSTCRT" $TSTCRTN "My EC Cert 3" $KEYID
+
+ECBASE3URIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
+ECBASE3URIWITHPINSOURCE="pkcs11:id=${URIKEYID}?pin-source=file:${PINFILE}"
+ECBASE3URI="pkcs11:id=${URIKEYID}"
+ECPUB3URI="pkcs11:type=public;id=${URIKEYID}"
+ECPRI3URI="pkcs11:type=private;id=${URIKEYID}"
+ECCRT3URI="pkcs11:type=cert;object=${TSTCRTN}"
+
+title LINE "EC3 PKCS11 URIS"
+echo "${ECBASE3URIWITHPINVALUE}"
+echo "${ECBASE3URIWITHPINSOURCE}"
+echo "${ECBASE3URI}"
+echo "${ECPUB3URI}"
+echo "${ECPRI3URI}"
+echo "${ECCRT3URI}"
+echo ""
 
 title PARA "Show contents of kryoptic token"
 echo " ----------------------------------------------------------------------------------------------------"
@@ -439,6 +437,13 @@ export ECPEERPUBURI="${ECPEERPUBURI}"
 export ECPEERPRIURI="${ECPEERPRIURI}"
 export ECPEERCRTURI="${ECPEERCRTURI}"
 
+export EDBASEURIWITHPINVALUE="${EDBASEURIWITHPINVALUE}"
+export EDBASEURIWITHPINSOURCE="${EDBASEURIWITHPINSOURCE}"
+export EDBASEURI="${EDBASEURI}"
+export EDPUBURI="${EDPUBURI}"
+export EDPRIURI="${EDPRIURI}"
+export EDCRTURI="${EDCRTURI}"
+
 export BASE2URIWITHPINVALUE="${BASEURIWITHPINVALUE}"
 export BASE2URIWITHPINSOURCE="${BASEURIWITHPINSOURCE}"
 export BASE2URI="${BASE2URI}"
@@ -450,6 +455,13 @@ export ECBASE2URIWITHPINSOURCE="${ECBASE2URIWITHPINSOURCE}"
 export ECBASE2URI="${ECBASE2URI}"
 export ECPRI2URI="${ECPRI2URI}"
 export ECCRT2URI="${ECCRT2URI}"
+
+export ECBASE3URIWITHPINVALUE="${ECBASE3URIWITHPINVALUE}"
+export ECBASE3URIWITHPINSOURCE="${ECBASE3URIWITHPINSOURCE}"
+export ECBASE3URI="${ECBASE3URI}"
+export ECPUB3URI="${ECPUB3URI}"
+export ECPRI3URI="${ECPRI3URI}"
+export ECCRT3URI="${ECCRT3URI}"
 DBGSCRIPT
 
 if [ -n "${ECXBASEURI}" ]; then

--- a/tests/trsapssam
+++ b/tests/trsapssam
@@ -55,6 +55,7 @@ FAIL=0
 echo "$output" | grep "mechanism not allowed with this key" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -ne 0 ]; then
     echo "Signature seem to have failed for unrelated reasons"
+    echo "$output";
     exit 1
 fi
 
@@ -82,5 +83,6 @@ FAIL=0
 echo "$output" | grep "An invalid mechanism was specified to the cryptographic operation" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -ne 0 ]; then
     echo "Signature seem to have failed for unrelated reasons"
+    echo "$output";
     exit 1
 fi


### PR DESCRIPTION
#### Description

This enabled ed25519 tests with kryoptic (and few more forgotten tests).

This depends on latchset/kryoptic#80. Tested locally with this branch.

#### Checklist

- [ ] ~Code modified for feature~
- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
