### PR TITLE
tests: tpkey: make function without return value return void

### DIFF
--- a/tests/tpkey.c
+++ b/tests/tpkey.c
@@ -114,7 +114,7 @@ static void check_public_info(EVP_PKEY *key)
     BIO_free(membio);
 }
 
-static int check_peer_ec_key_copy(void)
+static void check_peer_ec_key_copy(void)
 {
     EVP_PKEY *key;
     size_t key_bits;


### PR DESCRIPTION
`check_peer_ec_key_copy` either terminates the program by calling `exit()` or it falls through the end of function without returning a value despite being defined to return int.

Given that the caller doesn't check its return value anyway, change its return type to void.