### PR TITLE
Debug logs extra

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -1439,6 +1439,8 @@ static int p11prov_ec_import_genr(CK_KEY_TYPE key_type, void *keydata,
     }
 
     if (class == CKO_DOMAIN_PARAMETERS && key_type != CKK_EC) {
+        P11PROV_debug("ec import of key %p domain parameters is not for EC",
+                      key);
         /* There are no Domain parameters associated with an
          * ECX or RSA key in OpenSSL, so there is nothing really
          * we can import */

--- a/src/provider.c
+++ b/src/provider.c
@@ -1464,6 +1464,9 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
     }
     ctx->handle = handle;
 
+    P11PROV_debug("Starting provider %s %d.%d", PACKAGE_NAME, PACKAGE_MAJOR,
+                  PACKAGE_MINOR);
+
     ret = pthread_rwlock_init(&ctx->quirk_lock, NULL);
     if (ret != 0) {
         ret = errno;

--- a/src/session.c
+++ b/src/session.c
@@ -316,20 +316,24 @@ static CK_RV session_check(P11PROV_SESSION *session, CK_FLAGS flags)
     int ret;
 
     if (!session) {
+        P11PROV_debug("Checked session not set");
         return CKR_GENERAL_ERROR;
     }
 
     /* lockless check, if this fails in any way it is bad regardless */
     if (!session->in_use) {
+        P11PROV_debug("Checked session %lu in use", session->session);
         return CKR_GENERAL_ERROR;
     }
 
     /* no handle, nothing to check */
     if (session->session == CK_INVALID_HANDLE) {
+        P11PROV_debug("Checked session %lu handle invalid", session->session);
         return CKR_OK;
     }
 
     /* check that the pkcs11 session is still ok */
+    P11PROV_debug("Checking session %lu", session->session);
     ret = p11prov_GetSessionInfo(session->provctx, session->session,
                                  &session_info);
     if (ret == CKR_OK) {
@@ -779,6 +783,8 @@ static CK_RV slot_login(P11PROV_SLOT *slot, P11PROV_URI *uri,
     CK_FLAGS flags = DEFLT_SESSION_FLAGS;
     int num_open_sessions = 0;
     CK_RV ret;
+
+    P11PROV_debug("Slot login (slot=%p, uri=%p)", slot, uri);
 
     /* try to get a login_session */
     ret = fetch_session(pool, flags, true, &session);

--- a/src/slot.c
+++ b/src/slot.c
@@ -243,6 +243,7 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
             && (slot->token.flags & CKF_TOKEN_INITIALIZED)
             && (!(slot->token.flags & CKF_USER_PIN_LOCKED))) {
             sctx->default_slot = slot->id;
+            P11PROV_debug("Slot(%lu) set as a default slot", slot->id);
         }
 
         P11PROV_debug_slot(ctx, slot->id, &slot->slot, &slot->token,


### PR DESCRIPTION
#### Description

This adds some debug logs that I have been using for debugging various issues with pkcs11-proxy. There are no changes in logic (except some renaming so logging can happen after the locked section). It is quite useful to see how the objects are getting to the pool which also uncovered one issue in the provider (different PR will be created for that).

I'm of course happy to remove the ones that you don't find useful - basically just trying to minimize the diff for my branch.

#### Checklist

- [x] Code modified for feature


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
