### PR TITLE
Debug logs time

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 int debug_level = -1;
-FILE *stddebug = NULL;
+static FILE *stddebug = NULL;
 
 /* this function relies on being called by P11PROV_debug, after
  * an __atomic_compare_exchange_n sets debug_lazy_init to -1,
@@ -69,6 +69,15 @@ void p11prov_debug(const char *file, int line, const char *func,
 {
     const char newline[] = "\n";
     va_list args;
+    struct timespec ts;
+    struct tm tm_info;
+    char timebuf[64];
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+    localtime_r(&ts.tv_sec, &tm_info);
+    strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M:%S", &tm_info);
+
+    fprintf(stddebug, "[%s.%03ld] ", timebuf, ts.tv_nsec / 1000000);
 
     if (file) {
         fprintf(stddebug, "[%s:%d] ", file, line);


### PR DESCRIPTION
#### Description

This PR adds a configurable time entry to the debug log. The first commit adds it as disable by default and the second one enables it by default (option can still be used to disable it in that case). I find it more useful to have time there as my use case involved correlation with other logs. But I understand if you prefer not to have it enabled by default. In such case I will remove the second commit.

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
