### PR TITLE
tests: Run more TLS tests when forcing all server operations on token

### DIFF
--- a/docs/provider-pkcs11.7
+++ b/docs/provider-pkcs11.7
@@ -202,6 +202,12 @@ Some implementatations of PKCS11 don\[cq]t allow setting
 \f[V]pApplication\f[R] and \f[V]Notify\f[R] callback functions in
 \f[V]C_OpenSession\f[R].
 This option sets NULL values for both callbacks.
+.SS no-allowed-mechanisms
+.PP
+Some implementatations of PKCS11 don\[cq]t support
+\f[V]CKA_ALLOWED_MECHANISMS\f[R] attribute on keys.
+Setting this quirk prevents the provider from attempting to set and read
+this attribute.
 .PP
 Default: none
 .PP

--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -194,6 +194,11 @@ Some implementatations of PKCS11 don't allow setting `pApplication` and
 `Notify` callback functions in `C_OpenSession`.
 This option sets NULL values for both callbacks.
 
+### no-allowed-mechanisms
+Some implementatations of PKCS11 don't support `CKA_ALLOWED_MECHANISMS`
+attribute on keys. Setting this quirk prevents the provider from
+attempting to set and read this attribute.
+
 Default: none
 
 Example:

--- a/src/debug.c
+++ b/src/debug.c
@@ -107,6 +107,9 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
         }
     }
 
+    /* set error mark so we can clear spurious errors */
+    p11prov_set_error_mark(ctx);
+
     ret = p11prov_GetMechanismInfo(ctx, slotid, type, &info);
     if (ret != CKR_OK) {
         p11prov_debug(NULL, 0, NULL,
@@ -129,6 +132,8 @@ void p11prov_debug_mechanism(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
             }
         }
     }
+    /* if there was any error, remove it, this is just a debug function */
+    p11prov_pop_error_to_mark(ctx);
 }
 
 extern struct ckmap token_flags[];

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -474,7 +474,7 @@ fi
 cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
 
 # for listing the separate pkcs11 calls
-#export PKCS11SPY="${PKCS11_PROVIDER_MODULE}"
+#export PKCS11SPY="${P11LIB}"
 #export PKCS11_PROVIDER_MODULE=/usr/lib64/pkcs11-spy.so
 DBGSCRIPT
 gen_unsetvars

--- a/tests/softhsm-init.sh
+++ b/tests/softhsm-init.sh
@@ -62,6 +62,6 @@ export TOKENLABELURI="SoftHSM%20Token"
 softhsm2-util --init-token --label "${TOKENLABEL}" --free --pin "${PINVALUE}" --so-pin "${PINVALUE}"
 
 #softhsm crashes on de-init so we need to default to this quirk
-export TOKENOPTIONS="pkcs11-module-quirks = no-deinit"
+export TOKENOPTIONS="pkcs11-module-quirks = no-deinit no-operation-state"
 
 export TOKENCONFIGVARS="export SOFTHSM2_CONF=${TMPPDIR}/softhsm.conf"

--- a/tests/softokn-init.sh
+++ b/tests/softokn-init.sh
@@ -19,5 +19,5 @@ export NSS_LIB_PARAMS="configDir=${TOKDIR}"
 export TOKENLABEL="NSS Certificate DB"
 export TOKENLABELURI="NSS%20Certificate%20DB"
 
-export TOKENOPTIONS="pkcs11-module-quirks = no-operation-state"
+export TOKENOPTIONS="pkcs11-module-quirks = no-operation-state no-allowed-mechanisms"
 export TOKENCONFIGVARS="export NSS_LIB_PARAMS=configDir=${TOKDIR}"

--- a/tests/softokn-init.sh
+++ b/tests/softokn-init.sh
@@ -18,4 +18,6 @@ export NSS_LIB_PARAMS="configDir=${TOKDIR}"
 
 export TOKENLABEL="NSS Certificate DB"
 export TOKENLABELURI="NSS%20Certificate%20DB"
+
+export TOKENOPTIONS="pkcs11-module-quirks = no-operation-state"
 export TOKENCONFIGVARS="export NSS_LIB_PARAMS=configDir=${TOKDIR}"

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -46,5 +46,5 @@ LOGFILE="${TESTBLDDIR}/${TEST_NAME}.${TOKEN_DRIVER}.log"
 echo "Executing ${COMMAND}"
 (
   set -o pipefail
-  ${COMMAND} | tee "${LOGFILE}"
+  ${COMMAND} 2>&1 | tee "${LOGFILE}"
 )

--- a/tests/ttls
+++ b/tests/ttls
@@ -25,7 +25,7 @@ SERVER_PID=-1
 # Make sure we terminate programs if test fails in the middle
 # shellcheck disable=SC2317  # Shellcheck for some reason does not follow trap
 wait_for_server_at_exit() {
-    wait "$1"
+    wait "$1" || :
     echo "Server output:"
     cat "${TMPPDIR}/s_server_output"
 }

--- a/tests/ttls
+++ b/tests/ttls
@@ -112,6 +112,9 @@ run_tests() {
 
     title PARA "Run test with TLS 1.2 and ECDH"
     run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
+
+    title PARA "Run test with TLS 1.3 and specific suite"
+    run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_3 -ciphersuites TLS_AES_256_GCM_SHA384 -groups secp256r1"
 }
 
 title SECTION "TLS with key in provider"

