### PR TITLE
Add support for HMAC

### DIFF
--- a/src/mac.c
+++ b/src/mac.c
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2025 NXP
+ */
+
+#include "provider.h"
+#include <string.h>
+
+struct p11prov_mac_ctx {
+    P11PROV_CTX *provctx;
+
+    P11PROV_OBJ *key;
+    P11PROV_SESSION *session;
+
+    CK_MECHANISM_TYPE mech;
+    CK_MECHANISM_TYPE hash_mech;
+};
+
+typedef struct p11prov_mac_ctx P11PROV_MAC_CTX;
+
+#define HMAC_MECHANISM(hash_mech) \
+    { \
+        .hash = CKM_##hash_mech, .mech = CKM_##hash_mech##_HMAC \
+    }
+
+static const struct {
+    CK_MECHANISM_TYPE mech;
+    CK_MECHANISM_TYPE hash;
+} hmac_mechanisms[] = { HMAC_MECHANISM(SHA_1),
+                        HMAC_MECHANISM(SHA224),
+                        HMAC_MECHANISM(SHA256),
+                        HMAC_MECHANISM(SHA384),
+                        HMAC_MECHANISM(SHA512),
+
+                        HMAC_MECHANISM(BLAKE2B_160),
+                        HMAC_MECHANISM(BLAKE2B_256),
+                        HMAC_MECHANISM(BLAKE2B_384),
+                        HMAC_MECHANISM(BLAKE2B_512),
+
+                        HMAC_MECHANISM(MD2),
+                        HMAC_MECHANISM(MD5),
+
+                        HMAC_MECHANISM(RIPEMD128),
+                        HMAC_MECHANISM(RIPEMD160),
+
+                        HMAC_MECHANISM(SHA3_224),
+                        HMAC_MECHANISM(SHA3_256),
+                        HMAC_MECHANISM(SHA3_384),
+                        HMAC_MECHANISM(SHA3_512),
+
+                        HMAC_MECHANISM(SHA512_224),
+                        HMAC_MECHANISM(SHA512_256),
+                        HMAC_MECHANISM(SHA512_T),
+
+                        { .hash = CK_UNAVAILABLE_INFORMATION,
+                          .mech = CK_UNAVAILABLE_INFORMATION } };
+
+static void *p11prov_mac_newctx(void *provctx)
+{
+    P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
+    P11PROV_MAC_CTX *macctx;
+
+    P11PROV_debug("mac newctx");
+
+    macctx = OPENSSL_zalloc(sizeof(*macctx));
+    if (macctx == NULL) {
+        return NULL;
+    }
+
+    macctx->provctx = ctx;
+
+    /* default mechanism */
+    macctx->mech = CKM_SHA_1_HMAC;
+    macctx->hash_mech = CKM_SHA_1;
+
+    return macctx;
+}
+
+static void p11prov_mac_freectx(void *ctx)
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+
+    P11PROV_debug("mac freectx (ctx:%p)", ctx);
+
+    p11prov_obj_free(macctx->key);
+
+    if (macctx->session) p11prov_return_session(macctx->session);
+
+    OPENSSL_clear_free(macctx, sizeof(*macctx));
+}
+
+static int p11prov_hmac_get_ctx_params(void *ctx, OSSL_PARAM params[])
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+    OSSL_PARAM *p;
+    CK_RV ret;
+    size_t digest_size = 0;
+    size_t block_size = 0;
+
+    P11PROV_debug("mac get ctx params (ctx=%p, params=%p)", macctx, params);
+
+    if (params == NULL) return RET_OSSL_OK;
+
+    p = OSSL_PARAM_locate(params, OSSL_MAC_PARAM_SIZE);
+    if (p) {
+        ret = p11prov_digest_get_digest_size(macctx->hash_mech, &digest_size);
+        if (ret != CKR_OK || digest_size == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+
+        OSSL_PARAM_set_size_t(p, digest_size);
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_MAC_PARAM_BLOCK_SIZE);
+    if (p) {
+        ret = p11prov_digest_get_block_size(macctx->hash_mech, &block_size);
+        if (ret != CKR_OK || block_size == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+
+        OSSL_PARAM_set_size_t(p, block_size);
+    }
+
+    return RET_OSSL_OK;
+}
+
+static const OSSL_PARAM *p11prov_hmac_gettable_ctx_params(void *ctx,
+                                                          void *provctx)
+{
+    static const OSSL_PARAM known_gettable_ctx_params[] = {
+        OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
+        OSSL_PARAM_size_t(OSSL_MAC_PARAM_BLOCK_SIZE, NULL), OSSL_PARAM_END
+    };
+    return known_gettable_ctx_params;
+}
+
+static CK_RV inner_mac_key(P11PROV_MAC_CTX *macctx, const uint8_t *key,
+                           size_t keylen, P11PROV_OBJ **keyobj)
+{
+    CK_SLOT_ID slotid = CK_UNAVAILABLE_INFORMATION;
+    CK_RV ret;
+
+    if (macctx->session == NULL) {
+        ret = p11prov_get_session(macctx->provctx, &slotid, NULL, NULL,
+                                  macctx->mech, NULL, NULL, false, false,
+                                  &macctx->session);
+        if (ret != CKR_OK) {
+            return ret;
+        }
+    }
+    if (macctx->session == NULL) {
+        return CKR_SESSION_HANDLE_INVALID;
+    }
+
+    *keyobj = p11prov_create_secret_key(macctx->provctx, macctx->session, true,
+                                        (unsigned char *)key, keylen);
+    if (*keyobj == NULL) {
+        return CKR_KEY_HANDLE_INVALID;
+    }
+    return CKR_OK;
+}
+
+static int p11prov_hmac_set_ctx_params(void *ctx, const OSSL_PARAM params[])
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+    const OSSL_PARAM *p;
+    int ret;
+
+    P11PROV_debug("mac set ctx params (ctx=%p, params=%p)", macctx, params);
+
+    p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_TLS_DATA_SIZE);
+    if (p) {
+        /*
+         * TLS_DATA_SIZE parameter should activate some special handling
+         * for TLS records that are mac-then-encrypt and have variable length
+         * padding (i.e. CBC ciphersuites).
+         *
+         * For now, just raise "not supported" error.
+         */
+        P11PROV_raise(ctx, CKR_ARGUMENTS_BAD,
+                      "TLS_DATA_SIZE is not supported!");
+        return RET_OSSL_ERR;
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_DIGEST);
+    if (p) {
+        const char *digest = NULL;
+        CK_RV rv;
+
+        ret = OSSL_PARAM_get_utf8_string_ptr(p, &digest);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+
+        rv = p11prov_digest_get_by_name(digest, &macctx->hash_mech);
+        if (rv != CKR_OK) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+        P11PROV_debug("set digest to %lu", macctx->hash_mech);
+
+        macctx->mech = CK_UNAVAILABLE_INFORMATION;
+        for (int i = 0; hmac_mechanisms[i].hash != CK_UNAVAILABLE_INFORMATION;
+             i++) {
+            if (macctx->hash_mech == hmac_mechanisms[i].hash) {
+                macctx->mech = hmac_mechanisms[i].mech;
+                break;
+            }
+        }
+
+        if (macctx->mech == CK_UNAVAILABLE_INFORMATION) {
+            P11PROV_debug("No associated HMAC mechanism");
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
+            return RET_OSSL_ERR;
+        }
+
+        P11PROV_debug("set MAC to %lu", macctx->mech);
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_KEY);
+    if (p) {
+        const void *key = NULL;
+        size_t key_len;
+        CK_RV rv;
+
+        ret = OSSL_PARAM_get_octet_string_ptr(p, &key, &key_len);
+        if (ret != RET_OSSL_OK) {
+            return ret;
+        }
+
+        /* Create Session and key from key material */
+        p11prov_obj_free(macctx->key);
+        rv = inner_mac_key(macctx, key, key_len, &macctx->key);
+        if (rv != CKR_OK) {
+            return RET_OSSL_ERR;
+        }
+        P11PROV_debug("set key (len:%lu)", key_len);
+    }
+
+    return RET_OSSL_OK;
+}
+
+static const OSSL_PARAM *p11prov_hmac_settable_ctx_params(void *ctx,
+                                                          void *provctx)
+{
+    static const OSSL_PARAM known_settable_ctx_params[] = {
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
+        OSSL_PARAM_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE, NULL), OSSL_PARAM_END
+    };
+    return known_settable_ctx_params;
+}
+
+static int p11prov_hmac_init(void *ctx, const unsigned char *key, size_t keylen,
+                             const OSSL_PARAM params[])
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+    CK_RV ret = CKR_OK;
+    CK_OBJECT_HANDLE pkey_handle = CK_INVALID_HANDLE;
+    CK_MECHANISM mech = { 0 };
+
+    P11PROV_debug("hmac init (ctx:%p, key:%p[%zu], params:%p)", ctx, key,
+                  keylen, params);
+
+    ret = p11prov_ctx_status(macctx->provctx);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
+    ret = p11prov_hmac_set_ctx_params(ctx, params);
+    if (ret != RET_OSSL_OK) {
+        P11PROV_raise(macctx->provctx, ret, "Invalid params");
+        return RET_OSSL_ERR;
+    }
+
+    if (key) {
+        p11prov_obj_free(macctx->key);
+        ret = inner_mac_key(macctx, key, keylen, &macctx->key);
+        if (ret != CKR_OK) {
+            return RET_OSSL_ERR;
+        }
+        P11PROV_debug("set key (len:%lu)", keylen);
+    }
+
+    if (macctx->key == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
+        return RET_OSSL_ERR;
+    }
+
+    pkey_handle = p11prov_obj_get_handle(macctx->key);
+    if (pkey_handle == CK_INVALID_HANDLE) {
+        P11PROV_raise(ctx, CKR_KEY_HANDLE_INVALID, "Invalid key handle");
+        return RET_OSSL_ERR;
+    }
+
+    mech.mechanism = macctx->mech;
+    mech.pParameter = NULL;
+    mech.ulParameterLen = 0;
+
+    ret = p11prov_SignInit(macctx->provctx,
+                           p11prov_session_handle(macctx->session), &mech,
+                           pkey_handle);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_OK;
+}
+
+static int p11prov_hmac_update(void *ctx, const unsigned char *in, size_t inl)
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+    CK_RV ret = CKR_OK;
+
+    ret = p11prov_SignUpdate(macctx->provctx,
+                             p11prov_session_handle(macctx->session),
+                             (CK_BYTE_PTR)in, inl);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
+    return RET_OSSL_OK;
+}
+
+static int p11prov_hmac_final(void *ctx, unsigned char *out, size_t *outl,
+                              size_t outsize)
+{
+    P11PROV_MAC_CTX *macctx = (P11PROV_MAC_CTX *)ctx;
+    CK_RV ret = CKR_OK;
+    CK_ULONG siglen = outsize;
+
+    ret = p11prov_SignFinal(
+        macctx->provctx, p11prov_session_handle(macctx->session), out, &siglen);
+    if (ret != CKR_OK) {
+        return RET_OSSL_ERR;
+    }
+
+    *outl = siglen;
+    return RET_OSSL_OK;
+}
+
+const OSSL_DISPATCH p11prov_hmac_mac_functions[] = {
+    DISPATCH_MAC_ELEM(mac, NEWCTX, newctx),
+    DISPATCH_MAC_ELEM(mac, FREECTX, freectx),
+    DISPATCH_MAC_ELEM(hmac, GET_CTX_PARAMS, get_ctx_params),
+    DISPATCH_MAC_ELEM(hmac, GETTABLE_CTX_PARAMS, gettable_ctx_params),
+    DISPATCH_MAC_ELEM(hmac, SET_CTX_PARAMS, set_ctx_params),
+    DISPATCH_MAC_ELEM(hmac, SETTABLE_CTX_PARAMS, settable_ctx_params),
+    DISPATCH_MAC_ELEM(hmac, INIT, init),
+    DISPATCH_MAC_ELEM(hmac, UPDATE, update),
+    DISPATCH_MAC_ELEM(hmac, FINAL, final),
+    { 0, NULL },
+};

