### PR TITLE
tests: Use LeakSanitizer to catch future memory leaks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Build Kryoptic
         run: |
           cd kryoptic
-          cargo build
+          cargo build --features standard
 
       - name: Setup, Build and Install pkcs11-provider
         run: |

--- a/.github/workflows/kryoptic.yml
+++ b/.github/workflows/kryoptic.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Build Kryoptic
         run: |
           cd kryoptic
-          cargo build
-          cargo test | tee testout.log 2>&1
+          cargo build --features standard
+          cargo test --features standard | tee testout.log 2>&1
           grep -q "0 failed" testout.log
 
       - name: Setup

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -78,7 +78,7 @@ if get_option('b_sanitize') == 'address'
     name_prefix: '',
   )
 
-  test_env.set('ASAN_OPTIONS', 'fast_unwind_on_malloc=0')
+  test_env.set('ASAN_OPTIONS', 'fast_unwind_on_malloc=0:detect_leaks=1')
   test_env.set('LSAN_OPTIONS', 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()))
   test_env.set('FAKE_DLCLOSE', fake_dlclose.full_path())
 


### PR DESCRIPTION
#### Description

Follow-up to #471. The address sanitizer should catch memory leaks, but it needs the configuration, which was missing

https://clang.llvm.org/docs/LeakSanitizer.html


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