--- a/tests/ttls
+++ b/tests/ttls
@@ -42,6 +42,7 @@ run_test() {
         set timeout 60;
         expect {
             \"ACCEPT\" {};
+            eof { exit 2; }
             default {
                 send \" NO ACCEPT \n\";
                 exit 1;
@@ -52,6 +53,7 @@ run_test() {
         close \$server_ready;
         expect {
             \"END SSL SESSION PARAMETERS\" {};
+            eof { exit 2; }
             default {
                 send \" NO SESSION PARAMETERS \n\";
                 exit 1;
@@ -74,6 +76,7 @@ run_test() {
         set timeout 60;
         expect {
             \" TLS SUCCESSFUL \" {};
+            eof { exit 2; }
             default {
                 send \" NO TLS SUCCESSFUL MESSAGE \n\";
                 exit 1;

--- a/tests/ttls
+++ b/tests/ttls
@@ -88,7 +88,7 @@ run_test() {
                 send \" NO EOF \n\";
                 exit 1;
             };
-        }"
+        }" || (wait_for_server_at_exit $SERVER_PID; exit 1; )
 
     wait_for_server_at_exit $SERVER_PID
 }

--- a/tests/ttls
+++ b/tests/ttls
@@ -67,7 +67,7 @@ run_test() {
                 send \" NO EOF \n\";
                 exit 1;
             };
-        }" > "${TMPPDIR}/s_server_output" &
+        }" &> "${TMPPDIR}/s_server_output" &
     SERVER_PID=$!
 
     read -r < "${TMPPDIR}/s_server_ready"
@@ -93,36 +93,43 @@ run_test() {
     wait_for_server_at_exit $SERVER_PID
 }
 
-title PARA "Run sanity test with default values (RSA)"
-run_test "$PRIURI" "$CRTURI"
+run_tests() {
 
-title PARA "Run sanity test with default values (ECDSA)"
-run_test "$ECPRIURI" "$ECCRTURI"
+    title PARA "Run sanity test with default values (RSA)"
+    run_test "$PRIURI" "$CRTURI"
 
-title PARA "Run test with TLS 1.2"
-run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
+    title PARA "Run sanity test with default values (ECDSA)"
+    run_test "$ECPRIURI" "$ECCRTURI"
 
-title PARA "Run test with explicit TLS 1.3"
-run_test "$PRIURI" "$CRTURI" "" "-tls1_3"
+    title PARA "Run test with TLS 1.2"
+    run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
 
-title PARA "Run test with TLS 1.2 (ECDSA)"
-run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2"
+    title PARA "Run test with explicit TLS 1.3"
+    run_test "$PRIURI" "$CRTURI" "" "-tls1_3"
 
-title PARA "Run test with TLS 1.2 and ECDH"
-run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
+    title PARA "Run test with TLS 1.2 (ECDSA)"
+    run_test "$ECPRIURI" "$ECCRTURI" "-tls1_2" "-tls1_2"
 
+    title PARA "Run test with TLS 1.2 and ECDH"
+    run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_2 -cipher ECDHE-ECDSA-AES128-GCM-SHA256 -groups secp256r1"
+}
+
+title SECTION "TLS with key in provider"
+run_tests
+title ENDSECTION
+
+title SECTION "Forcing the provider for all server operations"
 #Try again forcing all operations on the token
 #We need to disable digest operations as OpenSSL depends on context duplication working
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed -e "s/#MORECONF/alg_section = algorithm_sec\n\n[algorithm_sec]\ndefault_properties = ?provider=pkcs11/" \
-    -e "s/#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
+sed -e "s/^#MORECONF/alg_section = algorithm_sec\n\n[algorithm_sec]\ndefault_properties = ?provider=pkcs11/" \
+    -e "s/^#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
     "${OPENSSL_CONF}" > "${OPENSSL_CONF}.forcetoken"
 OPENSSL_CONF=${OPENSSL_CONF}.forcetoken
 
-title PARA "Run test with TLS 1.3 preferring token functions"
-run_test "$ECPRIURI" "$ECCRTURI" "" "-tls1_3"
+run_tests
 
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
-
+title ENDSECTION
 
 exit 0;


### PR DESCRIPTION
#### Description

This is rebase of previously closed PR #427, which adds also a test reproducer for #449.

This is trying to solve few issues:
 * The standard error is not recorded in the log files, which makes them hard to use for debugging
 * The expect script `default` does not catch `eof`, which makes some failures hidden
 * One of these failures happens in the client, when the provider is forced to be used, but it dies on verification failure. This is because the SSL/TLS code picks up errors left on stack that were not cleaned in several occasions
 * The error from reproducer from #449 was also being hidden because the server closed the connection.
 * The TLS tests when the provider is forced to be used were executing only one basic use case. This again attempts to run all of them.
 * The query for ALLOWED_MECHANISM during signature was leaving errors on the stack with softokn. I added the `no-allowed-mechanisms` for the softokn tests and documented this undocumented quirk
 * When doing operations on imported keys, we had undefined slot id, which caused the signature verification failures in client.

#### Checklist

- [X] Code modified for feature
- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
- [X] Documentation updated

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
