### PR TITLE
Allow fallback to pulling cert when checking private/public key consistency

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -104,6 +104,7 @@ test_programs = {
   'tsession': ['tsession.c'],
   'tgenkey': ['tgenkey.c'],
   'tlsctx': ['tlsctx.c', 'util.c'],
+  'tlssetkey': ['tlssetkey.c', 'util.c'],
   'tdigests': ['tdigests.c'],
   'treadkeys': ['treadkeys.c'],
   'tcmpkeys': ['tcmpkeys.c', 'util.c'],

--- a/tests/tlssetkey.c
+++ b/tests/tlssetkey.c
@@ -1,0 +1,53 @@
+/* Copyright (C) 2024 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <openssl/ssl.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/core_names.h>
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+    EVP_PKEY *pkey = NULL;
+    X509 *cert = NULL;
+    SSL_CTX *ctx;
+    int ret = 0;
+
+    if (argc != 3) {
+        fprintf(stderr, "Usage: tlssetkey [certuri] [pkeyuri]\n");
+        exit(EXIT_FAILURE);
+    }
+    cert = load_cert(argv[1]);
+    pkey = load_key(argv[2]);
+
+    ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) {
+        fprintf(stderr, "Failed to create SSL Context\n");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    ret = SSL_CTX_use_certificate(ctx, cert);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to set Certificate");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    ret = SSL_CTX_use_PrivateKey(ctx, pkey);
+    if (ret != 1) {
+        fprintf(stderr, "Failed to set Private Key");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    fprintf(stderr, "Cert and Key successfully set on TLS Context!\n");
+
+    SSL_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    X509_free(cert);
+    exit(EXIT_SUCCESS);
+}

--- a/tests/ttls
+++ b/tests/ttls
@@ -7,6 +7,14 @@ source "${TESTSSRCDIR}/helpers.sh"
 title PARA "Test SSL_CTX creation"
 $CHECKER "${TESTBLDDIR}/tlsctx"
 
+title PARA "Test setting cert/keys on TLS Context"
+$CHECKER "${TESTBLDDIR}/tlssetkey" "${ECCRTURI}" "${ECPRIURI}"
+
+if [ -n "$ECBASE2URI" ]; then
+    title PARA "Test setting cert/keys on TLS Context w/o pub key"
+    $CHECKER "${TESTBLDDIR}/tlssetkey" "${ECCRT2URI}" "${ECPRI2URI}"
+fi
+
 title PARA "Test an actual TLS connection"
 
 rm -f "${TMPPDIR}/s_server_output"

--- a/tests/util.h
+++ b/tests/util.h
@@ -3,3 +3,4 @@
 
 void ossl_err_print(void);
 EVP_PKEY *load_key(const char *uri);
+X509 *load_cert(const char *uri);


### PR DESCRIPTION
#### Description

This behavior is needed to pass some openssl consistency checks with tokens that store the public key only in a cert object.

Fixes #430 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- ~[ ] Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
