### PR TITLE
Prevent removing duplicated objects from pool

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -32,6 +32,7 @@ struct p11prov_crt {
 struct p11prov_obj {
     P11PROV_CTX *ctx;
     bool raf; /* re-init after fork */
+    bool dup; /* duplicated */
 
     CK_SLOT_ID slotid;
     CK_OBJECT_HANDLE handle;
@@ -220,8 +221,8 @@ static void obj_rm_from_pool(P11PROV_OBJ *obj)
     P11PROV_OBJ_POOL *pool;
     CK_RV ret;
 
-    if (obj->slotid == CK_UNAVAILABLE_INFORMATION) {
-        /* a mock object */
+    if (obj->dup || obj->slotid == CK_UNAVAILABLE_INFORMATION) {
+        /* a duplicate or a mock object */
         return;
     }
 
@@ -3395,6 +3396,7 @@ static CK_RV return_dup_key(P11PROV_OBJ *dst, P11PROV_OBJ *src)
         }
         dst->numattrs++;
     }
+    dst->dup = true;
 
     return CKR_OK;
 }


### PR DESCRIPTION
#### Description

This PR prevents attempt to remove objects that have been created by duplication. Those objects have never been added to the pool but they are still attempted to be removed which results in an error.


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Test suite updated with tests (still need to figure this out)


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
