### PR TITLE
Allow build on RHEL 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [fedora, debian, centos9, centos10, ubuntu]
+        name: [fedora, debian, centos9, centos10, ubuntu, almalinux8]
         compiler: [gcc, clang]
         token: [softokn, softhsm]
         include:
@@ -28,6 +28,15 @@ jobs:
             container: quay.io/centos/centos:stream10
           - name: ubuntu
             container: ubuntu:latest
+          - name: almalinux8
+            container: almalinux:8
+        exclude:
+          # Testing EL8 on a single compler (gcc) is sufficient.
+          - name: almalinux8
+            compiler: clang
+          # For whatever reason tests fail on EL8 with SoftHSM2.
+          - name: almalinux8
+            token: softhsm
     container: ${{ matrix.container }}
     steps:
       - name: Install Dependencies
@@ -36,9 +45,15 @@ jobs:
               dnf_opts="--enablerepo=crb"
             fi
             if [ -f /etc/redhat-release ]; then
+              if [ "${{ matrix.name }}" = "almalinux8" ]; then
+                dnf -y install epel-release
+                dnf -y install openssl3-devel openssl3
+                dnf_opts="--enablerepo=powertools"
+              else
+                dnf -y install openssl-devel openssl
+              fi
               dnf -y install $dnf_opts \
-                git ${{ matrix.compiler }} meson which \
-                pkgconf-pkg-config openssl-devel openssl \
+                git ${{ matrix.compiler }} meson which pkgconf-pkg-config \
                 diffutils expect valgrind opensc python3-six
               if [ "${{ matrix.token }}" = "softokn" ]; then
                 dnf -y install nss-softokn nss-tools nss-softokn-devel \

--- a/meson.build
+++ b/meson.build
@@ -45,9 +45,15 @@ conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set('PACKAGE_MAJOR', major_version)
 conf.set('PACKAGE_MINOR', minor_version)
 
-libcrypto = dependency('libcrypto', version: '>= 3.0.7')
+libcrypto = dependency('libcrypto', version: '>= 3.0.7', required: false)
+if not libcrypto.found()
+  libcrypto = dependency('libcrypto3', version: '>= 3.0.7', required: true)
+endif
 provider_path = libcrypto.get_variable(pkgconfig: 'modulesdir')
-libssl = dependency('libssl', version: '>= 3.0.7')
+libssl = dependency('libssl', version: '>= 3.0.7', required: false)
+if not libssl.found()
+  libssl = dependency('libssl3', version: '>= 3.0.7', required: true, method: 'pkg-config')
+endif
 
 host_system = host_machine.system()
 if host_system == 'windows'

--- a/tests/cert.json.ecdsa.in
+++ b/tests/cert.json.ecdsa.in
@@ -1,5 +1,5 @@
 ,
