### PR TITLE
ci: Fix DNF caching

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /var/cache/dnf
+            /var/cache/libdnf5
           key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
 
       - name: Install Build Requirements
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /var/cache/dnf
+            /var/cache/libdnf5
           key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
 
       - name: Install Dependencies

--- a/.github/workflows/kryoptic.yml
+++ b/.github/workflows/kryoptic.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /var/cache/dnf
+            /var/cache/libdnf5
           key: ${{ runner.os }}-dnf-${{ steps.get-date.outputs.date }}
 
       - name: Install Dependencies


### PR DESCRIPTION
#### Description

The DNF changed location of the  cache files in Fedora so the caching of metadata and downloads did not work. Same issue and fix as in latchset/kryoptic#167.

#### Checklist

- [X] Just CI update

#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
