### PR TITLE
Try to avoid requesting a PIN just to load a cert

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -97,7 +97,8 @@ static void store_fetch(struct p11prov_store_ctx *ctx,
         || login_behavior == PUBKEY_LOGIN_ALWAYS) {
         login = true;
     }
-    if (p11prov_uri_get_class(ctx->parsed_uri) == CKO_PUBLIC_KEY
+    if ((p11prov_uri_get_class(ctx->parsed_uri) == CKO_PUBLIC_KEY
+         || p11prov_uri_get_class(ctx->parsed_uri) == CKO_CERTIFICATE)
         && login_behavior != PUBKEY_LOGIN_ALWAYS) {
         login = false;
     }


### PR DESCRIPTION
#### Description

In many tokens certificates can be loaded without logging into the token,
If the URI unequivocally refrences a certificate object, try to load it without forsing a login.

Fixes #508

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
