### PR TITLE
Support TLS operation with EdDSA keys

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -28,6 +28,7 @@ Files: .github/*
        tools/openssl*.cnf
        tests/*.pem
        tests/cert.json.in
+       tests/cert.json.part.in
        scripts/clean-dist.sh
 Copyright: (C) 2022 - 2024 Simo Sorce <simo@redhat.com>
 License: Apache-2.0

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1396,8 +1396,8 @@ static int p11prov_ec_match(const void *keydata1, const void *keydata2,
     return p11prov_common_match(keydata1, keydata2, CKK_EC, selection);
 }
 
-static int p11prov_ec_import(void *keydata, int selection,
-                             const OSSL_PARAM params[])
+static int p11prov_ec_import_genr(CK_KEY_TYPE key_type, void *keydata,
+                                  int selection, const OSSL_PARAM params[])
 {
     P11PROV_OBJ *key = (P11PROV_OBJ *)keydata;
     CK_OBJECT_CLASS class = CKO_PUBLIC_KEY;
@@ -1426,11 +1426,17 @@ static int p11prov_ec_import(void *keydata, int selection,
         }
     }
 
-    rv = p11prov_obj_import_key(key, CKK_EC, class, params);
+    rv = p11prov_obj_import_key(key, key_type, class, params);
     if (rv != CKR_OK) {
         return RET_OSSL_ERR;
     }
     return RET_OSSL_OK;
+}
+
+static int p11prov_ec_import(void *keydata, int selection,
+                             const OSSL_PARAM params[])
+{
+    return p11prov_ec_import_genr(CKK_EC, keydata, selection, params);
 }
 
 static int p11prov_ec_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
@@ -1915,6 +1921,12 @@ static int p11prov_ed_export(void *keydata, int selection, OSSL_CALLBACK *cb_fn,
     return RET_OSSL_ERR;
 }
 
+static int p11prov_ed_import(void *keydata, int selection,
+                             const OSSL_PARAM params[])
+{
+    return p11prov_ec_import_genr(CKK_EC_EDWARDS, keydata, selection, params);
+}
+
 static const OSSL_PARAM *p11prov_ed_import_types(int selection)
 {
     static const OSSL_PARAM p11prov_ed_imp_key_types[] = {
@@ -2082,7 +2094,7 @@ const OSSL_DISPATCH p11prov_ed25519_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ec, FREE, free),
     DISPATCH_KEYMGMT_ELEM(ec, HAS, has),
     DISPATCH_KEYMGMT_ELEM(ed, MATCH, match),
-    DISPATCH_KEYMGMT_ELEM(ec, IMPORT, import),
+    DISPATCH_KEYMGMT_ELEM(ed, IMPORT, import),
     DISPATCH_KEYMGMT_ELEM(ed, IMPORT_TYPES, import_types),
     DISPATCH_KEYMGMT_ELEM(ed, EXPORT, export),
     DISPATCH_KEYMGMT_ELEM(ed, EXPORT_TYPES, export_types),
@@ -2106,7 +2118,7 @@ const OSSL_DISPATCH p11prov_ed448_keymgmt_functions[] = {
     DISPATCH_KEYMGMT_ELEM(ec, FREE, free),
     DISPATCH_KEYMGMT_ELEM(ec, HAS, has),
     DISPATCH_KEYMGMT_ELEM(ed, MATCH, match),
-    DISPATCH_KEYMGMT_ELEM(ec, IMPORT, import),
+    DISPATCH_KEYMGMT_ELEM(ed, IMPORT, import),
     DISPATCH_KEYMGMT_ELEM(ed, IMPORT_TYPES, import_types),
     DISPATCH_KEYMGMT_ELEM(ed, EXPORT, export),
     DISPATCH_KEYMGMT_ELEM(ed, EXPORT_TYPES, export_types),

--- a/tests/cert.json.in
+++ b/tests/cert.json.in
@@ -1,5 +1,5 @@
 [
-    {"server_command": [@CHECKER@"openssl", "s_server", "-www", "-port", "@PORT@",
+    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@",
                         "-key", "@PRIURI@", "-cert", "@CRTURI@",
                         "-verify", "1", "-CAfile", "tests/clientX509Cert.pem"],
      "comment": "Use ANY certificate just to ensure that server tries to authorise a client",
@@ -18,19 +18,4 @@
                        "-s", "@SIGALGS@",
                        "-p", "@PORT@"]}
      ]
-    },
-    {"server_command": [@CHECKER@"openssl", "s_server", "-www", "-port", "@PORT@", "-key", "@ECPRIURI@", "-cert", "@ECCRTURI@"],
-     "comment": "Run test with ECDSA hostkey in pkcs11 provider",
-     "environment": {"PYTHONPATH" : "."},
-     "server_hostname": "localhost",
-     "server_port": @PORT@,
-     "tests" : [
-       {"name" : "test-tls13-conversation.py",
-        "arguments" : ["-p", "@PORT@"]},
-       {"name" : "test-conversation.py",
-        "arguments" : ["-p", "@PORT@",
-                       "-d"]}
-     ]
     }
-]
-

--- a/tests/cert.json.part.in
+++ b/tests/cert.json.part.in
@@ -1,0 +1,15 @@
+,
+    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
+     "comment": "Run test without certificate verify",
+     "environment": {"PYTHONPATH" : "."},
+     "server_hostname": "localhost",
+     "server_port": @PORT@,
+     "tests" : [
+       {"name" : "test-tls13-conversation.py",
+        "arguments" : ["-p", "@PORT@"]},
+       {"name" : "test-conversation.py",
+        "arguments" : ["-p", "@PORT@",
+                       "-d"]}
+     ]
+    }
+

--- a/tests/ttls
+++ b/tests/ttls
@@ -38,11 +38,14 @@ run_test() {
     CERT="$2"
     SRV_ARGS=$3
     CLNT_ARGS=$4
-    expect -c "spawn $CHECKER openssl s_server -accept \"${PORT}\" -naccept 1 -key \"${KEY}\" -cert \"${CERT}\" $SRV_ARGS;
-        set timeout 60;
+
+    export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug-tls-server.log"
+    expect -c "spawn $CHECKER openssl s_server $PROPQ -accept \"${PORT}\" -naccept 1 -key \"${KEY}\" -cert \"${CERT}\" $SRV_ARGS;
+        set timeout 10;
         expect {
             \"ACCEPT\" {};
             eof { exit 2; }
+            timeout { exit 5; }
             default {
                 send \" NO ACCEPT \n\";
                 exit 1;
@@ -54,6 +57,7 @@ run_test() {
         expect {
             \"END SSL SESSION PARAMETERS\" {};
             eof { exit 2; }
+            timeout { exit 5; }
             default {
                 send \" NO SESSION PARAMETERS \n\";
                 exit 1;
@@ -63,6 +67,7 @@ run_test() {
         send \"Q\n\"
         expect {
             eof {exit 0;};
+            timeout { exit 5; }
             default {
                 send \" NO EOF \n\";
                 exit 1;
@@ -72,11 +77,13 @@ run_test() {
 
     read -r < "${TMPPDIR}/s_server_ready"
 
-    expect -c "spawn $CHECKER openssl s_client -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
-        set timeout 60;
+    export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug-tls-client.log"
+    expect -c "spawn $CHECKER openssl s_client $PROPQ -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
+        set timeout 10;
         expect {
             \" TLS SUCCESSFUL \" {};
             eof { exit 2; }
+            timeout { exit 5; }
             default {
                 send \" NO TLS SUCCESSFUL MESSAGE \n\";
                 exit 1;
@@ -84,6 +91,7 @@ run_test() {
         }
         expect {
             eof {exit 0;};
+            timeout { exit 5; }
             default {
                 send \" NO EOF \n\";
                 exit 1;
@@ -100,6 +108,11 @@ run_tests() {
 
     title PARA "Run sanity test with default values (ECDSA)"
     run_test "$ECPRIURI" "$ECCRTURI"
+
+    if [[ -n "$EDBASEURI" ]]; then
+        title PARA "Run sanity test with default values (EdDSA)"
+        run_test "$EDPRIURI" "$EDCRTURI"
+    fi
 
     title PARA "Run test with TLS 1.2"
     run_test "$PRIURI" "$CRTURI" "" "-tls1_2"
@@ -118,15 +131,18 @@ run_tests() {
 }
 
 title SECTION "TLS with key in provider"
+PROPQ=""
 run_tests
 title ENDSECTION
 
 title SECTION "Forcing the provider for all server operations"
-#Try again forcing all operations on the token
-#We need to disable digest operations as OpenSSL depends on context duplication working
+# We can not put this into the openssl.cnf directly, as it would be picked up by softhsm
+# causing infinite recursion when doing EdDSA key operations.
+PROPQ="-propquery \"?provider=pkcs11\""
+# Try again forcing all operations on the token
+# We need to disable digest operations as OpenSSL depends on context duplication working
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed -e "s/^#MORECONF/alg_section = algorithm_sec\n\n[algorithm_sec]\ndefault_properties = ?provider=pkcs11/" \
-    -e "s/^#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
+sed -e "s/^#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
     "${OPENSSL_CONF}" > "${OPENSSL_CONF}.forcetoken"
 OPENSSL_CONF=${OPENSSL_CONF}.forcetoken
 

--- a/tests/ttlsfuzzer
+++ b/tests/ttlsfuzzer
@@ -9,7 +9,7 @@ if [[ ! -d "${TESTSSRCDIR}/../tlsfuzzer/tlsfuzzer" ]]; then
     exit 77;
 fi
 
-TMPFILE="${PWD}/tls-fuzzer.$$.tmp"
+TMPFILE="${TMPPDIR}/tls-fuzzer.$$.tmp"
 PORT="$TESTPORT"
 PYTHON=$(which python3)
 
@@ -20,13 +20,18 @@ else
     SIGALGS="ecdsa_secp256r1_sha256 ecdsa_secp384r1_sha384 ecdsa_secp521r1_sha512 ed25519 ed448 8+26 8+27 8+28 rsa_pss_pss_sha256 rsa_pss_pss_sha384 rsa_pss_pss_sha512 rsa_pss_rsae_sha256 rsa_pss_rsae_sha384 rsa_pss_rsae_sha512 rsa_pkcs1_sha256 rsa_pkcs1_sha384 rsa_pkcs1_sha512 ecdsa_sha224 rsa_pkcs1_sha224"
 fi
 
-run_tests() {
+prepare_test() {
+    TEMPLATE="$1"
+    KEY="$2"
+    CERT="$3"
     # Prepare the tlsfuzzer configuration
-    sed -e "s|@PRIURI@|$PRIURI|g" -e "s/@CRTURI@/$CRTURI/g" \
-        -e "s|@ECPRIURI@|$ECPRIURI|g" -e "s/@ECCRTURI@/$ECCRTURI/g" \
+    sed -e "s|@PRIURI@|$KEY|g" -e "s/@CRTURI@/$CERT/g" \
         -e "s/@PORT@/$PORT/g" \
-        -e "s/@SIGALGS@/$SIGALGS/g" "${TESTSSRCDIR}/cert.json.in" >"${TMPFILE}"
+        -e "s/@PROPQ@/$PROPQ/g" \
+        -e "s/@SIGALGS@/$SIGALGS/g" "${TESTSSRCDIR}/${TEMPLATE}" >>"${TMPFILE}"
+}
 
+run_test() {
     # Run openssl under checker program if needed
     if [[ -n "$CHECKER" ]]; then
         IFS=" " read -r -a ARR <<< "$CHECKER"
@@ -39,8 +44,31 @@ run_tests() {
     test -L ecdsa || ln -s ../python-ecdsa/src/ecdsa ecdsa
     test -L tlslite || ln -s ../tlslite-ng/tlslite tlslite 2>/dev/null
     PYTHONPATH=. "${PYTHON}" tests/scripts_retention.py "${TMPFILE}" openssl 821
-    rm -f "${TMPFILE}"
     popd
+}
+
+run_tests() {
+    # truncate
+    true > "${TMPFILE}"
+
+    title PARA "Prepare CertificateVerify test with RSA"
+    prepare_test cert.json.in "$PRIURI" "$CRTURI"
+
+    title PARA "Prepare test for RSA"
+    prepare_test cert.json.part.in "$PRIURI" "$CRTURI"
+
+    title PARA "Prepare test for ECDSA"
+    prepare_test cert.json.part.in "$ECPRIURI" "$ECCRTURI"
+
+    if [[ -n "$EDBASEURI" ]]; then
+        title PARA "Prepare test for EdDSA"
+        prepare_test cert.json.part.in "$EDPRIURI" "$EDCRTURI"
+    fi
+
+    # the missing closing brace
+    echo "]" >> "${TMPFILE}"
+
+    run_test
 }
 
 title SECTION "Run TLS fuzzer with server key on provider"
@@ -48,10 +76,12 @@ run_tests
 title ENDSECTION
 
 title SECTION "Run TLS fuzzer forcing the provider for all server operations"
-#We need to disable digest operations as OpenSSL depends on context duplication working
+# We can not put this into the openssl.cnf directly, as it would be picked up by softhsm
+# causing infinite recursion when doing EdDSA key operations.
+PROPQ="\"-propquery\", \"?provider=pkcs11\", "
+# We need to disable digest operations as OpenSSL depends on context duplication working
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-sed -e "s/^#MORECONF/alg_section = algorithm_sec\n\n[algorithm_sec]\ndefault_properties = ?provider=pkcs11/" \
-    -e "s/^#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
+sed -e "s/^#pkcs11-module-block-operations/pkcs11-module-block-operations = digest/" \
     "${OPENSSL_CONF}" > "${OPENSSL_CONF}.forcetoken"
 export OPENSSL_CONF=${OPENSSL_CONF}.forcetoken
 


### PR DESCRIPTION
#### Description

It turned out the import of EdDSA keys went through the ECDSA code paths which failed down the road. After fixing that, the TLS tests turned out to go into infinite recursion in softhsm where the softhsm operation would call back to the pkcs11 provider code making everything explode. The workaround is to use the propquery on the openssl tools cli, which looks like working ok.

Fixes #461.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [X] Code modified for feature
- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests
- [ ] Documentation updated

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
