### PR TITLE
fix: p11prov_tls_constant_time_depadding bug corrected

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -271,7 +271,7 @@ p11prov_tls_constant_time_depadding(struct p11prov_rsaenc_ctx *encctx,
         return RET_OSSL_ERR;
     }
 
-    cond = constant_equal(*out_size, 2 + length);
+    cond = constant_equal(*out_size, length);
 
     ver_cond = constant_equal(buf[0], encctx->tls_padding.client_ver_major);
     ver_cond &= constant_equal(buf[1], encctx->tls_padding.client_ver_minor);
@@ -286,7 +286,7 @@ p11prov_tls_constant_time_depadding(struct p11prov_rsaenc_ctx *encctx,
     }
     cond &= ver_cond;
 
-    constant_select_buf(cond, length, out, buf + 2, randbuf);
+    constant_select_buf(cond, length, out, buf, randbuf);
 
     *out_size = length;
     *ret_cond = cond;


### PR DESCRIPTION
Hi, 

Today, the connection to EVIDEN’s HSM CRYPT2PAY using the Latchset provider fails when the openssl “-cipher” option (any TLS_RSA encryption) is requested (e.g. ./openssl s_client -connect 127.0.0.1:11036 -CApath /int1/pki/store/ac/crt_rehash -tls1_2 -cipher AES128-GCM-SHA256)
The problem is caused by the 'p11prov_tls_constant_time_depadding' function in the source file src/asymmetric_cipher. c, lines 274 and 289.

274: cond = constant_equal(*out_size, 2 + length);
...
289: constant_select_buf (conc, length, out, buf + 2, randbuf);

the '2' offset is a problem and corresponds to the first 2 bytes before padding removal (done by PKCS#11)
The best proof is lines 275 and 277 which compare 2 first bytes of input buffer with client version (major and minor)

Tests :

This corrected version has been tested in our testing environment and works correctly in all our use cases.
Could it be taken into account ?

Thanks