--- a/src/mac.h
+++ b/src/mac.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2025 NXP
+ */
+
+#ifndef _MAC_H
+#define _MAC_H
+
+/* MAC fns */
+#define DISPATCH_HMAC_FN(name) DECL_DISPATCH_FUNC(kdf, p11prov_hmac, name)
+#define DISPATCH_MAC_ELEM(prefix, NAME, name) \
+    { \
+        OSSL_FUNC_MAC_##NAME, (void (*)(void))p11prov_##prefix##_##name \
+    }
+extern const OSSL_DISPATCH p11prov_hmac_mac_functions[];
+
+#endif /* _MAC_H */

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ pkcs11_provider_sources = [
   'exchange.c',
   'kdf.c',
   'keymgmt.c',
+  'mac.c',
   'pk11_uri.c',
   'interface.c',
   'objects.c',

--- a/src/objects.c
+++ b/src/objects.c
@@ -1526,12 +1526,15 @@ P11PROV_OBJ *p11prov_create_secret_key(P11PROV_CTX *provctx,
     CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
     CK_KEY_TYPE key_type = CKK_GENERIC_SECRET;
     CK_BBOOL val_true = CK_TRUE;
+    CK_BBOOL val_false = CK_FALSE;
     CK_BBOOL val_token = session_key ? CK_FALSE : CK_TRUE;
-    CK_ATTRIBUTE key_template[5] = {
+    CK_ATTRIBUTE key_template[7] = {
         { CKA_CLASS, &key_class, sizeof(key_class) },
         { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
         { CKA_TOKEN, &val_token, sizeof(val_token) },
         { CKA_DERIVE, &val_true, sizeof(val_true) },
+        { CKA_SIGN, &val_true, sizeof(val_true) },
+        { CKA_PRIVATE, &val_false, sizeof(val_false) },
         { CKA_VALUE, (void *)secret, secretlen },
     };
     CK_OBJECT_HANDLE key_handle;
@@ -1554,7 +1557,7 @@ P11PROV_OBJ *p11prov_create_secret_key(P11PROV_CTX *provctx,
         return NULL;
     }
 
-    ret = p11prov_CreateObject(provctx, sess, key_template, 5, &key_handle);
+    ret = p11prov_CreateObject(provctx, sess, key_template, 7, &key_handle);
     if (ret != CKR_OK) {
         return NULL;
     }

--- a/src/provider.c
+++ b/src/provider.c
@@ -62,6 +62,7 @@ struct p11prov_ctx {
     OSSL_ALGORITHM *op_cipher;
     OSSL_ALGORITHM *op_skeymgmt;
 #endif
+    OSSL_ALGORITHM *op_mac;
 
     pthread_rwlock_t quirk_lock;
     struct quirk *quirks;
@@ -863,6 +864,15 @@ static CK_RV alg_set_op(OSSL_ALGORITHM **op, int idx, OSSL_ALGORITHM *alg)
         CKM_AES_OFB, CKM_AES_CFB8, CKM_AES_CFB128, CKM_AES_CFB1
 #endif
 
+#define HMAC(hash) CKM_##hash##_HMAC, CKM_##hash##_HMAC_GENERAL
+#define HMAC_MECHS \
+    HMAC(BLAKE2B_160), HMAC(BLAKE2B_256), HMAC(BLAKE2B_384), \
+        HMAC(BLAKE2B_512), HMAC(MD2), HMAC(MD5), HMAC(RIPEMD128), \
+        HMAC(RIPEMD160), HMAC(SHA_1), HMAC(SHA224), HMAC(SHA256), \
+        HMAC(SHA384), HMAC(SHA512), HMAC(SHA3_224), HMAC(SHA3_256), \
+        HMAC(SHA3_384), HMAC(SHA3_512), HMAC(SHA512_224), HMAC(SHA512_256), \
+        HMAC(SHA512_T)
+
 static void alg_rm_mechs(CK_ULONG *checklist, CK_ULONG *rmlist, int *clsize,
                          int rmsize)
 {
@@ -916,9 +926,9 @@ static CK_RV operations_init(P11PROV_CTX *ctx)
                              DIGEST_MECHS,
                              CKM_EDDSA,
 #if SKEY_SUPPORT == 1
-                             AES_MECHS
+                             AES_MECHS,
 #endif
-    };
+                             HMAC_MECHS };
     bool add_rsasig = false;
     bool add_rsaenc = false;
     int cl_size = sizeof(checklist) / sizeof(CK_ULONG);
@@ -931,6 +941,7 @@ static CK_RV operations_init(P11PROV_CTX *ctx)
 #if SKEY_SUPPORT == 1
     int cipher_idx = 0;
 #endif
+    int mac_idx = 0;
     int slot_idx = 0;
     const char *prop = get_default_properties(ctx);
     CK_RV ret;
@@ -1133,6 +1144,49 @@ static CK_RV operations_init(P11PROV_CTX *ctx)
                 UNCHECK_MECHS(CKM_AES_CTS);
                 break;
 #endif
+            case CKM_BLAKE2B_160_HMAC:
+            case CKM_BLAKE2B_160_HMAC_GENERAL:
+            case CKM_BLAKE2B_256_HMAC:
+            case CKM_BLAKE2B_256_HMAC_GENERAL:
+            case CKM_BLAKE2B_384_HMAC:
+            case CKM_BLAKE2B_384_HMAC_GENERAL:
+            case CKM_BLAKE2B_512_HMAC:
+            case CKM_BLAKE2B_512_HMAC_GENERAL:
+            case CKM_MD2_HMAC:
+            case CKM_MD2_HMAC_GENERAL:
+            case CKM_MD5_HMAC:
+            case CKM_MD5_HMAC_GENERAL:
+            case CKM_RIPEMD128_HMAC:
+            case CKM_RIPEMD128_HMAC_GENERAL:
+            case CKM_RIPEMD160_HMAC:
+            case CKM_RIPEMD160_HMAC_GENERAL:
+            case CKM_SHA_1_HMAC:
+            case CKM_SHA_1_HMAC_GENERAL:
+            case CKM_SHA224_HMAC:
+            case CKM_SHA224_HMAC_GENERAL:
+            case CKM_SHA256_HMAC:
+            case CKM_SHA256_HMAC_GENERAL:
+            case CKM_SHA384_HMAC:
+            case CKM_SHA384_HMAC_GENERAL:
+            case CKM_SHA512_HMAC:
+            case CKM_SHA512_HMAC_GENERAL:
+            case CKM_SHA3_224_HMAC:
+            case CKM_SHA3_224_HMAC_GENERAL:
+            case CKM_SHA3_256_HMAC:
+            case CKM_SHA3_256_HMAC_GENERAL:
+            case CKM_SHA3_384_HMAC:
+            case CKM_SHA3_384_HMAC_GENERAL:
+            case CKM_SHA3_512_HMAC:
+            case CKM_SHA3_512_HMAC_GENERAL:
+            case CKM_SHA512_224_HMAC:
+            case CKM_SHA512_224_HMAC_GENERAL:
+            case CKM_SHA512_256_HMAC:
+            case CKM_SHA512_256_HMAC_GENERAL:
+            case CKM_SHA512_T_HMAC:
+            case CKM_SHA512_T_HMAC_GENERAL:
+                ADD_ALGO(HMAC, hmac, mac, prop);
+                UNCHECK_MECHS(HMAC_MECHS);
+                break;
             default:
                 P11PROV_raise(ctx, CKR_GENERAL_ERROR,
                               "Unhandled mechianism %lu", mech);
@@ -1158,6 +1212,7 @@ static CK_RV operations_init(P11PROV_CTX *ctx)
 #if SKEY_SUPPORT == 1
     TERM_ALGO(cipher);
 #endif
+    TERM_ALGO(mac);
 
     /* handle random */
     ret = p11prov_check_random(ctx);
@@ -1359,6 +1414,9 @@ p11prov_query_operation(void *provctx, int operation_id, int *no_cache)
         *no_cache = 0;
         return ctx->op_skeymgmt;
 #endif
+    case OSSL_OP_MAC:
+        *no_cache = 0;
+        return ctx->op_mac;
     }
     *no_cache = 0;
     return NULL;

--- a/src/provider.h
+++ b/src/provider.h
@@ -72,6 +72,8 @@
 #define P11PROV_DESCS_DER "DER decoder implementation in PKCS11 provider"
 #define P11PROV_NAMES_URI "pkcs11"
 #define P11PROV_DESCS_URI "PKCS11 URI Store"
+#define P11PROV_NAMES_HMAC "HMAC"
+#define P11PROV_DESCS_HMAC "PKCS11 HMAC Implementation"
 
 #define P11PROV_PARAM_URI "pkcs11_uri"
 #define P11PROV_PARAM_EPHEMERAL "pkcs11_ephemeral"
@@ -237,6 +239,7 @@ int p11prov_pop_error_to_mark(P11PROV_CTX *ctx);
 #include "slot.h"
 #include "random.h"
 #include "pk11_uri.h"
+#include "mac.h"
 
 #if SKEY_SUPPORT == 1
 #include "cipher.h"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -151,6 +151,7 @@ tests = {
   'fork': {'suites': all_suites},
   'oaepsha2': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'hkdf': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
+  'hmac': {'suites': all_suites},
   'imported' : {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'rsa': {'suites': all_suites},
   'rsapss': {'suites': all_suites},

--- a/tests/thmac
+++ b/tests/thmac
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "${TESTSSRCDIR}/helpers.sh"
+
+# Need to configure early loading, otherwise MACs might not be available
+sed "s/#pkcs11-module-load-behavior/pkcs11-module-load-behavior = early/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.early_load"
+OPENSSL_CONF=${OPENSSL_CONF}.early_load
+
+title PARA "Test HMAC support"
+
+# Use a large key size, softhsm requires it to be >= digest size
+HMAC_HEX_KEY=aaaabbbbaaaabbbbaaaabbbbaaaabbbbaaaabbbbaaaabbbbaaaabbbbaaaabbbb
+
+declare -A digests=(
+    # These HMAC digests should be generally supported
+    ["supported"]="sha1 SSL3-SHA1 SHA1 SHA256 SHA-256 SHA2-256 SHA384 SHA-384 SHA2-384 SHA512 SHA-512 SHA2-512"
+
+    ["optional"]="SHA512-224 SHA-512/224 SHA2-512/224 SHA512-256 SHA-512/256 SHA2-512/256 MD2 MD5 BLAKE2S-256 BLAKE2s256 BLAKE2B-512 BLAKE2b512"
+)
+
+for key in "${!digests[@]}"; do
+    declare -a values=( ${digests[$key]} )
+    FAIL=0
+
+    for digest in "${values[@]}"; do
+        ossl "
+        mac -digest ${digest}
+            -macopt key:${HMAC_HEX_KEY}
+            -in ${RAND64FILE}
+            -out ${TMPPDIR}/hmac-out-pkcs11.bin
+            -propquery provider=pkcs11
+            hmac" || FAIL=1
+        if [ $FAIL -eq 1 ]; then
+            if [ "${key}" = "supported" ]; then
+                exit 1
+            else
+                continue
+            fi
+        fi
+
+        ossl "
+        mac -digest ${digest}
+            -macopt key:${HMAC_HEX_KEY}
+            -in ${RAND64FILE}
+            -out ${TMPPDIR}/hmac-out.bin
+            hmac" || FAIL=1
+        if [ $FAIL -eq 1 ]; then
+            exit 1
+        fi
+
+        diff "${TMPPDIR}/hmac-out-pkcs11.bin" "${TMPPDIR}/hmac-out.bin"
+    done
+done


### PR DESCRIPTION
#### Description

In the context of TLS 1.3, HMAC is used to calculate the `verify_data` with the Finished key. Right now, OpenSSL falls back to it's own internal HMAC.

Add an HMAC implementation that calls into the PKCS11 library to do the HMAC calculation. TLS1.3 does not truncate the HMAC length, so use `CKM_XXX_HMAC` mechanisms without an explicit length.

Add tests that compare the output from PKCS11 to the output of OpenSSL. Since PKCS11 libs may not have implementations for all the mechanisms in the specification, define a subset of "mandatory" HMACs that should be supported by all the test suites.

In the process, I had to add 2 new attributes for the generic secret key:
- `CKA_SIGN`: needed to be able to call `C_SignInit` with the key
- `CKA_PRIVATE`: `softhsm` seems to require this attribute for everything to work fine - I guess this could be removed, but the tests would have to be disabled for softhsm

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
