### PR TITLE
Enable RSA-PSS with ALLOWED_MECHANISMS tests for kryoptic

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -140,7 +140,7 @@ tests = {
   'hkdf': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'imported' : {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'rsapss': {'suites': ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']},
-  'rsapssam': {'suites': ['softhsm']},
+  'rsapssam': {'suites': ['softhsm', 'kryoptic']},
   'genkey': {'suites': ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']},
   'session': {'suites': ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']},
   'rand': {'suites': ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']},

--- a/tests/tlsctx.c
+++ b/tests/tlsctx.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     SSL_CTX_free(ctx);
 
     env = getenv("SUPPORT_RSA_PKCS1_ENCRYPTION");
-    if (env && env[0] == "1") {
+    if (env && env[0] == '1') {
         test_pkcs1_with_tls_padding();
     }
 

--- a/tests/trsapssam
+++ b/tests/trsapssam
@@ -52,7 +52,7 @@ if [ $FAIL -eq 0 ]; then
 fi
 output="$helper_output"
 FAIL=0
-echo "$output" | grep "mechanism not allowed with this key" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "Public Key operation error" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -ne 0 ]; then
     echo "Signature seem to have failed for unrelated reasons"
     echo "$output";


### PR DESCRIPTION
#### Description

For some reason, with the kryoptic backend we are not getting all the same
errors, but this one is common.

There is also one warning that I missed in the previous PR

#### Checklist

- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
