### PR TITLE
packaging: Enable gpgcheck by default for downstream builds

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -63,5 +63,5 @@ jobs:
         run: |
           mkdir -p rpmbuild/SOURCES
           cp builddir/meson-dist/pkcs11-provider*tar.xz rpmbuild/SOURCES/
-          rpmbuild --define "_topdir $PWD/rpmbuild" -ba \
+          rpmbuild --define "_topdir $PWD/rpmbuild" -ba --without=gpgcheck \
               packaging/pkcs11-provider.spec

--- a/packaging/pkcs11-provider.spec
+++ b/packaging/pkcs11-provider.spec
@@ -1,5 +1,5 @@
 #Enable gpg signature verification
-%bcond_with gpgcheck
+%bcond gpgcheck 1
 
 Name:          pkcs11-provider
 Version:       1.0


### PR DESCRIPTION
#### Description

Enable gpgcheck by default for downstream builds (so it is not forgotten) but disable it in the ci as we do not have signed tarballs.

#### Checklist

--

#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [ ] ~There is a test suite reasonably covering new functionality or modifications~
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
