### PR TITLE
tests: extend FIPS mode to NSS softokn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
         if : ( steps.nss-version-check.outputs.skiptest != 'true' )
         run: |
             if [ "${{ matrix.compiler }}" = "gcc" -a \( "${{ matrix.name }}" = "centos9" -o "${{ matrix.name }}" = "centos10" \) ]; then
-              OPENSSL_FORCE_FIPS_MODE=1 \
+              PKCS11_PROVIDER_FORCE_FIPS_MODE=1 \
               meson test --num-processes 1 -C builddir
             fi
 

--- a/tests/softokn-init.sh
+++ b/tests/softokn-init.sh
@@ -16,8 +16,13 @@ certutil -N -d "${TOKDIR}" -f "${PINFILE}"
 export P11LIB="${SOFTOKNPATH%%/}/libsoftokn3${SHARED_EXT}"
 export NSS_LIB_PARAMS="configDir=${TOKDIR}"
 
-export TOKENLABEL="NSS Certificate DB"
-export TOKENLABELURI="NSS%20Certificate%20DB"
+if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]]; then
+    export TOKENLABEL="NSS FIPS 140-2 Certificate DB"
+    export TOKENLABELURI="NSS%20FIPS%20140-2%20Certificate%20DB"
+else
+    export TOKENLABEL="NSS Certificate DB"
+    export TOKENLABELURI="NSS%20Certificate%20DB"
+fi
 
 export TOKENOPTIONS="${TOKENOPTIONS}\npkcs11-module-quirks = no-operation-state no-allowed-mechanisms"
 export TOKENCONFIGVARS="export NSS_LIB_PARAMS=configDir=${TOKDIR}"

--- a/tests/tcms
+++ b/tests/tcms
@@ -4,6 +4,11 @@
 
 source "${TESTSSRCDIR}/helpers.sh"
 
+if [[ "$NSS_FIPS" = "1" ]] && [[ "$TOKENTYPE" = "softokn" ]]; then
+    title "ECDH tests are not supported in FIPS for softokn token -- skipping"
+    exit 77;
+fi
+
 MESSAGEFILE=${TMPPDIR}/cms-message.txt
 echo "CMS Test Message" > "${MESSAGEFILE}"
 

--- a/tests/tecdh
+++ b/tests/tecdh
@@ -4,6 +4,11 @@
 
 source "${TESTSSRCDIR}/helpers.sh"
 
+if [[ "$NSS_FIPS" = "1" ]] && [[ "$TOKENTYPE" = "softokn" ]]; then
+    title "ECDH tests are not supported in FIPS for softokn token -- skipping"
+    exit 77;
+fi
+
 title PARA "ECDH Exchange"
 ossl '
 pkeyutl -derive -inkey ${ECBASEURI}

--- a/tests/thkdf
+++ b/tests/thkdf
@@ -4,6 +4,11 @@
 
 source "${TESTSSRCDIR}/helpers.sh"
 
+if [[ "$NSS_FIPS" = "1" ]] && [[ "$TOKENTYPE" = "softokn" ]]; then
+    title "ECDH tests are not supported in FIPS for softokn token -- skipping"
+    exit 77;
+fi
+
 title PARA "HKDF Derivation"
 export HKDF_HEX_SECRET=ffeeddccbbaa
 export HKDF_HEX_SALT=ffeeddccbbaa

--- a/tests/ttls
+++ b/tests/ttls
@@ -4,6 +4,11 @@
 
 source "${TESTSSRCDIR}/helpers.sh"
 
+if [[ "$NSS_FIPS" = "1" ]] && [[ "$TOKENTYPE" = "softokn" ]]; then
+    title "ECDH tests are not supported in FIPS for softokn token -- skipping"
+    exit 77;
+fi
+
 title PARA "Test SSL_CTX creation"
 $CHECKER "${TESTBLDDIR}/tlsctx"
 


### PR DESCRIPTION
#### Description

In CI we have tests running when OpenSSL is in FIPS mode. This extends FIPS testing to NSS softokn as wll. There are four tests that need to be skipped for NSS softokn in FIPS mode - ecdh, hkdf, tls and cms. They are doing the key derivation and softokn has additional restrictions in FIPS for it.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests (N/A)
- [ ] Test suite updated with negative tests (N/A)
- [ ] Documentation updated (N/A)


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
