### PR TITLE
Fix warnings when building against older OpenSSL

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -1100,6 +1100,7 @@ struct mldsa_key_point {
     size_t len;
 };
 
+#ifdef NID_ML_DSA_44
 static int p11prov_mldsa_set_keypoint_data(const OSSL_PARAM *params, void *key)
 {
     struct mldsa_key_point *keypoint = (struct mldsa_key_point *)key;
@@ -1120,15 +1121,16 @@ static int p11prov_mldsa_set_keypoint_data(const OSSL_PARAM *params, void *key)
 
     return RET_OSSL_OK;
 }
+#endif /* defined(NID_ML_DSA_44) */
 
 static X509_PUBKEY *p11prov_mldsa_pubkey_to_x509(P11PROV_OBJ *key)
 {
+#ifdef NID_ML_DSA_44
     struct mldsa_key_point keypoint = { 0 };
     X509_PUBKEY *pubkey;
     int nid = NID_undef;
     int ret;
 
-#ifdef NID_ML_DSA_44
     switch (p11prov_obj_get_key_param_set(key)) {
     case CKP_ML_DSA_44:
         nid = NID_ML_DSA_44;


### PR DESCRIPTION
#### Description

The variables keypoint, pubkey, nid, and ret are unused when NID_ML_DSA_44 is not defined, and so is the
p11prov_mldsa_set_keypoint_data function.

#### Checklist

- [x] Code modified for ~~feature~~ bug

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
