### PR TITLE
Integration test improvements (bind with kryoptic and disabling early initialization)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
     branches: ["main"]
 
 jobs:
-  test:
+  test-libssh-httpd:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -19,16 +19,113 @@ jobs:
     env:
       PKCS11_MODULE: /usr/lib64/ossl-modules/pkcs11.so
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - name: Get Date for DNF cache entry
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: DNF cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+          key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
+
       - name: Install Build Requirements
         run: dnf -y install gcc git meson openssl-devel
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Setup, Build and Install pkcs11-provider
         run: |
           meson setup -Dlibdir=/usr/lib64 builddir
           meson compile -C builddir
           meson install -C builddir
-      - name: Test
+
+      - name: Test ${{ matrix.test }} with softhsm
         run: |
-          pushd tests/integration
-          bash -e ${{ matrix.test }}.sh
+          pushd tests/integration && bash -e ${{ matrix.test }}.sh
+
+  test-bind:
+    name: bind
+    runs-on: ubuntu-22.04
+    container: fedora:rawhide
+    steps:
+      - name: Get Date for DNF cache entry
+        id: get-date
+        run: |
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: DNF cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/dnf
+          key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
+
+      - name: Install Dependencies
+        run: |
+            dnf -y install clang git meson cargo expect \
+              pkgconf-pkg-config openssl-devel openssl opensc \
+              p11-kit-devel p11-kit-server gnutls-utils \
+              gcc g++ perl-interpreter zlib-devel sqlite-devel \
+              httpd bind9-next softhsm \
+              'perl(Module::Load::Conditional)' 'perl(File::Temp)' \
+              'perl(IPC::Cmd)' 'perl(FindBin)' 'perl(lib)' \
+              'perl(File::Compare)' 'perl(File::Copy)'
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Kryoptic
+        id: kryoptic_setup
+        run: |
+          git clone https://github.com/latchset/kryoptic.git
+          cd kryoptic
+          git submodule update --init
+          echo "KRYOPTIC=${PWD}" >> "$GITHUB_OUTPUT"
+
+      - name: OpenSSL build cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            kryoptic/openssl/
+          key: ${{ runner.os }}-ossl-${{ hashFiles('kryoptic/.git/modules/openssl/HEAD') }}
+
+      - name: Generate lock file
+        run: |
+          cd kryoptic
+          cargo generate-lockfile
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            kryoptic/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('kryoptic/**/Cargo.lock') }}
+
+      - name: Build Kryoptic
+        run: |
+          cd kryoptic
+          cargo build
+
+      - name: Setup, Build and Install pkcs11-provider
+        run: |
+          meson setup -Dlibdir=/usr/lib64 builddir
+          meson compile -C builddir
+          meson install -C builddir
+
+      - name: Test bind with kryoptic
+        env:
+          PKCS11_MODULE: /usr/lib64/ossl-modules/pkcs11.so
+          KRYOPTIC: ${{ steps.kryoptic_setup.outputs.KRYOPTIC }}
+        run: |
+          pushd tests/integration && bash -e bind.sh kryoptic ; popd

--- a/tests/integration/bind.sh
+++ b/tests/integration/bind.sh
@@ -2,78 +2,62 @@
 # Copyright (C) 2024 Ondrej Moris <omoris@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
