### PR TITLE
PKCS11 provider returns a P11PROV_OBJ *

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1145,6 +1145,7 @@ static CK_RV fetch_secret_key(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     struct fetch_attrs attrs[BASE_KEY_ATTRS_NUM];
     int num;
     CK_RV ret;
+    CK_ATTRIBUTE *size = NULL;
 
     key->attrs = OPENSSL_zalloc(BASE_KEY_ATTRS_NUM * sizeof(CK_ATTRIBUTE));
     if (key->attrs == NULL) {
@@ -1155,6 +1156,7 @@ static CK_RV fetch_secret_key(P11PROV_CTX *ctx, P11PROV_SESSION *session,
     FA_SET_BUF_ALLOC(attrs, num, CKA_ID, false);
     FA_SET_BUF_ALLOC(attrs, num, CKA_LABEL, false);
     FA_SET_BUF_ALLOC(attrs, num, CKA_ALWAYS_AUTHENTICATE, false);
+    FA_SET_BUF_ALLOC(attrs, num, CKA_VALUE_LEN, false);
 
     ret = p11prov_fetch_attributes(ctx, session, object, attrs, num);
     if (ret != CKR_OK) {
@@ -1165,6 +1167,21 @@ static CK_RV fetch_secret_key(P11PROV_CTX *ctx, P11PROV_SESSION *session,
 
     key->numattrs = 0;
     p11prov_move_alloc_attrs(attrs, num, key->attrs, &key->numattrs);
+
+    size = p11prov_obj_get_attr(key, CKA_VALUE_LEN);
+    if (!size) { /* Not all tokens support this attribute, stop*/
+        P11PROV_debug("Failed to query key attribute CKA_VALUE_LEN");
+        return CKR_OK;
+    }
+
+    if (size->ulValueLen == sizeof(CK_ULONG)) {
+        key->data.key.size = *(CK_ULONG *)size->pValue;
+        key->data.key.bit_size = key->data.key.size * 8;
+    } else {
+        P11PROV_raise(key->ctx, CKR_GENERAL_ERROR,
+                      "Unsupported Key Size format");
+        return CKR_GENERAL_ERROR;
+    }
 
     return CKR_OK;
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -83,6 +83,9 @@ P11PROV_OBJ *p11prov_obj_import_secret_key(P11PROV_CTX *ctx, CK_KEY_TYPE type,
                                            const unsigned char *key,
                                            size_t keylen);
 
+P11PROV_OBJ *p11prov_obj_assign_secret_key(P11PROV_CTX *ctx, CK_KEY_TYPE type,
+                                           P11PROV_OBJ *key);
+
 CK_RV p11prov_obj_set_ec_encoded_public_key(P11PROV_OBJ *key,
                                             const void *pubkey,
                                             size_t pubkey_len);

--- a/src/skeymgmt.c
+++ b/src/skeymgmt.c
@@ -27,7 +27,6 @@ static void *p11prov_aes_import(void *provctx, int selection,
 {
     P11PROV_CTX *ctx = (P11PROV_CTX *)provctx;
     const OSSL_PARAM *p;
-    unsigned char *key;
     size_t keylen;
 
     P11PROV_debug("aes import");
@@ -43,19 +42,33 @@ static void *p11prov_aes_import(void *provctx, int selection,
 
     p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES);
     if (p) {
+        unsigned char *key;
         int ret =
             OSSL_PARAM_get_octet_string_ptr(p, (const void **)&key, &keylen);
+
         if (ret != RET_OSSL_OK) {
             P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Invalid data");
             return NULL;
         }
-    } else {
-        /* Not a digestible secret key */
-        P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Raw Bytes param unavailable");
-        return NULL;
+        return p11prov_obj_import_secret_key(ctx, CKK_AES, key, keylen);
     }
 
-    return p11prov_obj_import_secret_key(ctx, CKK_AES, key, keylen);
+    p = OSSL_PARAM_locate_const(params, OSSL_OBJECT_PARAM_REFERENCE);
+    if (p) {
+        P11PROV_OBJ *obj = NULL;
+        int ret =
+            OSSL_PARAM_get_octet_string_ptr(p, (const void **)&obj, &keylen);
+
+        if (ret != RET_OSSL_OK) {
+            P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Invalid data");
+            return NULL;
+        }
+        return p11prov_obj_assign_secret_key(ctx, CKK_AES, obj);
+    }
+
+    /* Not a digestible secret key */
+    P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Raw Bytes param unavailable");
+    return NULL;
 }
 
 static int p11prov_aes_export(void *keydata, int selection,
@@ -256,7 +269,8 @@ static const char *p11prov_aes_get_key_id(void *keydata)
 }
 
 static const OSSL_PARAM aes_import_params[] = {
-    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0), OSSL_PARAM_END
+    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0),
+    OSSL_PARAM_octet_ptr(OSSL_OBJECT_PARAM_REFERENCE, NULL, 0), OSSL_PARAM_END
 };
 
 static const OSSL_PARAM *p11prov_aes_imp_settable_params(void *provctx)


### PR DESCRIPTION
...and should be able to take it back, fill with attributes and return back

Related: https://github.com/openssl/openssl/pull/28278

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
