### PR TITLE
Fixes latchset/pkcs11-provider#502 Explicitly request EcDH derive return key as a session object

### DIFF
--- a/src/exchange.c
+++ b/src/exchange.c
@@ -213,12 +213,13 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     CK_BBOOL val_true = CK_TRUE;
     CK_BBOOL val_false = CK_FALSE;
     CK_ULONG key_size = outlen;
-    CK_ATTRIBUTE key_template[5] = {
+    CK_ATTRIBUTE key_template[6] = {
         { CKA_CLASS, &key_class, sizeof(key_class) },
         { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
         { CKA_SENSITIVE, &val_false, sizeof(val_false) },
         { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
         { CKA_VALUE_LEN, &key_size, sizeof(key_size) },
+        { CKA_TOKEN, &val_false, sizeof(val_false) },
     };
     CK_MECHANISM mechanism;
     P11PROV_SESSION *session = NULL;
@@ -280,7 +281,7 @@ static int p11prov_ecdh_derive(void *ctx, unsigned char *secret,
     }
 
     ret = p11prov_derive_key(ecdhctx->provctx, slotid, &mechanism, handle,
-                             key_template, 5, &session, &secret_handle);
+                             key_template, 6, &session, &secret_handle);
     if (ret != CKR_OK) {
         return RET_OSSL_ERR;
     }


### PR DESCRIPTION
Bugfix for OpenSC PKCS#11 provider compatibility.

#### Description

OpenSC PKCS#11 module fail C_DeriveKey operations with CKR_TEMPLATE_INCOMPLETE error code when used with PKCS#15 smart cards unless CKA_TOKEN attribute is set on the request template. Fix by always requesting session keys (CKA_TOKEN=false). This is also supposed to be the default by PKCS#11 v3.1 - thus not changing the existing behavior.

Current test suite does not address the issue, as the subject failure depends on the  underlying PKCS#11 module, and the cryptographic token used, thus no changes on tests. 

#### Checklist

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
