### PR TITLE
Remove unused environtment variables

### DIFF
--- a/tests/kryoptic-init.sh
+++ b/tests/kryoptic-init.sh
@@ -43,8 +43,4 @@ export TOKENCONFIGVARS="export KRYOPTIC_CONF=$TOKDIR/kryoptic.sql"
 
 export TESTPORT="34000"
 
-# Older versions of certtool do not support non-DER encoded CKA_EC_POINT
-# so set the kryoptic env var to enforce compatibility for the setup phase
-export KRYOPTIC_EC_POINT_ENCODING="DER"
-
 export SUPPORT_ALLOWED_MECHANISMS=1

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -73,7 +73,6 @@ mkdir "${TOKDIR}"
 
 PINFILE="${TMPPDIR}/pinfile.txt"
 echo ${PINVALUE} > "${PINFILE}"
-export GNUTLS_PIN=$PINVALUE
 
 if [ "${TOKENTYPE}" == "softhsm" ]; then
     source "${TESTSSRCDIR}/softhsm-init.sh"


### PR DESCRIPTION
#### Description

The environment variables was needed only for the certtool, which was removed in d681a1abe244ba08a62498ab4da8b0351f5b40f1 some months ago.

#### Checklist

- [x] Test suite updated with functionality tests


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
