### PR TITLE
tests: extend FIPS mode to NSS softokn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
         if : ( steps.nss-version-check.outputs.skiptest != 'true' )
         run: |
             if [ "${{ matrix.compiler }}" = "gcc" -a \( "${{ matrix.name }}" = "centos9" -o "${{ matrix.name }}" = "centos10" \) ]; then
-              OPENSSL_FORCE_FIPS_MODE=1 \
+              PKCS11_PROVIDER_FORCE_FIPS_MODE=1 \
               meson test --num-processes 1 -C builddir
             fi
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -26,7 +26,7 @@ if [[ "$OPENSC_VERSION" -le "25" ]]; then
 fi
 
 # FIPS Mode
-if [[ "${OPENSSL_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]]; then
+if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]]; then
     # We can not use Edwards curves in FIPS mode
     SUPPORT_ED25519=0
     SUPPORT_ED448=0
@@ -44,6 +44,17 @@ if [[ "${OPENSSL_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled
     # We also need additional configuration in openssl.cnf to assume the token
     # is FIPS token
     TOKENOPTIONS="pkcs11-module-assume-fips = true"
+
+    # Force OpenSSL FIPS mode
+    export OPENSSL_FORCE_FIPS_MODE=1
+
+    # Force NSS softokn FIPS mode
+    export NSS_FIPS=1
+
+    # NSS softokn requires stronger PIN in FIPS mode
+    PINVALUE="fo0m4nchU"
+else
+    PINVALUE="12345678"
 fi
 
 # Temporary dir and Token data dir
@@ -55,7 +66,6 @@ fi
 mkdir "${TMPPDIR}"
 mkdir "${TOKDIR}"
 
-PINVALUE="12345678"
 PINFILE="${TMPPDIR}/pinfile.txt"
 echo ${PINVALUE} > "${PINFILE}"
 export GNUTLS_PIN=$PINVALUE
@@ -607,6 +617,19 @@ cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
 #export PKCS11SPY="${P11LIB}"
 #export PKCS11_PROVIDER_MODULE=/usr/lib64/pkcs11-spy.so
 DBGSCRIPT
+
+if [ -n "${OPENSSL_FORCE_FIPS_MODE}" ]; then
+    cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
+export OPENSSL_FORCE_FIPS_MODE=1
+DBGSCRIPT
+fi
+
+if [ -n "${NSS_FIPS}" ]; then
+    cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
+export NSS_FIPS=1
+DBGSCRIPT
+fi
+
 gen_unsetvars
 
 title ENDSECTION

--- a/tests/softokn-init.sh
+++ b/tests/softokn-init.sh
@@ -16,8 +16,13 @@ certutil -N -d "${TOKDIR}" -f "${PINFILE}"
 export P11LIB="${SOFTOKNPATH%%/}/libsoftokn3${SHARED_EXT}"
 export NSS_LIB_PARAMS="configDir=${TOKDIR}"
 
-export TOKENLABEL="NSS Certificate DB"
-export TOKENLABELURI="NSS%20Certificate%20DB"
+if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]]; then
+    export TOKENLABEL="NSS FIPS 140-2 Certificate DB"
+    export TOKENLABELURI="NSS%20FIPS%20140-2%20Certificate%20DB"
+else
+    export TOKENLABEL="NSS Certificate DB"
+    export TOKENLABELURI="NSS%20Certificate%20DB"
+fi
 
 export TOKENOPTIONS="${TOKENOPTIONS}\npkcs11-module-quirks = no-operation-state no-allowed-mechanisms"
 export TOKENCONFIGVARS="export NSS_LIB_PARAMS=configDir=${TOKDIR}"


### PR DESCRIPTION
#### Description

This extend FIPS mode testing to NSS softokn as well (originally we only forced OpenSSL FIPS mode).

#### Checklist

N/A

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
