### PR TITLE
Fine tune how default slot is selected

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -239,7 +239,6 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
          * and the following query excludes it */
         if ((sctx->default_slot == CK_UNAVAILABLE_INFORMATION)
             && (slot->token.flags & CKF_LOGIN_REQUIRED)
-            && (slot->token.flags & CKF_USER_PIN_INITIALIZED)
             && (slot->token.flags & CKF_TOKEN_INITIALIZED)
             && (!(slot->token.flags & CKF_USER_PIN_LOCKED))) {
             sctx->default_slot = slot->id;


### PR DESCRIPTION
#### Description

Do not require CKF_USER_PIN_INITIALIZED top be set for default slot.

Fixes #569


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [x] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
