### PR TITLE
Drop SoftHSM from the matrix for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14]
-        token: [softokn, softhsm]
+        token: [softokn]
     steps:
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
We build on Mac OS X just to ensure the code builds, however we do not absolutely need to run multiple tests, as functionality with the various tokens is already tested in the rest of the CI

Given lately MAc OS X 14 + SoftHSM always times out, disable it from the matrix for now.

Note that the rest of the conditionals are intentionally preserved, so that we can simply re-add sofhtsm to the matrix should we want to.

Resloves #515 

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] ~Code modified for feature~
- [ ] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
