### PR TITLE
Add a SBOM template in CycloneDX format

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -23,6 +23,7 @@ Files: .github/*
        .clang-format
        .clang-format-ignore
        packaging/pkcs11-provider.spec
+       packaging/sbom.cdx.json
        docs/*
        tests/lsan.supp
        tools/openssl*.cnf

--- a/packaging/sbom.cdx.json
+++ b/packaging/sbom.cdx.json
@@ -1,0 +1,44 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "version": 1,
+    "metadata": {
+        "authors": [
+            {
+                "name": "@VCS_SBOM_AUTHORS@"
+            }
+        ]
+    },
+    "components": [
+        {
+            "type": "library",
+            "bom-ref": "pkg:github/latchset/pkcs11-provider@@VCS_TAG@",
+            "cpe": "cpe:2.3:a:latchset:pkcs11-provider:@VCS_TAG@:*:*:*:*:*:*:*",
+            "name": "pkcs11-provider",
+            "version": "@VCS_VERSION@",
+            "description":
+                "OpenSSL 3.x provider to access Hardware and Software Tokens using the PKCS#11 Cryptographic Token Interface",
+            "supplier": {
+                "name": "pkcs11-provider developers"
+            },
+            "authors": [
+                {
+                    "name": "@VCS_AUTHORS@"
+                }
+            ],
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ],
+            "externalReferences": [
+                {
+                    "type": "vcs",
+                    "url": "https://github.com/latchset/pkcs11-provider"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi,

My name is Richard Hughes and I'm a developer at Red Hat. I'm the maintainer of fwupd and LVFS, and am trying to improve software supply chain security by encouraging OEMs, ODMs and IBVs to ship Software Bill of Materials with each firmware binary blob (SBOMs).

I'm working alongside lots of other companies proactively trying to do the right thing. The reason I've opened this pull request is because your project is either used in the *build process* of a firmware we care about (e.g. EDK II, or coreboot) or is built *into the firmware binary* itself. Although my personal focus is on firmware, the SBOM file is in CycloneDX format (one of the most popular industry standards) which makes it also useful when building containers or OS images too.

I would like to contribute this template SBOM file into your project that gets included into source control with substituted values that get populated automatically. I'm not super familiar with OpenSSL (or pkcs11-provider more specifically), and so I've done my best populating the project values -- but please point out any that are incorrect and I'll fix them up. I've also put the `sbom.cdx.json` file in what I feel is the right place, but please say if you want me to put it somewhere different or name it a different thing; the directory and `sbom` prefix are unimportant. I also wasn’t 100% sure whether to mark the component as a *library* or *application*, so advice is welcome.

The various firmware build tools will take these incomplete SBOM files and then build them into a complete composite SBOM to represent the firmware. Having an upstream reference to what the PURL and CPE values should be means we have something we can trust; I could quite easily spin up a web-service that we say "what CPE do we use for X" -> `cpe:2.3:a:Y:Z::::::::` but we don't actually know if that's still true, up to date, or what the maintainer actually wants them to be. Putting the template upstream means we can trust the values we find in the checked out code during the build process.

Also, if you’re not happy with being labelled a *supplier* (which seems more appropriate from a SBOM point of view, but makes some open source maintainers uncomfortable) we can remove that bit.

I've written a bit more about this proposal here https://blogs.gnome.org/hughsie/2024/11/14/firmware-sboms-for-open-source-projects/ and there's also lot more information about firmware SBOMs here: https://lvfs.readthedocs.io/en/latest/sbom.html – many thanks for your time.

#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [ ] ~There is a test suite reasonably covering new functionality or modifications~
- [ ] ~This feature/change has adequate documentation added~
- [ ] ~Code conform to coding style that today cannot yet be enforced via the check style test~
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
