### PR TITLE
Drop use of certtool from setup

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -30,7 +30,7 @@ jobs:
           if [ -f /etc/fedora-release ]; then
             dnf -y install git clang gcc pkgconf-pkg-config meson \
               openssl-devel openssl diffutils expect \
-              softhsm opensc p11-kit-devel p11-kit-server gnutls-utils \
+              softhsm opensc p11-kit-devel p11-kit-server \
               nss-softokn nss-tools nss-softokn-devel \
               dnf-command\(debuginfo-install\) libasan
             dnf -y debuginfo-install openssl
@@ -40,7 +40,7 @@ jobs:
             apt-get -yq install git gcc clang meson \
               pkg-config libssl-dev openssl expect \
               procps libnss3 libnss3-tools libnss3-dev softhsm2 opensc p11-kit \
-              libp11-kit-dev p11-kit-modules gnutls-bin \
+              libp11-kit-dev p11-kit-modules \
               openssl-dbgsym libssl3t64-dbgsym
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               dnf -y install $dnf_opts \
                 git ${{ matrix.compiler }} meson which \
                 pkgconf-pkg-config openssl-devel openssl \
-                diffutils expect valgrind opensc gnutls-utils python3-six
+                diffutils expect valgrind opensc python3-six
               if [ "${{ matrix.token }}" = "softokn" ]; then
                 dnf -y install nss-softokn nss-tools nss-softokn-devel \
                   nss-devel
@@ -50,7 +50,7 @@ jobs:
               apt-get -q update
               apt-get -yq install git ${{ matrix.compiler }} meson \
                 pkg-config libssl-dev openssl expect \
-                valgrind procps opensc gnutls-bin python3-six
+                valgrind procps opensc python3-six
               if [ "${{ matrix.token }}" = "softokn" ]; then
                 apt-get -yq install libnss3 libnss3-tools libnss3-dev
               elif [ "${{ matrix.token }}" = "softhsm" ]; then

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -33,14 +33,13 @@ jobs:
                 pkgconf-pkg-config openssl-devel openssl xz \
                 nss-softokn nss-tools nss-softokn-devel \
                 softhsm opensc p11-kit-devel p11-kit-server \
-                rpm-build nss-devel gnutls-utils
+                rpm-build nss-devel
             elif [ -f /etc/debian_version ]; then
               apt-get -q update
               apt-get -yq install git gcc meson expect \
                 pkg-config libssl-dev openssl \
                 xz-utils libnss3 libnss3-tools libnss3-dev \
-                softhsm2 opensc p11-kit libp11-kit-dev p11-kit-modules \
-                gnutls-bin
+                softhsm2 opensc p11-kit libp11-kit-dev p11-kit-modules
             fi
 
       - name: Checkout Repository

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Dependencies
         run: |
             dnf -y install clang git meson cargo expect pkgconf-pkg-config \
-              openssl-devel openssl opensc p11-kit-devel gnutls-utils \
+              openssl-devel openssl opensc p11-kit-devel \
               gcc g++ sqlite-devel httpd bind9-next softhsm
 
       - name: Checkout Repository

--- a/.github/workflows/kryoptic.yml
+++ b/.github/workflows/kryoptic.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Dependencies
         run: |
             dnf -y install clang git meson cargo expect pkgconf-pkg-config \
-              openssl-devel openssl opensc p11-kit-devel gnutls-utils \
+              openssl-devel openssl opensc p11-kit-devel \
               gcc g++ sqlite-devel python3-six which
 
       - name: Checkout Repository

--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -29,7 +29,6 @@ BuildRequires: openssl
 BuildRequires: softhsm
 BuildRequires: opensc
 BuildRequires: p11-kit-devel
-BuildRequires: gnutls-utils
 BuildRequires: xz
 BuildRequires: expect
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -101,3 +101,14 @@ selfsign_cert() {
     ossl 'x509 -new -subj /CN=${SUBJ}/ -days 365 -extensions v3_ca -extfile ${OPENSSL_CONF} -out ${CERT} -outform PEM -signkey ${KEY} ${AARGS}'
     echo "$helper_output"
 }
