### PR TITLE
Some fixes for EdDSA signatures + test coverage

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -970,7 +970,7 @@ static int p11prov_ec_edwards_encoder_encode_text(
     P11PROV_OBJ *key = (P11PROV_OBJ *)inkey;
     CK_KEY_TYPE type;
     CK_ULONG keysize;
-    const char *type_name = "ED25519";
+    const char *type_name = ED25519;
     char *uri = NULL;
     BIO *out;
     int ret;
@@ -990,8 +990,8 @@ static int p11prov_ec_edwards_encoder_encode_text(
     }
 
     keysize = p11prov_obj_get_key_bit_size(key);
-    if (keysize == 448) {
-        type_name = "ED448";
+    if (keysize == ED448_BIT_SIZE) {
+        type_name = ED448;
     }
     if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
         CK_OBJECT_CLASS class = p11prov_obj_get_class(key);

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -232,34 +232,38 @@ if [ "${TOKENTYPE}" != "softokn" ]; then
     echo "${EDPUBURI}"
     echo "${EDPRIURI}"
     echo "${EDCRTURI}"
-fi
 
-# FIXME The pkcs11-tool before OpenSC 0.26 does not support Ed448 so they can
-# not be generated here
-#
-# generate ED448
-#KEYID='0009'
-#URIKEYID="%00%09"
-#ED2CRTN="ed2Cert"
-#
-# pkcs11-tool "${P11DEFARGS[@]}" --keypairgen --key-type="EC:edwards448" \
-# 	--label="${ED2CRTN}" --id="$KEYID"
-# ca_sign $ED2CRTN "My ED448 Cert" $KEYID
-#
-# ED2BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
-# ED2BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
-# ED2BASEURI="pkcs11:id=${URIKEYID}"
-# ED2PUBURI="pkcs11:type=public;id=${URIKEYID}"
-# ED2PRIURI="pkcs11:type=private;id=${URIKEYID}"
-# ED2CRTURI="pkcs11:type=cert;object=${ED2CRTN}"
-#
-# title LINE "ED448 PKCS11 URIS"
-# echo "${EDBASEURIWITHPINVALUE}"
-# echo "${EDBASEURIWITHPINSOURCE}"
-# echo "${EDBASEURI}"
-# echo "${EDPUBURI}"
-# echo "${EDPRIURI}"
-# echo "${EDCRTURI}"
+    # this requires OpenSC 0.26.0, which is not available in Ubuntu and CentOS 9
+    if [[ -f /etc/debian_version ]] && grep Ubuntu /etc/lsb-release; then
+        echo "Ed448 not supported in Ubuntu's OpenSC version"
+    elif [[ -f /etc/redhat-release ]] && grep "release 9" /etc/redhat-release; then
+        echo "Ed448 not supported in EL9's OpenSC version"
+    else
+        # generate ED448
+        KEYID='0009'
+        URIKEYID="%00%09"
+        ED2CRTN="ed2Cert"
+
+        pkcs11-tool "${P11DEFARGS[@]}" --keypairgen --key-type="EC:Ed448" \
+            --label="${ED2CRTN}" --id="$KEYID"
+        ca_sign $ED2CRTN "My ED448 Cert" $KEYID
+
+        ED2BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
+        ED2BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
+        ED2BASEURI="pkcs11:id=${URIKEYID}"
+        ED2PUBURI="pkcs11:type=public;id=${URIKEYID}"
+        ED2PRIURI="pkcs11:type=private;id=${URIKEYID}"
+        ED2CRTURI="pkcs11:type=cert;object=${ED2CRTN}"
+
+        title LINE "ED448 PKCS11 URIS"
+        echo "${ED2BASEURIWITHPINVALUE}"
+        echo "${ED2BASEURIWITHPINSOURCE}"
+        echo "${ED2BASEURI}"
+        echo "${ED2PUBURI}"
+        echo "${ED2PRIURI}"
+        echo "${ED2CRTURI}"
+    fi
+fi
 
 title PARA "generate RSA key pair, self-signed certificate, remove public key"
 KEYID='0005'
@@ -451,6 +455,18 @@ export EDBASEURI="${EDBASEURI}"
 export EDPUBURI="${EDPUBURI}"
 export EDPRIURI="${EDPRIURI}"
 export EDCRTURI="${EDCRTURI}"
+DBGSCRIPT
+fi
+
+if [ -n "${ED2BASEURI}" ]; then
+    cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
+
+export ED2BASEURIWITHPINVALUE="${ED2BASEURIWITHPINVALUE}"
+export ED2BASEURIWITHPINSOURCE="${ED2BASEURIWITHPINSOURCE}"
+export ED2BASEURI="${ED2BASEURI}"
+export ED2PUBURI="${ED2PUBURI}"
+export ED2PRIURI="${ED2PRIURI}"
+export ED2CRTURI="${ED2CRTURI}"
 DBGSCRIPT
 fi
 

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -121,4 +121,34 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed "s/^pkcs11-module-token-pin.*$/##nopin/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.nopin"
+OPENSSL_CONF=${OPENSSL_CONF}.nopin
+
+title PARA "Test interactive Login on key without ALWAYS AUTHENTICATE"
+# shellcheck disable=SC2153 # It is correctly defined in the testvars
+output=$(expect -c "spawn -noecho $CHECKER ${TESTBLDDIR}/tsession \"$EDBASEURI\";
+                expect \"Enter PIN for PKCS#11 Token (Slot *:\" {
+                    send \"${PINVALUE}\r\"; exp_continue; }
+                expect \"ALL A-OK\";")
+FAIL=0
+echo "$output" | grep "Enter PIN for PKCS#11 Token (Slot .*):" > /dev/null 2>&1 || FAIL=1
+prompts=$(echo "$output" | grep -c "Enter PIN for PKCS#11 Token (Slot .*):" 2>&1)
+# 1 login to read key only
+if [ "$prompts" -ne "1" ]; then
+    echo "Failed receive expected amount of prompts (got $prompts, expected 1)"
+    FAIL=2
+fi
+if [ $FAIL -eq 1 ]; then
+    echo "Failed to obtain expected prompt"
+fi
+if [ $FAIL -ne 0 ]; then
+    echo
+    echo "Original command output:"
+    echo "$output"
+    echo
+    exit 1
+fi
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+
 exit 0

--- a/tests/tedwards
+++ b/tests/tedwards
@@ -103,9 +103,9 @@ if [[ -n $ED2BASEURI ]]; then
     
     title PARA "Test EVP_PKEY_eq on public ED448 key via import"
     $CHECKER "${TESTBLDDIR}/tcmpkeys" "$ED2PUBURI" "${TMPPDIR}"/ed2out.pub
-    title PARA "Match private ED key against public key"
+    title PARA "Match private ED448 key against public key"
     $CHECKER "${TESTBLDDIR}/tcmpkeys" "$ED2PRIURI" "${TMPPDIR}"/ed2out.pub
-    title PARA "Match private ED key against public key (commutativity)"
+    title PARA "Match private ED448 key against public key (commutativity)"
     $CHECKER "${TESTBLDDIR}/tcmpkeys" "${TMPPDIR}"/ed2out.pub "$ED2PRIURI"
 fi
 

--- a/tests/tgenkey.c
+++ b/tests/tgenkey.c
@@ -268,7 +268,7 @@ static void gen_keys(const char *key_type, const char *label, const char *idhex,
     OSSL_STORE_close(store);
 }
 
-static void sign_test(const char *label, bool fail)
+static void sign_test(const char *label, const EVP_MD *md, bool fail)
 {
     OSSL_STORE_CTX *store;
     OSSL_STORE_SEARCH *search;
@@ -324,7 +324,7 @@ static void sign_test(const char *label, bool fail)
         exit(EXIT_FAILURE);
     }
 
-    ret = EVP_DigestSignInit(ctx, &pctx, EVP_sha256(), NULL, privkey);
+    ret = EVP_DigestSignInit(ctx, &pctx, md, NULL, privkey);
     if (ret == 0) {
         fprintf(stderr, "Failed to init Sig Ctx\n");
         exit(EXIT_FAILURE);
@@ -434,6 +434,9 @@ int main(int argc, char *argv[])
             params[2] = OSSL_PARAM_construct_end();
 
             gen_keys("RSA", label, idhex, params, false);
+
+            sign_test(label, EVP_sha256(), false);
+
             free(label);
             free(uri);
 
@@ -490,6 +493,9 @@ int main(int argc, char *argv[])
             params[2] = OSSL_PARAM_construct_end();
 
             gen_keys("EC", label, idhex, params, false);
+
+            sign_test(label, EVP_sha256(), false);
+
             free(label);
             free(uri);
 
@@ -520,7 +526,7 @@ int main(int argc, char *argv[])
 
             gen_keys("RSA", label, idhex, params, false);
 
-            sign_test(label, true);
+            sign_test(label, EVP_sha256(), true);
 
             params[1] = OSSL_PARAM_construct_utf8_string("pkcs11_key_usage",
                                                          (char *)bad_usage, 0);
@@ -552,6 +558,9 @@ int main(int argc, char *argv[])
             params[1] = OSSL_PARAM_construct_end();
 
             gen_keys(tests[num], label, idhex, params, false);
+
+            sign_test(label, NULL, false);
+
             free(label);
             free(uri);
         } else {


### PR DESCRIPTION
#### Description

There was a logic error in creating the eddsa signature params for pkcs11, that when `OSSL_SIGNATURE_PARAM_INSTANCE` OSSL_PARAM was not provided, the pkcs11 parameters were not created and Ed448 operations were failing.

For some reason, the pkcs11 parameters are required for the Ed448 even if no prehashing nor context is used.

Additionally, if only the context is provided by OpenSSL/caller, we also need to provide the correct parameters, which was not handled before.

Unfortunately, this is not the issue I was after during last days.

#### Checklist

- [X] Code modified for feature
- [X] Test suite updated with functionality tests



#### Reviewer's checklist:

- [x] There is a test suite reasonably covering new functionality or modifications
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
