### PR TITLE
Run all pkcs11 tests from libssh

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -12,19 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [fedora, debian, centos]
+        name: [fedora, debian, centos9, centos10]
         include:
           - name: fedora
             container: fedora:latest
           - name: debian
             container: debian:sid
-          - name: centos
+          - name: centos9
             container: quay.io/centos/centos:stream9
+          - name: centos10
+            container: quay.io/centos/centos:stream10
     container: ${{ matrix.container }}
     steps:
       - name: Install Dependencies
         run: |
-            if [ "${{ matrix.name }}" = centos ]; then
+            if [ "${{ matrix.name }}" = "centos9" -o "${{ matrix.name }}" = "centos10" ]; then
               dnf_opts="--enablerepo=crb"
             fi
             if [ -f /etc/redhat-release ]; then

--- a/tests/integration/libssh.sh
+++ b/tests/integration/libssh.sh
@@ -70,11 +70,9 @@ libssh_test()
     title PARA "Run libssh pkcs11 tests"
 
     pushd "${WORKDIR}"/libssh-mirror/build
-    PKCS11_PROVIDER_DEBUG=file:$PKCS11_DEBUG_FILE ctest \
-      --output-on-failure -R \
-      '(torture_auth_pkcs11|torture_pki_rsa_uri|torture_pki_ecdsa_uri)' \
-     | tee testout.log 2>&1
-    grep -q "100% tests passed, 0 tests failed out of 3" testout.log
+    PKCS11_PROVIDER_DEBUG=file:$PKCS11_DEBUG_FILE ctest --output-on-failure \
+      -R  '(pkcs11|uri)' | tee testout.log 2>&1
+    grep -q "100% tests passed, 0 tests failed out of 4" testout.log
     test -s "$PKCS11_DEBUG_FILE"
 
     echo "Test passed"


### PR DESCRIPTION
#### Description

Some time ago, I wrote the tests for libssh to use Ed25519 keys from pkcs11-provider:

https://gitlab.com/libssh/libssh-mirror/-/merge_requests/558

But it looks like the integration tests explicitly select just the tree tests that were here before so the new one was never picked up. This adjusts the regex to match all the pkcs11 uri tests in libssh testsuite

In libssh tests this one test is failing though (unexpectedly prompting for pin interactively)  so I am trying to figure out what is going on there and if the libssh or pkcs11-provider needs a fix. We need to extend this coverage anyway though.

#### Checklist

- [X] Test suite updated with functionality tests
- [X] Test suite updated with negative tests


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
