### PR TITLE
fix: p11prov_tls_constant_time_depadding bug corrected

### DIFF
--- a/src/asymmetric_cipher.c
+++ b/src/asymmetric_cipher.c
@@ -271,7 +271,7 @@ p11prov_tls_constant_time_depadding(struct p11prov_rsaenc_ctx *encctx,
         return RET_OSSL_ERR;
     }
 
-    cond = constant_equal(*out_size, 2 + length);
+    cond = constant_equal(*out_size, length);
 
     ver_cond = constant_equal(buf[0], encctx->tls_padding.client_ver_major);
     ver_cond &= constant_equal(buf[1], encctx->tls_padding.client_ver_minor);
@@ -286,7 +286,7 @@ p11prov_tls_constant_time_depadding(struct p11prov_rsaenc_ctx *encctx,
     }
     cond &= ver_cond;
 
-    constant_select_buf(cond, length, out, buf + 2, randbuf);
+    constant_select_buf(cond, length, out, buf, randbuf);
 
     *out_size = length;
     *ret_cond = cond;

--- a/tests/tlsctx.c
+++ b/tests/tlsctx.c
@@ -14,7 +14,7 @@ static void test_pkcs1_with_tls_padding(void)
     EVP_PKEY_CTX *ctx;
     EVP_PKEY *prikey;
     EVP_PKEY *pubkey;
-    unsigned char plain[SSL_MAX_MASTER_KEY_LENGTH + 2] = { 0x03, 0x03, 0x01 };
+    unsigned char plain[SSL_MAX_MASTER_KEY_LENGTH] = { 0x03, 0x03, 0x01 };
     unsigned char enc[1024];
     unsigned char dec[1024];
     size_t enclen;
@@ -97,8 +97,7 @@ static void test_pkcs1_with_tls_padding(void)
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(prikey);
 
