### PR TITLE
Correctly handle some aspects of key import

### DIFF
--- a/tests/tfork.c
+++ b/tests/tfork.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
     pid_t pid;
     int status;
 
-    key = util_gen_key("Fork-Test");
+    key = util_gen_key("RSA", "Fork-Test");
 
     /* test a simple op first */
     sign_op(key, -1);

--- a/tests/tpkey.c
+++ b/tests/tpkey.c
@@ -114,6 +114,30 @@ static void check_public_info(EVP_PKEY *key)
     BIO_free(membio);
 }
 
+static int check_peer_ec_key_copy(void)
+{
+    EVP_PKEY *key;
+    size_t key_bits;
+    EVP_PKEY *peer_key;
+    size_t peer_key_bits;
+
+    key = util_gen_key("P-256", "Pkey peer copy Test");
+    key_bits = EVP_PKEY_bits(key);
+
+    peer_key = EVP_PKEY_new();
+    EVP_PKEY_copy_parameters(peer_key, key);
+    peer_key_bits = EVP_PKEY_bits(peer_key);
+
+    if (key_bits != peer_key_bits) {
+        fprintf(stderr, "key_bits(%ld) != peer_key_bits(%ld)\n", key_bits,
+                peer_key_bits);
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_free(peer_key);
+    EVP_PKEY_free(key);
+}
+
 int main(int argc, char *argv[])
 {
     const char *data = "Sign Me!";
@@ -121,7 +145,7 @@ int main(int argc, char *argv[])
     size_t siglen;
     EVP_PKEY *key;
 
-    key = util_gen_key("Pkey sigver Test");
+    key = util_gen_key("RSA", "Pkey sigver Test");
 
     /* test a simple op first */
     sign_op(key, data, sizeof(data), &sig, &siglen);
@@ -129,6 +153,10 @@ int main(int argc, char *argv[])
     verify_op(key, data, sizeof(data), sig, siglen);
 
     check_public_info(key);
+
+    check_peer_ec_key_copy();
+
+    EVP_PKEY_free(key);
 
     PRINTERR("ALL A-OK!\n");
     exit(EXIT_SUCCESS);

--- a/tests/util.h
+++ b/tests/util.h
@@ -20,4 +20,4 @@ void ossl_err_print(void);
 EVP_PKEY *load_key(const char *uri);
 X509 *load_cert(const char *uri, const UI_METHOD *ui_method, void *ui_data);
 void hexify(char *out, unsigned char *byte, size_t len);
-EVP_PKEY *util_gen_key(const char *label);
+EVP_PKEY *util_gen_key(const char *type, const char *label);


### PR DESCRIPTION
#### Description

OpenSSL assumes you can create a new EC key by copy the domain parameters from a peer key first (to establish a compatible key type for operations like ECDH), and only later generates the private key material.
    
Better identify those keys by assigning the CKO_DOMAIN_PARAMETER class to them once parameters are set. We do not have a fully formed key at this point but we already have a bunch of parameter set so this also allows to make decisions on what should or should not be changed anymore at this point. (for example this now will prevent re-importing other parameters over the key).
    
Fixes #543

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [ ] ~Test suite updated with negative tests~
- [ ] ~Documentation updated~


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