+if [ $# -ne 1 ]; then
+    echo "Usage bind.sh <tokentype>"
+    exit 1
+fi
+
 # shellcheck disable=SC1091
 source "../helpers.sh"
 
-BASEDIR=$PWD
-WORKDIR=$(mktemp -d)
-PIN="123456"
-PKCS11_DEBUG_FILE="${WORKDIR}/pkcs11-bind-test.log"
+TOKENTYPE=$1
 
-install_dependencies()
+# Temporary dir and Token data dir
+TMPPDIR="/tmp/bind/${TOKENTYPE}"
+TOKDIR="$TMPPDIR/tokens"
+if [ -d "${TMPPDIR}" ]; then
+    rm -fr "${TMPPDIR}"
+fi
+mkdir -p "${TMPPDIR}"
+mkdir "${TOKDIR}"
+
+PINVALUE="123456"
+PINFILE="${TMPPDIR}/pinfile.txt"
+echo ${PINVALUE} > "${PINFILE}"
+PKCS11_DEBUG_FILE="${TMPPDIR}/pkcs11-bind-test.log"
+TEST_RESULT=1
+
+token_setup()
 {
-    title PARA "Install dependencies"
+    title PARA "Token setup"
 
-    dnf install -y --skip-broken \
-        meson \
-        p11-kit httpd mod_ssl openssl-devel gnutls-utils nss-tools \
-        p11-kit-devel opensc softhsm-devel procps-ng \
-        openssl util-linux bind9-next opensc
-}
+    if [ "${TOKENTYPE}" == "softhsm" ]; then
+        # shellcheck disable=SC1091
+        source "../softhsm-init.sh"
+        export XDG_RUNTIME_DIR=$PWD
+        eval "$(p11-kit server --provider "$P11LIB" "pkcs11:")"
+        test -n "$P11_KIT_SERVER_PID"
+        export P11LIB="/usr/lib64/pkcs11/p11-kit-client.so"
+    elif [ "${TOKENTYPE}" == "softokn" ]; then
+        # shellcheck disable=SC1091
+        SHARED_EXT=".so" SOFTOKNPATH="/usr/lib64" source "../softokn-init.sh"
+    elif [ "${TOKENTYPE}" == "kryoptic" ]; then
+        # shellcheck disable=SC1091
+        source "../kryoptic-init.sh"
+    else
+        echo "Unknown token type: $TOKENTYPE"
+        exit 1
+    fi
+    export PKCS11_PROVIDER_MODULE=$P11LIB
+    ${TOKENCONFIGVARS}
 
-softhsm_token_setup()
-{
-    title PARA "Softhsm token setup"
-
-    cp -rnp /var/lib/softhsm/tokens{,.bck}
-    export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/libsofthsm2.so"
-    softhsm2-util --init-token --free --label softhsm --pin $PIN --so-pin $PIN
-    pkcs11-tool --module $PKCS11_PROVIDER_MODULE \
-                --login --pin $PIN \
-                --keypairgen --key-type rsa:2048 --label localhost-ksk
-    pkcs11-tool --module $PKCS11_PROVIDER_MODULE \
-                --login --pin $PIN \
-                --keypairgen --key-type rsa:2048 --label localhost-zsk
+    ARGS=("--module=${P11LIB}" "--login" "--pin=${PINVALUE}" "--token-label=${TOKENLABEL}")
+    pkcs11-tool "${ARGS[@]}" --keypairgen --key-type rsa:2048 --id '0001' --label localhost-ksk
+    pkcs11-tool "${ARGS[@]}" --keypairgen --key-type rsa:2048 --id '0002' --label localhost-zsk
 
     title SECTION "List token content"
-    TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
-    p11tool --login --set-pin "$PIN" --list-all "$TOKENURL"
+    pkcs11-tool "${ARGS[@]}" -O
     title ENDSECTION
-}
-
-pkcs11_provider_setup()
-{
-    title PARA "Get, compile and install pkcs11-provider"
-
-    if [ "$GITHUB_ACTIONS" == "true" ]; then
-        if [ -z "$PKCS11_MODULE" ]; then
-            echo "ERROR: Missing PKCS11_MODULE variable!"
-            exit 1
-        fi
-        echo "Skipped (running in Github Actions)"
-    else
-        git clone \
-            "${GIT_URL:-"https://github.com/latchset/pkcs11-provider.git"}" \
-            "${WORKDIR}"/pkcs11-provider
-        pushd "${WORKDIR}"/pkcs11-provider
-        git checkout "${GIT_REF:-"main"}"
-        meson setup -Dlibdir=/usr/lib64 builddir
-        meson compile -C builddir
-        meson install -C builddir
-        popd
-        export PKCS11_MODULE=/usr/lib64/ossl-modules/pkcs11.so
-    fi
-    test -e "$PKCS11_MODULE"
-}
-
-p11kit_server_setup()
-{
-    title PARA "Proxy module driver through p11-kit server"
-
-    export XDG_RUNTIME_DIR=$PWD
-    eval "$(p11-kit server --provider "$PKCS11_PROVIDER_MODULE" "pkcs11:")"
-    test -n "$P11_KIT_SERVER_PID"
-    export PKCS11_PROVIDER_MODULE="/usr/lib64/pkcs11/p11-kit-client.so"
 }
 
 openssl_setup()
@@ -82,93 +66,73 @@ openssl_setup()
 
     sed \
       -e "s|\(default = default_sect\)|\1\npkcs11 = pkcs11_sect\n|" \
-      -e "s|\(\[default_sect\]\)|\[pkcs11_sect\]\n\1|" \
+      -e "s|\(\[default_sect\]\)|\[pkcs11_sect\]\n$TOKENOPTIONS\n\1|" \
       -e "s|\(\[default_sect\]\)|module = $PKCS11_MODULE\n\1|" \
-      -e "s|\(\[default_sect\]\)|pkcs11-module-load-behavior = early\n\1|" \
       -e "s|\(\[default_sect\]\)|activate = 1\n\n\1|" \
-      /etc/pki/tls/openssl.cnf >"${WORKDIR}"/openssl.cnf
-
-    title SECTION "openssl.cnf"
-    cat "${WORKDIR}"/openssl.cnf
-    title ENDSECTION
+      -e "s|\(\[default_sect\]\)|pkcs11-module-token-pin = file:$PINFILE\n\1|" \
+      /etc/pki/tls/openssl.cnf >"${TMPPDIR}"/openssl.cnf
 }
 
 bind_setup()
 {
     title PARA "Bind setup"
 
-    cp /var/named/named.localhost "${WORKDIR}"/localhost
+    cp /var/named/named.localhost "${TMPPDIR}"/localhost
 }
 
 bind_test()
 {
     title PARA "Bind test"
+    (
+        export OPENSSL_CONF=${TMPPDIR}/openssl.cnf
+        export PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}
 
-    TOKENURL=$(p11tool --list-token-urls | grep "softhsm")
-    KSKURL="$(p11tool --login --set-pin "$PIN" --list-keys "$TOKENURL" \
-        | grep 'URL:.*object=localhost-ksk' \
-        | awk '{ print $NF }' \
-        | sed "s/type=.*\$/pin-value=$PIN/")"
-    ZSKURL="$(p11tool --login --set-pin "$PIN" --list-keys "$TOKENURL" \
-        | grep 'URL:.*object=localhost-zsk' \
-        | awk '{ print $NF }' \
-        | sed "s/type=.*\$/pin-value=$PIN/")"
+        title SECTION "Test 1: Extract KSK and ZSK keys from PKCS11 URIs"
+        dnssec-keyfromlabel -a RSASHA256 -l "pkcs11:object=localhost-zsk" -K "$TMPPDIR" localhost
+        dnssec-keyfromlabel -a RSASHA256 -l "pkcs11:object=localhost-ksk" -K "$TMPPDIR" -f KSK localhost
+        for K in "${TMPPDIR}"/*.key; do
+            cat "$K" >>"${TMPPDIR}/localhost"
+        done
+        test -s "${PKCS11_DEBUG_FILE}"
+        title ENDSECTION
 
-    pushd "$WORKDIR"
-
-    title PARA "Test 1: Extract KSK and ZSK keys from PKCS11 URIs"
-    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.extract \
-    OPENSSL_CONF=openssl.cnf \
-        dnssec-keyfromlabel -a RSASHA256 -l "$ZSKURL" localhost
-    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.extract \
-    OPENSSL_CONF=openssl.cnf \
-        dnssec-keyfromlabel -a RSASHA256 -l "$KSKURL" -f KSK localhost
-    for K in *.key; do
-        cat "$K" >>localhost
-    done
-    test -s "${PKCS11_DEBUG_FILE}".extract
-
-    title PARA "Test 2: Sign zone"
-    PKCS11_PROVIDER_DEBUG=file:${PKCS11_DEBUG_FILE}.sign \
-    OPENSSL_CONF=openssl.cnf \
-        dnssec-signzone -o localhost localhost
-    test -s "${PKCS11_DEBUG_FILE}".sign
-
-    popd
-    echo "Test passed"
+        title SECTION "Test 2: Sign zone"
+        dnssec-signzone -o localhost -K "$TMPPDIR" "${TMPPDIR}/localhost"
+        test -s "${PKCS11_DEBUG_FILE}"
+        title ENDSECTION
+    )
+    title LINE "PASSED"
+    TEST_RESULT=0
 }
 
+# shellcheck disable=SC2317
 cleanup() 
 {
     title PARA "Clean-up"
 
-    for L in "${PKCS11_DEBUG_FILE}".*; do
-        title SECTION "$L"
-        cat "$L"
-        title ENDSECTION
-    done
-
-    pushd "$BASEDIR" >/dev/null
-    rm -rf "$WORKDIR"
-    if [ -e /var/lib/softhsm/tokens.bck ]; then
-        rm -rf /var/lib/softhsm/tokens
-        mv /var/lib/softhsm/tokens.bck /var/lib/softhsm/tokens
+    if [ "$TEST_RESULT" -ne 0 ]; then
+        for L in ${TMPPDIR}/openssl.cnf $PKCS11_DEBUG_FILE; do
+            if [ -e "$L" ]; then
+                title SECTION "$L"
+                cat "$L"
+                title ENDSECTION
+            fi
+        done
     fi
-    cleanup_server "p11-kit" "$P11_KIT_SERVER_PID"
 
-    title LINE "Done"
+    if [ "${TOKENTYPE}" == "softhsm" ]; then
+        cleanup_server "p11-kit" "$P11_KIT_SERVER_PID"
+    fi
 }
-
 
 trap "cleanup" EXIT
 
 # Setup.
-install_dependencies
-softhsm_token_setup
-p11kit_server_setup
-pkcs11_provider_setup
+token_setup
 openssl_setup
 bind_setup
 
 # Test.
 bind_test
+
+exit $TEST_RESULT

--- a/tests/integration/httpd.sh
+++ b/tests/integration/httpd.sh
@@ -100,7 +100,6 @@ openssl_setup()
       -e "s|\(default = default_sect\)|\1\npkcs11 = pkcs11_sect\n|" \
       -e "s|\(\[default_sect\]\)|\[pkcs11_sect\]\n\1|" \
       -e "s|\(\[default_sect\]\)|module = $PKCS11_MODULE\n\1|" \
-      -e "s|\(\[default_sect\]\)|pkcs11-module-load-behavior = early\n\1|" \
       -e "s|\(\[default_sect\]\)|pkcs11-module-token-pin = file:$PIN_FILE\n\1|" \
       -e "s|\(\[default_sect\]\)|activate = 1\n\n\1|" \
       /etc/pki/tls/openssl.cnf >"${WORKDIR}"/openssl.cnf


### PR DESCRIPTION
#### Description

Changes:

1. Adds support for all three tokens to bind integration test (re-using already present init scripts to test tokens).
2. Disables early initialization quirk for both bind and httpd tests.
3. Updates integration tests actions by adding kryoptic setup, bind test is currently only enabled for kryoptic since bind bug (https://bugzilla.redhat.com/show_bug.cgi?id=2277997) prevents it from running with softokn or softhsm successfully

Fixes #266 

#### Checklist

N/A

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
