### PR TITLE
Add basic Ed448 tests

### DIFF
--- a/tests/setup-kryoptic.sh
+++ b/tests/setup-kryoptic.sh
@@ -269,6 +269,35 @@ echo "${EDPUBURI}"
 echo "${EDPRIURI}"
 echo "${EDCRTURI}"
 
+# FIXME The pkcs11-tool before OpenSC 0.26 does not support Ed448 so they can
+# not be generated here
+#
+# generate ED448
+#KEYID='0009'
+#URIKEYID="%00%09"
+#ED2CRT="${TMPPDIR}/ed2cert"
+#ED2CRTN="ed2Cert"
+#
+# shellcheck disable=SC2086
+# pkcs11-tool ${P11DEFARGS} --keypairgen --key-type="EC:edwards448" \
+# 	--label="${ED2CRTN}" --id="$KEYID"
+# ca_sign "$EDCRT" $ED2CRTN "My ED448 Cert" $KEYID
+#
+# ED2BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
+# ED2BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
+# ED2BASEURI="pkcs11:id=${URIKEYID}"
+# ED2PUBURI="pkcs11:type=public;id=${URIKEYID}"
+# ED2PRIURI="pkcs11:type=private;id=${URIKEYID}"
+# ED2CRTURI="pkcs11:type=cert;object=${ED2CRTN}"
+#
+# title LINE "ED448 PKCS11 URIS"
+# echo "${EDBASEURIWITHPINVALUE}"
+# echo "${EDBASEURIWITHPINSOURCE}"
+# echo "${EDBASEURI}"
+# echo "${EDPUBURI}"
+# echo "${EDPRIURI}"
+# echo "${EDCRTURI}"
+
 
 title PARA "generate RSA key pair, self-signed certificate, remove public key"
 KEYID='0005'

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -61,4 +61,64 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 
+# Test Ed448 too if supported
+if [[ -n $ED2BASEURI ]]; then
+    title PARA "Export ED448 Public key to a file"
+    ossl 'pkey -in $ED2PUBURI -pubin -pubout -out ${TMPPDIR}/ed2out.pub'
+    
+    title LINE "Print ED448 Public key from private"
+    ossl 'pkey -in $ED2PRIURI -pubout -text' $helper_emit
+    output="$helper_output"
+    FAIL=0
+    echo "$output" | grep "ED448 Public Key" > /dev/null 2>&1 || FAIL=1
+    if [ $FAIL -eq 1 ]; then
+        echo "Could not extract public key from private"
+        echo
+        echo "Original command output:"
+        echo "$output"
+        echo
+        exit 1
+    fi
+    
+    title PARA "DigestSign and DigestVerify with ED448"
+    ossl '
+    pkeyutl -sign -inkey "${ED2BASEURI}"
+                  -in ${RAND64FILE}
+                  -rawin
+                  -out ${TMPPDIR}/sha256-eddgstsig.bin'
+    ossl '
+    pkeyutl -verify -inkey "${ED2BASEURI}" -pubin
+                    -in ${RAND64FILE}
+                    -rawin
+                    -sigfile ${TMPPDIR}/sha256-eddgstsig.bin'
+    
+    title PARA "Test CSR generation from private ED448 keys"
+    ossl '
+    req -new -batch -key "${ED2PRIURI}" -out ${TMPPDIR}/ed448_csr.pem'
+    ossl '
+    req -in ${TMPPDIR}/ed448_csr.pem -verify -noout'
+    
+    title PARA "Test EVP_PKEY_eq on public Edwards key both on token"
+    $CHECKER "${TESTBLDDIR}/tcmpkeys" "$ED2PUBURI" "$ED2PUBURI"
+    
+    title PARA "Test EVP_PKEY_eq on public ED448 key via import"
+    $CHECKER "${TESTBLDDIR}/tcmpkeys" "$ED2PUBURI" "${TMPPDIR}"/ed2out.pub
+    title PARA "Match private ED key against public key"
+    $CHECKER "${TESTBLDDIR}/tcmpkeys" "$ED2PRIURI" "${TMPPDIR}"/ed2out.pub
+    title PARA "Match private ED key against public key (commutativity)"
+    $CHECKER "${TESTBLDDIR}/tcmpkeys" "${TMPPDIR}"/ed2out.pub "$ED2PRIURI"
+fi
+
+title PARA "Test Ed448 Key generation"
+output=$("${TESTBLDDIR}"/tgenkey "ED448" 2>&1 || true)
+FAIL=0
+echo "$output" | grep "Performed tests: 1" || FAIL=1
+if [ $FAIL -ne 0 ]; then
+    echo
+    echo "Original command output:"
+    echo "$output"
+    echo
+    exit 1
+fi
+
 exit 0

--- a/tests/tgenkey.c
+++ b/tests/tgenkey.c
@@ -154,7 +154,8 @@ static void check_keys(OSSL_STORE_CTX *store, const char *key_type)
         check_rsa_key(pubkey);
     } else if (strcmp(key_type, "EC") == 0) {
         check_ec_key(pubkey);
-    } else if (strcmp(key_type, "ED25519") == 0) {
+    } else if (strcmp(key_type, "ED25519") == 0
+               || strcmp(key_type, "ED448") == 0) {
         check_eddsa_key(pubkey);
     }
 
@@ -211,7 +212,8 @@ static void gen_keys(const char *key_type, const char *label, const char *idhex,
         check_rsa_key(key);
     } else if (strcmp(key_type, "EC") == 0) {
         check_ec_key(key);
-    } else if (strcmp(key_type, "ED25519") == 0) {
+    } else if (strcmp(key_type, "ED25519") == 0
+               || strcmp(key_type, "ED448") == 0) {
         check_eddsa_key(key);
     }
 
@@ -527,7 +529,8 @@ int main(int argc, char *argv[])
 
             free(label);
             free(uri);
-        } else if (strcmp(tests[num], "ED25519") == 0) {
+        } else if (strcmp(tests[num], "ED25519") == 0
+                   || strcmp(tests[num], "ED448") == 0) {
             ret = RAND_bytes(id, 16);
             if (ret != 1) {
                 fprintf(stderr, "Failed to generate key id\n");
@@ -548,7 +551,7 @@ int main(int argc, char *argv[])
             params[0] = OSSL_PARAM_construct_utf8_string("pkcs11_uri", uri, 0);
             params[1] = OSSL_PARAM_construct_end();
 
-            gen_keys("ED25519", label, idhex, params, false);
+            gen_keys(tests[num], label, idhex, params, false);
             free(label);
             free(uri);
         } else {


### PR DESCRIPTION
#### Description

The `pkcs11-tool` does not support generating these keys so we just test the internal key generation and processing with tgenkey.

#### Checklist

- [ ] ~Code modified for feature~
- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
