### PR TITLE
tests: Create separate self-signed EC key for tlsfuzzer testing

### DIFF
--- a/tests/cert.json.ecdsa.in
+++ b/tests/cert.json.ecdsa.in
@@ -22,23 +22,9 @@
        {"name" : "test-signature-algorithms.py",
         "arguments" : [
           "-n", "0", "--ecdsa",
-          "-x", "duplicated 206 non-rsa schemes", "-X", "handshake_failure",
-          "-x", "duplicated 2346 non-rsa schemes", "-X", "handshake_failure",
-          "-x", "duplicated 8123 non-rsa schemes", "-X", "handshake_failure",
-          "-x", "duplicated 23745 non-rsa schemes", "-X", "handshake_failure",
-          "-x", "duplicated 32748 non-rsa schemes", "-X", "handshake_failure",
-          "-x", "explicit SHA-256+RSA or ECDSA", "-X", "handshake_failure",
           "-x", "explicit SHA-1+RSA/ECDSA", "-X", "handshake_failure",
           "-x", "explicit SHA-1+RSA/ECDSA", "-X", "handshake_failure",
-          "-x", "implicit SHA-1 check", "-X", "handshake_failure",
-          "-x", "tolerance 10+RSA or ECDSA method", "-X", "handshake_failure",
-          "-x", "tolerance 215 RSA or ECDSA methods", "-X", "handshake_failure",
-          "-x", "tolerance 2355 RSA or ECDSA methods", "-X", "handshake_failure",
-          "-x", "tolerance 8132 RSA or ECDSA methods", "-X", "handshake_failure",
-          "-x", "tolerance 32758 methods with sig_alg_cert", "-X", "handshake_failure",
-          "-x", "tolerance max 32748 number of methods with sig_alg_cert", "-X", "handshake_failure",
-          "-x", "tolerance none+RSA or ECDSA", "-X", "handshake_failure",
-          "-x", "unique and well-known sig_algs, ecdsa algorithm last", "-X", "handshake_failure"
+          "-x", "implicit SHA-1 check", "-X", "handshake_failure"
         ],
 	"comment": "Crypto-Policies disable SHA-1."
        },

--- a/tests/tcerts
+++ b/tests/tcerts
@@ -28,7 +28,7 @@ title PARA "Use storeutl command to match specific certs via params"
 
 SUBJECTS=("/O=PKCS11 Provider/CN=My Test Cert"
           "/O=PKCS11 Provider/CN=My EC Cert"
-          "/O=PKCS11 Provider/CN=My Peer EC Cert"
+          "/CN=My Peer EC Cert"
           "/CN=Issuer")
 
 for subj in "${SUBJECTS[@]}"; do

--- a/tests/ttlsfuzzer
+++ b/tests/ttlsfuzzer
@@ -58,7 +58,10 @@ run_tests() {
     prepare_test cert.json.rsa.in "$PRIURI" "$CRTURI"
 
     title PARA "Prepare test for ECDSA"
-    prepare_test cert.json.ecdsa.in "$ECPRIURI" "$ECCRTURI"
+    # Note, that tlsfuzzer expects the homogeneous CA and server keys
+    # so we are using here the self-signed peer EC Key, instead of
+    # the default ECC key
+    prepare_test cert.json.ecdsa.in "$ECPEERPRIURI" "$ECPEERCRTURI"
 
     if [[ -n "$EDBASEURI" ]]; then
         title PARA "Prepare test for EdDSA"


### PR DESCRIPTION
#### Description

Follow up from #488, where we found the tlsfuzzer has problems with heterogeneous CA + server keys. This creates separate EC key outside of the main CA chain (EC Peer key used for ECDH generally), which turned out to be easier than I expected. It also simplifies the setup a bit and removes the excluded test cases, that should be working.

#### Checklist
- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
