### PR TITLE
Passing CK_P11PROV_IMPORTED_HANDLE while creating mock public key

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -3927,8 +3927,9 @@ P11PROV_OBJ *mock_pub_ec_key(P11PROV_CTX *ctx, CK_ATTRIBUTE_TYPE type,
     P11PROV_OBJ *key;
     CK_RV ret;
 
-    key = p11prov_obj_new(ctx, CK_UNAVAILABLE_INFORMATION, CK_INVALID_HANDLE,
-                          CK_UNAVAILABLE_INFORMATION);
+    key =
+        p11prov_obj_new(ctx, CK_UNAVAILABLE_INFORMATION,
+                        CK_P11PROV_IMPORTED_HANDLE, CK_UNAVAILABLE_INFORMATION);
     if (!key) {
         return NULL;
     }


### PR DESCRIPTION
This commit adds **CK_P11PROV_IMPORTED_HANDLE** argument while creating mock public key session object.

Before this patch, when we run TLS1.3 connection, below issue was reported by openssl:-
```
tls_parse_ctos_key_share:unable to find ecdh
parameters:ssl/statem/extensions_srvr.c:684
```

It is because of returning **CK_INVALID_HANDLE** instead of **obj->handle**.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature

#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [ ] ~There is a test suite reasonably covering new functionality or modifications~
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
