### PR TITLE
tests: No longer skip tests reading EC keys from cert

### DIFF
--- a/tests/tpubkey
+++ b/tests/tpubkey
@@ -58,11 +58,10 @@ if [ -n "$BASE2URI" ]; then
     title LINE "Export Public key to a file (base-uri)"
     ossl 'pkey -in $BASE2URI -pubout -out ${TMPPDIR}/base-cert.pub'
     diff "${TMPPDIR}/base-cert.pub" "${TMPPDIR}/priv-cert.pub"
+fi
 
-    # The MacOS keeps crashing in this step so lets skip the remaining tests
-    if [ "$(uname)" == "Darwin" ]; then
-        exit 0
-    fi
+if [ -n "$ECBASE2URI" ]; then
+    title PARA "Check we can get EC public keys from certificate objects"
 
     title LINE "Export Public EC key to a file (priv-uri)"
     ossl 'pkey -in $ECPRI2URI -pubout -out ${TMPPDIR}/ec-priv-cert.pub'


### PR DESCRIPTION
#### Description

This condition was introduced at the time when we were running the softhsm under p11-kit proxy, which caused some issues to mac.

We no longer do this so there is no need to skip this test either.

#### Checklist

- [ ] ~Code modified for feature~
- [X] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
