### PR TITLE
Ensure CMS with Explicit EC works

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         name: [fedora, debian, centos9, centos10, ubuntu, almalinux8]
         compiler: [gcc, clang]
-        token: [softokn, softhsm]
+        token: [softokn, softhsm, kryoptic]
         include:
           - name: fedora
             container: fedora:latest
@@ -37,6 +37,17 @@ jobs:
           # For whatever reason tests fail on EL8 with SoftHSM2.
           - name: almalinux8
             token: softhsm
+          # Kryoptic available on in Fedora rawhide for now
+          - name: debian
+            token: kryoptic
+          - name: centos9
+            token: kryoptic
+          - name: centos10
+            token: kryoptic
+          - name: ubuntu
+            token: kryoptic
+          - name: almalinux8
+            token: kryoptic
     container: ${{ matrix.container }}
     steps:
       - name: Install Dependencies
@@ -60,6 +71,8 @@ jobs:
                   nss-devel
               elif [ "${{ matrix.token }}" = "softhsm" ]; then
                 dnf -y install softhsm p11-kit-devel
+              elif [ "${{ matrix.token }}" = "kryoptic" ]; then
+                dnf -y install kryoptic
               fi
             elif [ -f /etc/debian_version ]; then
               apt-get -q update
@@ -85,11 +98,6 @@ jobs:
               fi
             fi
           fi
-          if [ "${{ matrix.name }}" = "debian" ]; then
-            if [ "${{ matrix.token }}" = "softhsm" ]; then
-                echo "skiptest=true" >> $GITHUB_OUTPUT
-              fi
-          fi
 
       - name: Checkout Repository
         if : ( steps.skip-check.outputs.skiptest != 'true' )
@@ -109,9 +117,18 @@ jobs:
 
       - name: Build and Test
         if : ( steps.skip-check.outputs.skiptest != 'true' )
+        shell: bash
         run: |
+          meson_tests=()
+          if [ "${{ matrix.name }}" = "debian" ] && [ "${{ matrix.token }}" = "softhsm" ]; then
+            # TLS tests are currently broken on debian+softhsm so we have to
+            # provide an explict list of test excluding tls.
+            while IFS= read -r line; do
+              meson_tests+=("$line")
+            done < <(meson test -C builddir --suite ${{ matrix.token }} --list |cut -d " " -f 3 | grep -v -E 'tls')
+          fi
           meson compile -C builddir
-          meson test --num-processes 1 -C builddir
+          meson test --num-processes 1 -C builddir --suite ${{ matrix.token }} "${meson_tests[@]}"
 
       - uses: actions/upload-artifact@v4
         if: failure()
@@ -124,11 +141,18 @@ jobs:
             builddir/tests/${{ matrix.token }}/openssl.cnf
 
       - name: Run tests with valgrind
-        if : ( steps.skip-check.outputs.skiptest != 'true' )
+        if : ( steps.skip-check.outputs.skiptest != 'true' && matrix.compiler == 'gcc' )
+        shell: bash
         run: |
-            if [ "${{ matrix.compiler }}" = "gcc" ]; then
-              meson test --num-processes 1 -C builddir --setup=valgrind
-            fi
+          meson_tests=()
+          if [ "${{ matrix.name }}" = "debian" ] && [ "${{ matrix.token }}" = "softhsm" ]; then
+            # TLS tests are currently broken on debian+softhsm so we have to
+            # provide an explict list of test excluding tls.
+            while IFS= read -r line; do
+              meson_tests+=("$line")
+            done < <(meson test -C builddir --suite ${{ matrix.token }} --list |cut -d " " -f 3 | grep -v -E 'tls')
+          fi
+          meson test --num-processes 1 -C builddir --setup=valgrind --suite ${{ matrix.token }} "${meson_tests[@]}"
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/src/objects.c
+++ b/src/objects.c
@@ -4264,7 +4264,7 @@ static CK_RV import_ec_params(P11PROV_OBJ *key, const OSSL_PARAM params[])
     }
 
     curve_nid = EC_GROUP_get_curve_name(group);
