### PR TITLE
Add code to prevent locking the token by mistake

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -439,6 +439,35 @@ err:
     return ret;
 }
 
+static CK_RV check_pin_flags_ok(P11PROV_CTX *ctx, CK_SLOT_ID slotid)
+{
+    CK_TOKEN_INFO token;
+    CK_RV ret;
+
+    ret = p11prov_GetTokenInfo(ctx, slotid, &token);
+    if (ret != CKR_OK) {
+        return ret;
+    }
+
+    if (token.flags & CKF_USER_PIN_FINAL_TRY) {
+        ret = CKR_CANCEL;
+        P11PROV_raise(ctx, ret,
+                      "Only one auth attempt left on token. "
+                      "Canceling login attempt to avoid locking the token. "
+                      "Manual user login required to reset counter.");
+    } else if (token.flags & CKF_USER_PIN_LOCKED) {
+        ret = CKR_PIN_LOCKED;
+        P11PROV_raise(ctx, ret, "PIN marked as locked, canceling login");
+    } else if (token.flags & CKF_USER_PIN_TO_BE_CHANGED) {
+        ret = CKR_PIN_EXPIRED;
+        P11PROV_raise(ctx, ret, "PIN marked as expired, canceling login");
+    } else {
+        ret = CKR_OK;
+    }
+
+    return ret;
+}
+
 /* returns a locked login_session if _session is not NULL */
 static CK_RV token_login(P11PROV_SESSION *session, P11PROV_URI *uri,
                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
@@ -520,6 +549,11 @@ static CK_RV token_login(P11PROV_SESSION *session, P11PROV_URI *uri,
 
             cache = p11prov_ctx_cache_pins(session->provctx);
         }
+    }
+
+    ret = check_pin_flags_ok(session->provctx, session->slotid);
+    if (ret != CKR_OK) {
+        goto done;
     }
 
     P11PROV_debug("Attempt Login on session %lu", session->session);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -140,6 +140,7 @@ tests = {
   'uri': {'suites': ['softokn', 'softhsm', 'kryoptic']},
   'ecxc': {'suites': ['softhsm', 'kryoptic']},
   'cms': {'suites': ['softokn', 'kryoptic']},
+  'pinlock': {'suites': ['kryoptic']},
 }
 
 test_wrapper = find_program('test-wrapper')

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -391,7 +391,8 @@ sed -e "s|@libtoollibs@|${LIBSPATH}|g" \
 title LINE "Export test variables to ${TMPPDIR}/testvars"
 cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
 ${TOKENCONFIGVARS}
-export P11LIB=${P11LIB}
+export P11LIB="${P11LIB}"
+export TOKENLABEL="${TOKENLABEL}"
 export PKCS11_PROVIDER_MODULE=${P11LIB}
 export PPDBGFILE=${TMPPDIR}/p11prov-debug.log
 export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug.log"

--- a/tests/tpinlock
+++ b/tests/tpinlock
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+# Copyright (C) 2024 Simo Sorce <simo@redhat.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "${TESTSSRCDIR}/helpers.sh"
+
+title PARA "Test PIN lock prevention"
+
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed "s/^pkcs11-module-token-pin.*$/##nopin/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.nopin"
+OPENSSL_CONF=${OPENSSL_CONF}.nopin
+
+BADPIN="bad"
+export BADPINURI="${PRIURI}?pin-value=${BADPIN}"
+export GOODPINURI="${PRIURI}?pin-value=${PINVALUE}"
+
+TOOLDEFARGS=("--module=${P11LIB}" "--token-label=${TOKENLABEL}")
+
+FAIL=0
+pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "PIN initialized" && FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "Failed to detect PIN status"
+    exit 1
+fi
+
+# Kryoptic allows for 10 tries by default
+for i in {1..10}; do
+    echo "Login attempt: $i"
+    pkcs11-tool "${TOOLDEFARGS[@]}" -l -I -p "${BADPIN}" && false
+    DETECT=0
+    pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "final user PIN try" && DETECT=1
+    if [ $DETECT -eq 1 ]; then
+        break
+    fi
+done
+FAIL=0
+pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "final user PIN try" && FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "Failed to reach "final try" status"
+    exit 1
+fi
+
+# Now we test one operation with a bad pin.
+# It should fail but not lock the token
+title LINE "Try op with bad pin and fail"
+FAIL=0
+ossl '
+pkeyutl -sign -inkey "${BADPINURI}"
+    -in ${TMPPDIR}/sha256.bin
+    -out ${TMPPDIR}/pinlock-sig.bin' || FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "Operation should have failed, pin lock prevention not working"
+    exit 1
+fi
+
+# Now we test one operation with a good pin.
+# It should fail because the token is on last try
+title LINE "Try op with good pin and fail"
+FAIL=0
+ossl '
+pkeyutl -sign -inkey "${GOODPINURI}"
+    -in ${TMPPDIR}/sha256.bin
+    -out ${TMPPDIR}/pinlock-sig.bin' || FAIL=1
+if [ $FAIL -eq 0 ]; then
+    echo "Operation should have failed, pin lock prevention not working"
+    exit 1
+fi
+
+
+# Now reset the token counter with a good try
+pkcs11-tool "${TOOLDEFARGS[@]}" -l -T -p "${PINVALUE}"
+
+# Now we test one operation with a good pin.
+# It should succeed
+title LINE "Try op with good pin and succeed"
+ossl '
+pkeyutl -sign -inkey "${GOODPINURI}"
+    -in ${TMPPDIR}/sha256.bin
+    -out ${TMPPDIR}/pinlock-sig.bin'
+
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}


### PR DESCRIPTION
#### Description

For tokens that properly report the status of the PIN authentication counter via token flags, check them out and refuse to attempt login if the token is on its last try.

A token should never be on its last try and finding this flags set is an indication that someone may have hardocded an in correct pin in the configuration or an URI. Proceeding would have a high chance of ending up blocking the token.

Fixes: #455

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
