### PR TITLE
Prevent login prompt when reading public RSA keys

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,6 +20,7 @@ jobs:
           additional_files: >-
             tbasic
             tcerts
+            tcms
             tdemoca
             tdigest
             tecc
@@ -27,14 +28,20 @@ jobs:
             tecxc
             tedwards
             test-wrapper
+            tforking
             thkdf
+            timported
             toaepsha2
             top_state
             tpem_encoder
+            tpinlock
             tpubkey
             trand
+            trsa
             trsapss
+            trsapssam
             ttls
+            ttlsfuzzer
             turi
           check_together: 'yes'
         env:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ check-style-show:
 check-style-fix:
 	git diff -U0 --no-color --relative origin/main -- ':!src/pkcs11.h' | $(CLANG_FORMAT_DIFF) -i -p1
 
+shellcheck:
+	shellcheck -P tests -e SC2016 tests/*.sh tests/test-wrapper tests/t{basic,certs,cms,democa,digest,ecc,ecdh,ecxc,edwards,forking,hkdf,imported,oaepsha2,op_state,pem_encoder,pinlock,pubkey,rand,rsa,rsapss,rsapssam,tls,tlsfuzzer,uri}
+
 generate-code:
 	for pfile in src/*.pre; do \
 		gfile=`echo $${pfile} | sed s/\.pre/\.gen\.c/`; \

--- a/src/objects.c
+++ b/src/objects.c
@@ -1289,7 +1289,7 @@ P11PROV_OBJ *p11prov_obj_find_associated(P11PROV_OBJ *obj,
     slotid = p11prov_obj_get_slotid(obj);
 
     ret = p11prov_get_session(obj->ctx, &slotid, NULL, NULL,
-                              CK_UNAVAILABLE_INFORMATION, NULL, NULL, true,
+                              CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
                               false, &session);
     if (ret != CKR_OK) {
         goto done;

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -160,15 +160,13 @@ ca_sign() {
 
     CERTSUBJ="/O=PKCS11 Provider/CN=$CN/"
     SIGNKEY="pkcs11:object=$CACRTN;token=$TOKENLABELURI;type=private"
-    CACRT="pkcs11:object=$CACRTN;token=$TOKENLABELURI;type=cert"
     CERTPUBKEY="pkcs11:object=$LABEL;token=$TOKENLABELURI;type=public"
 
     OPENSSL_CMD="x509
         -new -subj \"${CERTSUBJ}\" -days 365 -set_serial \"${SERIAL}\"
         -extensions v3_req -extfile \"${OPENSSL_CONF}\"
         -out \"${TMPPDIR}/${LABEL}.crt\" -outform DER
-        -force_pubkey \"${CERTPUBKEY}\" -CAkey \"${SIGNKEY}\"
-        -CA \"${CACRT}\""
+        -force_pubkey \"${CERTPUBKEY}\" -signkey \"${SIGNKEY}\""
 
     if [ "$SIGOPT" = "PSS" ]; then
         OPENSSL_CMD+=" -sigopt rsa_padding_mode:pss"

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -82,6 +82,21 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 
+# regression test for https://github.com/latchset/pkcs11-provider/issues/547
+title PARA "Make sure we are not prompted for pin to read public RSA key"
+# shellcheck disable=SC2153 # PUBURI is assigned in testvars
+expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PUBURI}\" -pubin -pubout -out -;
+    expect {
+        \"Enter PIN for PKCS#11 Token (Slot *:\" {
+            exit 1; }
+        timeout { exit 2; }
+        eof { exit 0; }
+    }" || {
+    echo "Unexpected pin prompt received!"
+    exit 1
+}
+
+
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 
 title PARA "Test EVP_PKEY_eq on public RSA key both on token"


### PR DESCRIPTION
#### Description

The #547 describes an issue that since 16b491c  the reading of public RSA keys prompts for a PIN. This is due to search for allowed mechanisms on associated private key, which is done in any case the public key does not have allowed_mechanisms attribute.

This PR has a reproducer for #547 and a partial fix for tokens not supporting allowed mechanisms.

For the remaining, it will likely need some more digging or workaround as we should login if the pin is provided by some means, but we should not if it is not. I did not manage to express this yet in the code.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [X] Code modified for feature
- [X] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