-    if (curve_nid == NID_undef) {
+    if (curve_nid != NID_undef) {
         curve_name = OSSL_EC_curve_nid2name(curve_nid);
         if (!curve_name) {
             P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Unknown curve");

--- a/src/provider.c
+++ b/src/provider.c
@@ -1285,7 +1285,9 @@ static CK_RV static_operations_init(P11PROV_CTX *ctx)
 
 static const char *p11prov_block_ops_names[OSSL_OP__HIGHEST + 1] = {
     [OSSL_OP_DIGEST] = "digest",
+#if SKEY_SUPPORT == 1
     [OSSL_OP_CIPHER] = "cipher",
+#endif
     [OSSL_OP_MAC] = "mac",
     [OSSL_OP_KDF] = "kdf",
     [OSSL_OP_RAND] = "rand",
@@ -1298,7 +1300,6 @@ static const char *p11prov_block_ops_names[OSSL_OP__HIGHEST + 1] = {
     [OSSL_OP_DECODER] = "decoder",
     [OSSL_OP_STORE] = "store",
 #if SKEY_SUPPORT == 1
-    [OSSL_OP_CIPHER] = "cipher",
     [OSSL_OP_SKEYMGMT] = "skeymgmt",
 #endif
 };

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -146,7 +146,7 @@ tests = {
   'certs': {'suites': all_suites},
   'ecc': {'suites': all_suites},
   'edwards': {'suites': ['softhsm', 'kryoptic', 'kryoptic.nss']},
-  'ecdh': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
+  'ecdh': {'suites': all_suites},
   'democa': {'suites': all_suites, 'is_parallel': false},
   'digest': {'suites': all_suites},
   'fork': {'suites': all_suites},

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -114,6 +114,7 @@ test_programs = {
   'tpkey': ['tpkey.c', 'util.c'],
   'pincache': ['pincache.c'],
   'ccerts': ['ccerts.c', 'util.c'],
+  'tecx': ['tecx.c', 'util.c'],
 }
 
 test_executables = []

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -390,9 +390,9 @@ else
     ECXCRTN="ecExplicitCert"
 
     ptool --write-object="${TESTSSRCDIR}/explicit_ec.key.der" --type=privkey \
-          --id="$KEYID" --label="${ECXCRTN}" 2>&1
+          --id="$KEYID" --label="${ECXCRTN}" --usage-sign --usage-derive 2>&1
     ptool --write-object="${TESTSSRCDIR}/explicit_ec.pub.der" --type=pubkey \
-          --id="$KEYID" --label="${ECXCRTN}" 2>&1
+          --id="$KEYID" --label="${ECXCRTN}" --usage-sign --usage-derive 2>&1
 
     ECXBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
     ECXBASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID}?pin-source=file:${PINFILE}"

--- a/tests/tecdh
+++ b/tests/tecdh
@@ -18,6 +18,11 @@ pkeyutl -derive -inkey ${ECBASEURI}
 title PARA "Additional test with EC keys"
 $CHECKER "${TESTBLDDIR}/tecx" "${ECPRIURI}" "${ECPEERPUBURI}"
 
+if [[  "$TOKENTYPE" = "softhsm" ]]; then
+    title "ECDH forced on token deadlocks SoftHSM2 so we skip those tests"
+    exit 0
+fi
+
 # Now test by forcing all operations on the token
 title PARA "ECDH Exchange forcing PKCS11 Provider"
 ORIG_OPENSSL_CONF=${OPENSSL_CONF}

--- a/tests/tecdh
+++ b/tests/tecdh
@@ -15,6 +15,8 @@ pkeyutl -derive -inkey ${ECBASEURI}
                 -peerkey ${ECPEERPUBURI}
                 -out ${TMPPDIR}/secret.ecdh.bin'
 
+title PARA "Additional test with EC keys"
+$CHECKER "${TESTBLDDIR}/tecx" "${ECPRIURI}" "${ECPEERPUBURI}"
 
 # Now test by forcing all operations on the token
 title PARA "ECDH Exchange forcing PKCS11 Provider"

--- a/tests/tecx.c
+++ b/tests/tecx.c
@@ -1,0 +1,64 @@
+/* Copyright (C) 2025 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <openssl/err.h>
+#include <openssl/store.h>
+#include <openssl/core_names.h>
+#include "util.h"
+
+static void ecdh_test(EVP_PKEY *a, EVP_PKEY *b)
+{
+    unsigned char secret[16];
+    size_t secretlen = 16;
+    EVP_PKEY_CTX *derivectx;
+
+    derivectx = EVP_PKEY_CTX_new_from_pkey(NULL, a, NULL);
+    if (!derivectx) {
+        fprintf(stderr, "EVP_PKEY_CTX_new_from_pkey failed!\n");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    if (EVP_PKEY_derive_init(derivectx) != 1) {
+        fprintf(stderr, "EVP_PKEY_derive_init failed!\n");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    if (EVP_PKEY_derive_set_peer(derivectx, b) != 1) {
+        fprintf(stderr, "EVP_PKEY_derive_set_peer failed!\n");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    if (EVP_PKEY_derive(derivectx, secret, &secretlen) != 1) {
+        fprintf(stderr, "EVP_PKEY_derive failed!\n");
+        ossl_err_print();
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_CTX_free(derivectx);
+}
+
+int main(int argc, char *argv[])
+{
+    EVP_PKEY *a, *b;
+
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s [privkey-uri] [pubkey-uri]\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    a = load_key(argv[1]);
+    b = load_key(argv[2]);
+
+    ecdh_test(a, b);
+
+    EVP_PKEY_free(a);
+    EVP_PKEY_free(b);
+
+    PRINTERR("ALL A-OK!\n");
+    exit(EXIT_SUCCESS);
+}

--- a/tests/tecxc
+++ b/tests/tecxc
@@ -133,4 +133,8 @@ req -new -batch -key "${ECXPRIURI}" -out ${TMPPDIR}/ecdsa_csr.pem'
 ossl '
 req -in ${TMPPDIR}/ecdsa_csr.pem -verify -noout'
 
+title PARA "Additional test with Explicit EC keys"
+$CHECKER "${TESTBLDDIR}/tecx" "${ECXPRIURI}" "${ECXPUBURI}"
+
+
 exit 0

--- a/tests/util.c
+++ b/tests/util.c
@@ -33,8 +33,9 @@ void ossl_err_print(void)
         first = false;
     }
     if (first) {
-        fprintf(stderr, "\n");
+        fprintf(stderr, "[No errors on the OpenSSL stack]\n");
     }
+    fflush(stderr);
 }
 
 EVP_PKEY *load_key(const char *uri)


### PR DESCRIPTION
#### Description

Fix EC params import for Explicit EC Keys, which broke CMS operations.
Add tests to avoid future regressions, enable ECDH tests for SoftHSM2 where possible.
Changes how some tests are run in CI to test more cases even when some tests are known fails on some platforms (eg TLS tests on Debian with SoftHSM2).

#562 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
