### PR TITLE
CI: split openssl action into two jobs

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -8,8 +8,8 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
-    name: CI with openssl master 
+  setup:
+    name: Build OpenSSL from master branch 
     runs-on: ubuntu-22.04
     container: fedora:latest
     steps:
@@ -29,10 +29,7 @@ jobs:
       - name: Install Dependencies
         run: |
             dnf -y install perl-FindBin perl-IPC-Cmd perl-File-Compare \
-              perl-File-Copy perl-Pod-Html clang git meson cargo expect \
-              pkgconf-pkg-config opensc p11-kit-devel gcc g++ sqlite-devel \
-              python3-six which cmake nss-softokn nss-tools nss-softokn-devel \
-              nss-devel softhsm
+              perl-File-Copy perl-Pod-Html git clang
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -60,6 +57,48 @@ jobs:
         run: |
           cd openssl
           ./config --prefix=/opt && make && make install_sw
+
+  build:
+    name: Build and test pkcs11-provider
+    needs: setup
+    runs-on: ubuntu-22.04
+    container: fedora:latest
+    steps:
+      - name: Get Date for DNF cache entry
+        id: get-date-dnf
+        run: |
+          echo "date=$(/bin/date -u "+%Y%V")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: DNF cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/libdnf5
+          key: ${{ runner.os }}-dnf-openssl-${{ steps.get-date-dnf.outputs.date }}
+
+      - name: Install Dependencies
+        run: |
+            dnf -y install clang meson cargo expect pkgconf-pkg-config opensc \
+              p11-kit-devel gcc g++ sqlite-devel python3-six which cmake \
+              nss-softokn nss-tools nss-softokn-devel nss-devel softhsm
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Date for /opt cache entry
+        id: get-date-opt
+        run: |
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Fetch built openssl from cache
+        id: cache-opt
+        uses: actions/cache@v4
+        with:
+          path: /opt
+          key: ${{ runner.os }}-opt-${{ steps.get-date-opt.outputs.date }}
+          fail-on-cache-miss: true
 
       - name: Setup and build pkcs11-provider
         run: |


### PR DESCRIPTION
#### Description

Cache actions only caches when job succeeds and since we can expect CI tests to fails during the development work OpenSSL built in /opt might not get cached during multiple executions within the same PR.

Separating openssl build into its own job make it always succeed and cache is stored even if the tests from the second job fails.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests (N/A)
- [ ] Test suite updated with negative tests (N/A)
- [ ] Documentation updated (N/A)


#### Reviewer's checklist:

- [ ] ~Any issues marked for closing are addressed~
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] ~This feature/change has adequate documentation added~
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] ~Coverity Scan has run if needed (code PR) and no new defects were found~
