### PR TITLE
Add meson option to disable explicit EC keys tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,11 @@ jobs:
           git config --global --add safe.directory \
               /__w/pkcs11-provider/pkcs11-provider
           git submodule update --init
-          CC=${{ matrix.compiler }} meson setup builddir
+          if [ -f /etc/redhat-release ]; then
+            CC=${{ matrix.compiler }} meson setup builddir
+          else
+            CC=${{ matrix.compiler }} meson setup builddir -Denable_explicit_EC_test=true
+          fi
       - name: Build and Test
         if : ( steps.nss-version-check.outputs.skiptest != 'true' )
         run: |

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,8 @@ option('preload_libasan',
        type: 'string',
        value: 'no',
        description: 'Path to libasan.so to preload')
+
+option('enable_explicit_EC_test',
+       type: 'boolean',
+       value: false,
+       description: 'Enable explicit EC tests')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,10 @@ if nss_softokn.found()
   endif
 endif
 
+if get_option('enable_explicit_EC_test')
+  conf_env.set('ENABLE_EXPLICIT_EC_TEST', '1')
+endif
+
 setup_script=find_program('setup.sh')
 foreach suite : ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']
   test(
@@ -46,6 +50,10 @@ test_env = environment({
   'TEST_PATH': meson.current_source_dir(),
   'TESTBLDDIR': meson.current_build_dir(),
 })
+
+if get_option('enable_explicit_EC_test')
+  test_env.set('ENABLE_EXPLICIT_EC_TEST', '1')
+endif
 
 valgrind = find_program('valgrind', required: false)
 if valgrind.found()
@@ -95,6 +103,7 @@ if get_option('b_sanitize') == 'address'
     test_env.set('CHECKER', 'env @0@=@1@'.format(preload_env_var, fake_dlclose.full_path()))
   endif
 endif
+
 
 test_programs = {
   'tsession': ['tsession.c'],

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -309,8 +309,8 @@ echo "${ECPRI2URI}"
 echo "${ECCRT2URI}"
 echo ""
 
-if [ -f /etc/redhat-release ]; then
-    title PARA "explicit EC unsupported on Fedora/EL"
+if [ -z "${ENABLE_EXPLICIT_EC_TEST}" ]; then
+    title PARA "explicit EC unsupported"
 elif [ "${TOKENTYPE}" == "softokn" ]; then
     title PARA "explicit EC unsupported with softokn"
 else

--- a/tests/tecxc
+++ b/tests/tecxc
@@ -2,10 +2,10 @@
 # Copyright (C) 2023 Simo Sorce <simo@redhat.com>
 # SPDX-License-Identifier: Apache-2.0
 
-# On Fedora/EL completely removed support for explicit EC from libcrypto,
-# so skip the test completely
-if [ -f /etc/redhat-release ]; then
-    exit 0
+# Some distributions completely removed support for explicit EC from libcrypto.
+# If `-Denable_explicit_EC_test=true` is not set, skip the test.
+if [ -z "${ENABLE_EXPLICIT_EC_TEST}" ]; then
+    exit 77
 fi
 
 source "${TESTSSRCDIR}/helpers.sh"


### PR DESCRIPTION
#### Description

This PR adds a meson option to disable explicit EC keys tests.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
