### PR TITLE
tests: Silence a new shellcheck warning

### DIFF
--- a/tests/integration/bind.sh
+++ b/tests/integration/bind.sh
@@ -105,7 +105,7 @@ bind_test()
     TEST_RESULT=0
 }
 
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 cleanup() 
 {
     title PARA "Clean-up"


### PR DESCRIPTION
#### Description

It seems this warning was recently added and now fails CI checks. It is expected that this particular check fails, though:

| ShellCheck is currently bad at figuring out functions that are invoked | via trap. In such cases, please ignore the message with a directive.

Source: https://www.shellcheck.net/wiki/SC2329

This breaks PR #607, although that doesn't modify the offending script, so I'm assuming something in the CI setup changed.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