-    if ((declen != sizeof(plain) - 2)
-        || (memcmp(plain + 2, dec, declen) != 0)) {
+    if ((declen != sizeof(plain)) || (memcmp(plain, dec, declen) != 0)) {
         fprintf(stderr, "Fail, decrypted master secret differs from input\n");
         ossl_err_print();
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Hi,

Sorry to have closed the previous pull request in which was the explanation of the issue :
https://github.com/latchset/pkcs11-provider/pull/438

So, I've created a new one PR in which I have modified and validated tests (specially the test "pkcs11-provider:softokn/tls" who failed in the previous PR : "49/58 pkcs11-provider:softokn / tls               OK              1.20s."

I also based my modifications on the latest commit on main branch and DCO Signed Off the commit (amend in my case).

Hope everything is OK to merge this correction on the main branch.
Let me know if you need more information.

Thanks.
Sébastien ANDERT

[root@abd701c306ad pkcs11-provider_PKCS11_Crypt2Pay_Compliant]# meson test -C builddir
ninja: Entering directory `/github/pkcs11-provider_PKCS11_Crypt2Pay_Compliant/builddir'
[2/2] Linking target tests/tlsctx
 1/58 pkcs11-provider:softokn / setup             OK              3.05s
 2/58 pkcs11-provider:softhsm / setup             OK              0.01s
 3/58 pkcs11-provider:kryoptic / setup            OK              0.01s
 4/58 pkcs11-provider:softokn / basic             OK              5.23s
 5/58 pkcs11-provider:softhsm / basic             SKIP            0.00s   exit status 77
 6/58 pkcs11-provider:kryoptic / basic            SKIP            0.00s   exit status 77
 7/58 pkcs11-provider:softokn / pubkey            OK              0.41s
 8/58 pkcs11-provider:softhsm / pubkey            SKIP            0.00s   exit status 77
 9/58 pkcs11-provider:kryoptic / pubkey           SKIP            0.00s   exit status 77
10/58 pkcs11-provider:softokn / certs             OK              0.17s
11/58 pkcs11-provider:softhsm / certs             SKIP            0.00s   exit status 77
12/58 pkcs11-provider:kryoptic / certs            SKIP            0.00s   exit status 77
13/58 pkcs11-provider:softokn / ecc               OK              0.69s
14/58 pkcs11-provider:softhsm / ecc               SKIP            0.00s   exit status 77
15/58 pkcs11-provider:kryoptic / ecc              SKIP            0.00s   exit status 77
16/58 pkcs11-provider:softhsm / edwards           SKIP            0.00s   exit status 77
17/58 pkcs11-provider:kryoptic / edwards          SKIP            0.00s   exit status 77
18/58 pkcs11-provider:softokn / ecdh              OK              0.13s
19/58 pkcs11-provider:kryoptic / ecdh             SKIP            0.00s   exit status 77
20/58 pkcs11-provider:softokn / democa            OK              2.25s
21/58 pkcs11-provider:softhsm / democa            SKIP            0.00s   exit status 77
22/58 pkcs11-provider:kryoptic / democa           SKIP            0.00s   exit status 77
23/58 pkcs11-provider:softokn / digest            OK              0.05s
24/58 pkcs11-provider:softhsm / digest            SKIP            0.00s   exit status 77
25/58 pkcs11-provider:kryoptic / digest           SKIP            0.00s   exit status 77
26/58 pkcs11-provider:softokn / fork              OK              0.55s
27/58 pkcs11-provider:softhsm / fork              SKIP            0.00s   exit status 77
28/58 pkcs11-provider:kryoptic / fork             SKIP            0.00s   exit status 77
29/58 pkcs11-provider:softokn / oaepsha2          OK              0.22s
30/58 pkcs11-provider:kryoptic / oaepsha2         SKIP            0.00s   exit status 77
31/58 pkcs11-provider:softokn / hkdf              OK              0.06s
32/58 pkcs11-provider:kryoptic / hkdf             SKIP            0.00s   exit status 77
33/58 pkcs11-provider:softokn / rsapss            OK              0.27s
34/58 pkcs11-provider:softhsm / rsapss            SKIP            0.00s   exit status 77
35/58 pkcs11-provider:kryoptic / rsapss           SKIP            0.00s   exit status 77
36/58 pkcs11-provider:softhsm / rsapssam          SKIP            0.00s   exit status 77
37/58 pkcs11-provider:softokn / genkey            OK              0.01s
38/58 pkcs11-provider:softhsm / genkey            SKIP            0.00s   exit status 77
39/58 pkcs11-provider:kryoptic / genkey           SKIP            0.00s   exit status 77
40/58 pkcs11-provider:softokn / session           OK              0.28s
41/58 pkcs11-provider:softhsm / session           SKIP            0.00s   exit status 77
42/58 pkcs11-provider:kryoptic / session          SKIP            0.00s   exit status 77
43/58 pkcs11-provider:softokn / rand              OK              0.03s
44/58 pkcs11-provider:softhsm / rand              SKIP            0.00s   exit status 77
45/58 pkcs11-provider:kryoptic / rand             SKIP            0.01s   exit status 77
46/58 pkcs11-provider:softokn / readkeys          OK              0.04s
47/58 pkcs11-provider:softhsm / readkeys          SKIP            0.00s   exit status 77
48/58 pkcs11-provider:kryoptic / readkeys         SKIP            0.00s   exit status 77
49/58 pkcs11-provider:softokn / tls               OK              1.20s
50/58 pkcs11-provider:softhsm / tls               SKIP            0.00s   exit status 77
51/58 pkcs11-provider:kryoptic / tls              SKIP            0.00s   exit status 77
52/58 pkcs11-provider:softokn / uri               OK              2.64s
53/58 pkcs11-provider:softhsm / uri               SKIP            0.00s   exit status 77
54/58 pkcs11-provider:kryoptic / uri              SKIP            0.00s   exit status 77
55/58 pkcs11-provider:softhsm / ecxc              SKIP            0.00s   exit status 77
56/58 pkcs11-provider:kryoptic / ecxc             SKIP            0.00s   exit status 77
57/58 pkcs11-provider:softokn / cms               OK              0.09s
58/58 pkcs11-provider:kryoptic / cms              SKIP            0.00s   exit status 77

Ok:                 21  
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            37  
Timeout:            0 