-    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
+    {"server_command": [@CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
      "comment": "Run test with @PRIURI@ without certificate verify",
      "environment": {"PYTHONPATH" : "."},
      "server_hostname": "localhost",

--- a/tests/cert.json.ed25519.in
+++ b/tests/cert.json.ed25519.in
@@ -1,5 +1,5 @@
 ,
-    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
+    {"server_command": [@CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
      "comment": "Run test with @PRIURI@ without certificate verify",
      "environment": {"PYTHONPATH" : "."},
      "server_hostname": "localhost",

--- a/tests/cert.json.ed448.in
+++ b/tests/cert.json.ed448.in
@@ -1,5 +1,5 @@
 ,
-    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
+    {"server_command": [@CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
      "comment": "Run test with @PRIURI@ without certificate verify",
      "environment": {"PYTHONPATH" : "."},
      "server_hostname": "localhost",

--- a/tests/cert.json.in
+++ b/tests/cert.json.in
@@ -1,5 +1,5 @@
 [
-    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@",
+    {"server_command": [@CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@",
                         "-key", "@PRIURI@", "-cert", "@CRTURI@",
                         "-verify", "1", "-CAfile", "tests/clientX509Cert.pem"],
      "comment": "Use ANY certificate just to ensure that server tries to authorise a client",

--- a/tests/cert.json.rsa.in
+++ b/tests/cert.json.rsa.in
@@ -1,5 +1,5 @@
 ,
-    {"server_command": [@CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
+    {"server_command": [@CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@", "-key", "@PRIURI@", "-cert", "@CRTURI@"],
      "comment": "Run test with @PRIURI@ without certificate verify",
      "environment": {"PYTHONPATH" : "."},
      "server_hostname": "localhost",

--- a/tests/cert.json.rsapss.in
+++ b/tests/cert.json.rsapss.in
@@ -1,6 +1,6 @@
 ,
     {"server_command": [
-       @CHECKER@"openssl", "s_server", @PROPQ@"-www", "-port", "@PORT@",
+       @CHECKER@"@OPENSSL@", "s_server", @PROPQ@"-www", "-port", "@PORT@",
        "-key", "@PRIURI@", "-cert", "@CRTURI@"],
      "comment": "Run test with RSA-PSS key without certificate verify",
      "environment": {"PYTHONPATH" : "."},

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -4,6 +4,9 @@
 
 : "${TESTBLDDIR=.}"
 
+OPENSSL=$(which openssl3 2>/dev/null || true)
+OPENSSL=${OPENSSL:-openssl}
+
 title()
 {
     case "$1" in
@@ -50,14 +53,14 @@ ossl()
     helper_output=""
     if [[ "${2}" = "$helper_emit" ]]; then
         echo "# r $1" >> "${TMPPDIR}/gdb-commands.txt"
-        echo "$CHECKER openssl $1"
+        echo "$CHECKER $OPENSSL $1"
         # shellcheck disable=SC2086  # this is intentionally split by words
-        __out=$(eval $CHECKER openssl $1)
+        __out=$(eval $CHECKER $OPENSSL $1)
     else
         echo "# r $1 $2" >> "${TMPPDIR}/gdb-commands.txt"
-        echo "$CHECKER openssl $1 $2"
+        echo "$CHECKER $OPENSSL $1 $2"
         # shellcheck disable=SC2086  # this is intentionally split by words
-        __out=$(eval $CHECKER openssl $1 $2)
+        __out=$(eval $CHECKER $OPENSSL $1 $2)
     fi
     __res=$?
     if [[ "${2}" = "$helper_emit" ]]; then

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -60,7 +60,7 @@ fi
 
 # Check if openssl supports skey
 SUPPORT_SKEY=0
-openssl skeyutl -h >/dev/null 2>&1 && SUPPORT_SKEY=1
+$OPENSSL skeyutl -h >/dev/null 2>&1 && SUPPORT_SKEY=1
 
 # Temporary dir and Token data dir
 TMPPDIR="${TESTBLDDIR}/${TOKENTYPE}"

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -60,7 +60,7 @@ ossl 'pkey -in $ECBASEURIWITHPINSOURCE -pubin -pubout -out ${TMPPDIR}/ec.pub.uri
 [[ -n $ED2BASEURIWITHPINSOURCE ]] && ossl 'pkey -in $ED2BASEURIWITHPINSOURCE -pubin -pubout -out ${TMPPDIR}/ed2.pub.uripinsource.pem'
 
 title PARA "Test prompting without PIN in config files"
-output=$(expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PRIURI}\" -text -noout;
+output=$(expect -c "spawn -noecho $CHECKER $OPENSSL pkey -in \"${PRIURI}\" -text -noout;
                    expect \"Enter pass phrase for PKCS#11 Token (Slot *:\";
                    send \"${PINVALUE}\r\";
                    expect \"Key ID:\";")
@@ -85,7 +85,7 @@ fi
 # regression test for https://github.com/latchset/pkcs11-provider/issues/547
 title PARA "Make sure we are not prompted for pin to read public RSA key"
 # shellcheck disable=SC2153 # PUBURI is assigned in testvars
-expect -c "spawn -noecho $CHECKER openssl pkey -in \"${PUBURI}\" -pubin -pubout -out -;
+expect -c "spawn -noecho $CHECKER $OPENSSL pkey -in \"${PUBURI}\" -pubin -pubout -out -;
     expect {
         \"Enter PIN for PKCS#11 Token (Slot *:\" {
             exit 1; }

--- a/tests/tdemoca
+++ b/tests/tdemoca
@@ -156,7 +156,7 @@ trap kill_children EXIT
 #Unclear why but w/o -rmd sha1 this fails
 #call this without wrapper otherwise we have issues killing it later ...
 # shellcheck disable=SC2153 # the PRIURI is defined in setup-soft{hsm,okn}
-$CHECKER openssl ocsp -index "${DEMOCA}/index.txt" -rsigner \
+$CHECKER "$OPENSSL" ocsp -index "${DEMOCA}/index.txt" -rsigner \
     "${DEMOCA}/ocspSigning.pem" -rkey "${PRIURI}" -CA "${DEMOCA}/cacert.pem" \
     -rmd sha256 -port "${PORT}" -text &
 sleep 0.5

--- a/tests/ttls
+++ b/tests/ttls
@@ -45,7 +45,7 @@ run_test() {
     CLNT_ARGS=$4
 
     export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug-tls-server.log"
-    expect -c "spawn $CHECKER openssl s_server $PROPQ -accept \"${PORT}\" -naccept 1 -key \"${KEY}\" -cert \"${CERT}\" $SRV_ARGS;
+    expect -c "spawn $CHECKER $OPENSSL s_server $PROPQ -accept \"${PORT}\" -naccept 1 -key \"${KEY}\" -cert \"${CERT}\" $SRV_ARGS;
         set timeout 10;
         expect {
             \"ACCEPT\" {};
@@ -83,7 +83,7 @@ run_test() {
     read -r < "${TMPPDIR}/s_server_ready"
 
     export PKCS11_PROVIDER_DEBUG="file:${TMPPDIR}/p11prov-debug-tls-client.log"
-    expect -c "spawn $CHECKER openssl s_client $PROPQ -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
+    expect -c "spawn $CHECKER $OPENSSL s_client $PROPQ -connect \"localhost:${PORT}\" -CAfile \"${CACRT}\" $CLNT_ARGS;
         set timeout 10;
         expect {
             \" TLS SUCCESSFUL \" {};

--- a/tests/ttlsfuzzer
+++ b/tests/ttlsfuzzer
@@ -18,7 +18,7 @@ TMPFILE="${TMPPDIR}/tls-fuzzer.$$.tmp"
 PORT="$TESTPORT"
 PYTHON=$(which python3)
 
-OPENSSL_VERSION=$(openssl version | sed 's/^OpenSSL \([0-9]*\)\.\([0-9]*\).*$/\1 \2/')
+OPENSSL_VERSION=$($OPENSSL version | sed 's/^OpenSSL \([0-9]*\)\.\([0-9]*\).*$/\1 \2/')
 OPENSSL_VERSION_MAJOR=$(echo "$OPENSSL_VERSION" | cut -d ' ' -f 1)
 OPENSSL_VERSION_MINOR=$(echo "$OPENSSL_VERSION" | cut -d ' ' -f 2)
 
@@ -41,6 +41,7 @@ prepare_test() {
     sed -e "s|@PRIURI@|$KEY|g" -e "s|@CRTURI@|$CERT|g" \
         -e "s/@PORT@/$PORT/g" \
         -e "s/@PROPQ@/$PROPQ/g" \
+        -e "s|@OPENSSL@|$OPENSSL|g" \
         -e "s/@SIGALGS@/$SIGALGS/g" "${TESTSSRCDIR}/${TEMPLATE}" >>"${TMPFILE}"
 }
 
@@ -56,7 +57,7 @@ run_test() {
     pushd "${TESTSSRCDIR}/../tlsfuzzer"
     test -L ecdsa || ln -s ../python-ecdsa/src/ecdsa ecdsa
     test -L tlslite || ln -s ../tlslite-ng/tlslite tlslite 2>/dev/null
-    PYTHONPATH=. "${PYTHON}" tests/scripts_retention.py "${TMPFILE}" openssl 821
+    PYTHONPATH=. "${PYTHON}" tests/scripts_retention.py "${TMPFILE}" "${OPENSSL}" 821
     popd
 }
 


### PR DESCRIPTION
#### Description

This modifies the meson script to look for alternative libcrypto/libssl package names so correct ones are found on RHEL 8 where the original names represent the OpenSSL 1.1 line and hence are not picked by meson. However OpenSSL 3 packages can be installed from the EPEL repository side-by-side with package names ending with `3` (e.g. libcrypto3).

See https://github.com/latchset/pkcs11-provider/discussions/570

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [x] Coverity Scan has run if needed (code PR) and no new defects were found