+
+ptool() {
+    # NSS uses the second slot for certificates, so we need to provide the token
+    # label in the args to allow pkcs11-tool to find the right slot
+    CMDOPTS=(--module="${P11LIB}" --token-label="${TOKENLABEL}")
+    if [ -n "$P11DEFLOGIN" ]; then
+        CMDOPTS+=("${P11DEFLOGIN[@]}")
+    fi
+    CMDOPTS+=("$@")
+    $CHECKER pkcs11-tool "${CMDOPTS[@]}"
+}

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -93,23 +93,11 @@ fi
 selfsign_cert() {
     KEY="$1"
     export CERT="$2"
-    shift 2
+    export SUBJ="$3"
+    shift 3
     export AARGS="$*"
 
-    TMPCA=${TMPPDIR}/tmpca
-    TMP_OPENSSL_CONF=${OPENSSL_CONF}
-    sed -e "s|^dir .*|dir = ${TMPCA}|" \
-        "${OPENSSL_CONF}" > "${OPENSSL_CONF}.tmpca"
-    export OPENSSL_CONF=${OPENSSL_CONF}.tmpca
-
-    mkdir -p "${TMPCA}/newcerts" "${TMPCA}/private"
-    if [ ! -e "${TMPCA}/serial" ]; then
-        echo "01" > "${TMPCA}/serial"
-    fi
-    touch "${TMPCA}/index.txt"
-
     title PARA "Generating a new selfsigned certificate for ${KEY}"
-    ossl 'req -batch -noenc -x509 -new -key ${KEY} ${AARGS} -out ${CERT}'
+    ossl 'x509 -new -subj /CN=${SUBJ}/ -days 365 -extensions v3_ca -extfile ${OPENSSL_CONF} -out ${CERT} -outform PEM -signkey ${KEY} ${AARGS}'
     echo "$helper_output"
-    OPENSSL_CONF=${TMP_OPENSSL_CONF}
 }

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -4,3 +4,4 @@
 leak:/usr/lib/softhsm/libsofthsm2.so
 # and this is the path on Fedora
 leak:/usr/lib64/pkcs11/libsofthsm2.so
+leak:/usr/bin/pkcs11-tool

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,18 +34,6 @@ if get_option('enable_explicit_EC_test')
   conf_env.set('ENABLE_EXPLICIT_EC_TEST', '1')
 endif
 
-setup_script=find_program('setup.sh')
-foreach suite : ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']
-  test(
-    'setup',
-    setup_script,
-    args: suite,
-    suite: suite,
-    env: conf_env,
-    is_parallel: false,
-  )
-endforeach
-
 test_env = environment({
   'TEST_PATH': meson.current_source_dir(),
   'TESTBLDDIR': meson.current_build_dir(),
@@ -69,6 +57,7 @@ if valgrind.found()
   )
 endif
 
+setup_deps = []
 if get_option('b_sanitize') == 'address'
   preload_libasan = get_option('preload_libasan')
   if preload_libasan == 'auto'
@@ -85,10 +74,7 @@ if get_option('b_sanitize') == 'address'
     'fake_dlclose.c',
     name_prefix: '',
   )
-
-  test_env.set('ASAN_OPTIONS', 'fast_unwind_on_malloc=0:detect_leaks=1')
-  test_env.set('LSAN_OPTIONS', 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()))
-  test_env.set('FAKE_DLCLOSE', fake_dlclose.full_path())
+  setup_deps += [fake_dlclose]
 
   preload_env_var = 'LD_PRELOAD'
   if host_machine.system() == 'darwin'
@@ -98,12 +84,23 @@ if get_option('b_sanitize') == 'address'
   # LD_PRELOAD is needed before invoking openssl as it is not instrumented with
   # asan and asan needs to be loaded as a first dynamic library of the process.
   if preload_libasan != 'no'
-    test_env.set('CHECKER', 'env @0@=@1@:@2@'.format(preload_env_var, preload_libasan, fake_dlclose.full_path()))
+    checker = 'env @0@=@1@:@2@'.format(preload_env_var, preload_libasan, fake_dlclose.full_path())
   else
-    test_env.set('CHECKER', 'env @0@=@1@'.format(preload_env_var, fake_dlclose.full_path()))
+    checker = 'env @0@=@1@'.format(preload_env_var, fake_dlclose.full_path())
   endif
-endif
 
+  add_env = {
+    'ASAN_OPTIONS': 'fast_unwind_on_malloc=0:detect_leaks=1',
+    'LSAN_OPTIONS': 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()),
+    'FAKE_DLCLOSE': fake_dlclose.full_path(),
+    'CHECKER': checker,
+  }
+
+  foreach name, value : add_env
+    conf_env.set(name, value)
+    test_env.set(name, value)
+  endforeach
+endif
 
 test_programs = {
   'tsession': ['tsession.c'],
@@ -126,6 +123,19 @@ foreach t, sources : test_programs
                  include_directories: [configinc],
                  dependencies: [libcrypto, libssl])
   test_executables += [t]
