### PR TITLE
Fix covscan checks

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -9,6 +9,9 @@ on:
       - labeled
   schedule:
     - cron: '41 3 * * 0'
+  pull_request:
+    types:
+      - labeled
 
 jobs:
   scheduled:
@@ -47,7 +50,7 @@ jobs:
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
   on-labeled-pr:
-    if: ${{ contains(github.event.action, 'labeled') && contains(github.event.*.labels.*.name, 'covscan') }}
+    if: ${{ ${{ github.event_name }} == 'pull_request_target' && contains(github.event.action, 'labeled') && contains(github.event.*.labels.*.name, 'covscan') }}
     name: Coverity Scan on PR
     runs-on: ubuntu-latest
     permissions:
@@ -84,7 +87,7 @@ jobs:
         run: gh pr edit "$NUMBER" --remove-label "covscan"
 
   on-covscan-not-needed:
-    if: ${{ contains(github.event.*.labels.*.name, 'covscan-not-needed')) }}
+    if: ${{ contains(github.event.action, 'labeled') && contains(github.event.*.labels.*.name, 'covscan-not-needed') }}
     name: Coverity Scan on PR
     runs-on: ubuntu-latest
     steps:
@@ -121,7 +124,7 @@ jobs:
           echo "Source files changed, covscan is needed"
 
   on-synchronize-covscan-ok:
-    if: ${{ contains(github.event.action, 'synchronize') && contains(github.event.*.labels.*.name, 'covscan-ok') }}
+    if: ${{ ${{ github.event_name }} == 'pull_request_target' && contains(github.event.action, 'synchronize') && contains(github.event.*.labels.*.name, 'covscan-ok') }}
     name: Coverity Scan on PR
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### Description

The last PR had a mistake in the covscan script, but because we have "pull_request_target" (due to the use of secrets) the actual change was not tested.

This PR is pushed on a branch in the main repo so that we can test the PR before merging.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