+endforeach
+
+setup_script=find_program('setup.sh')
+foreach suite : ['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']
+  test(
+    'setup',
+    setup_script,
+    args: suite,
+    suite: suite,
+    env: conf_env,
+    is_parallel: false,
+    depends: setup_deps,
+  )
 endforeach
 
 tests = {

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -81,9 +81,7 @@ basicConstraints = critical,CA:true
 # left out by default.
 # keyUsage = cRLSign, keyCertSign
 # Include email address in subject alt name: another PKIX recommendation
-subjectAltName=email:copy
-# Copy issuer details
-issuerAltName=issuer:copy
+subjectAltName=email:pkcs11-provider-tests@example.org
 
 
 

--- a/tests/tcerts
+++ b/tests/tcerts
@@ -4,7 +4,7 @@
 
 source "${TESTSSRCDIR}/helpers.sh"
 
-title PARA "Check we can fetch certifiatce objects"
+title PARA "Check we can fetch certificate objects"
 
 ossl '
 x509 -in ${CRTURI} -subject -out ${TMPPDIR}/crt-subj.txt'

--- a/tests/test-wrapper
+++ b/tests/test-wrapper
@@ -31,11 +31,6 @@ else
     COMMAND="${TESTBLDDIR}/t${TEST_NAME}"
 fi
 
-# Run the tests under valgrind with appropriate flags
-if [ -n "$VALGRIND" ] && [ -n "$LOG_COMPILER" ]; then
-    CHECKER="$LOG_COMPILER"
-fi
-
 # for compiled tests, we need to add valgrind/checker
 if [ -f "${TEST_PATH}/t${TEST_NAME}.c" ]; then
     COMMAND="$CHECKER $COMMAND"

--- a/tests/tpinlock
+++ b/tests/tpinlock
@@ -14,10 +14,8 @@ BADPIN="bad"
 export BADPINURI="${PRIURI}?pin-value=${BADPIN}"
 export GOODPINURI="${PRIURI}?pin-value=${PINVALUE}"
 
-TOOLDEFARGS=("--module=${P11LIB}" "--token-label=${TOKENLABEL}")
-
 FAIL=0
-pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "PIN initialized" && FAIL=1
+ptool -T | grep "PIN initialized" && FAIL=1
 if [ $FAIL -eq 0 ]; then
     echo "Failed to detect PIN status"
     exit 1
@@ -26,15 +24,15 @@ fi
 # Kryoptic allows for 10 tries by default
 for i in {1..10}; do
     echo "Login attempt: $i"
-    pkcs11-tool "${TOOLDEFARGS[@]}" -l -I -p "${BADPIN}" && false
+    ptool -l -I -p "${BADPIN}" && false
     DETECT=0
-    pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "final user PIN try" && DETECT=1
+    ptool -T | grep "final user PIN try" && DETECT=1
     if [ $DETECT -eq 1 ]; then
         break
     fi
 done
 FAIL=0
-pkcs11-tool "${TOOLDEFARGS[@]}" -T | grep "final user PIN try" && FAIL=1
+ptool -T | grep "final user PIN try" && FAIL=1
 if [ $FAIL -eq 0 ]; then
     echo "Failed to reach "final try" status"
     exit 1
@@ -68,7 +66,7 @@ fi
 
 
 # Now reset the token counter with a good try
-pkcs11-tool "${TOOLDEFARGS[@]}" -l -T -p "${PINVALUE}"
+ptool -l -T -p "${PINVALUE}"
 
 # Now we test one operation with a good pin.
 # It should succeed

--- a/tests/ttls
+++ b/tests/ttls
@@ -109,6 +109,7 @@ run_tests() {
     if [[ -n "$RSAPSSPRIURI" ]]; then
         title PARA "Run sanity test with default values (RSA-PSS)"
         selfsign_cert "${RSAPSSPRIURI}" "${TMPPDIR}/rsapss-default.pem" \
+            "RSA-PSS_Default_Digest" \
             "-sigopt rsa_padding_mode:pss"
 
         run_test "$RSAPSSPRIURI" "${TMPPDIR}/rsapss-default.pem"
@@ -117,6 +118,7 @@ run_tests() {
     if [[ -n "$RSAPSS2PRIURI" ]]; then
         title PARA "Run sanity test with RSA-PSS and SHA256"
         selfsign_cert "${RSAPSS2PRIURI}" "${TMPPDIR}/rsapss-sha256.pem" \
+            "RSA-PSS_SHA256_Digest" \
             "-sigopt rsa_padding_mode:pss" \
             "-sigopt digest:sha256" \
             "-sigopt rsa_pss_saltlen:-1"

--- a/tests/ttlsfuzzer
+++ b/tests/ttlsfuzzer
@@ -68,6 +68,7 @@ run_tests() {
         # do selfsign now using openssl as certool can not create SPKI using
         # RSA-PSS
         selfsign_cert "${RSAPSSPRIURI}" "${TMPPDIR}/rsapss-default.pem" \
+            "RSA-PSS_CERT" \
             "-sigopt rsa_padding_mode:pss" \
             "-sigopt digest:sha256" \
             "-sigopt rsa_pss_saltlen:-1"


### PR DESCRIPTION
#### Description

The openssl command is sufficient to generate and sign all the certs we need for the tests, so drop the use of certtool which reduce our dependency graph for building and testing

Fixes #481 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] ~Code modified for feature~
- [x] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
