### PR TITLE
We already have the P11PROV_OBJ* we need

### DIFF
--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -699,7 +699,7 @@ static void p11prov_rsa_free(void *key)
 static void *p11prov_rsa_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("rsa load %p, %ld", reference, reference_sz);
-    return p11prov_common_load(reference, reference_sz, CKK_RSA);
+    return p11prov_obj_from_typed_reference(reference, reference_sz, CKK_RSA);
 }
 
 static int p11prov_rsa_has(const void *keydata, int selection)
@@ -1353,7 +1353,7 @@ static void p11prov_ec_free(void *key)
 static void *p11prov_ec_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("ec load %p, %ld", reference, reference_sz);
-    return p11prov_common_load(reference, reference_sz, CKK_EC);
+    return p11prov_obj_from_typed_reference(reference, reference_sz, CKK_EC);
 }
 
 static int p11prov_ec_has(const void *keydata, int selection)
@@ -1893,7 +1893,8 @@ static const OSSL_PARAM *p11prov_ed_gen_settable_params(void *genctx,
 static void *p11prov_ed_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("ed load %p, %ld", reference, reference_sz);
-    return p11prov_common_load(reference, reference_sz, CKK_EC_EDWARDS);
+    return p11prov_obj_from_typed_reference(reference, reference_sz,
+                                            CKK_EC_EDWARDS);
 }
 
 static int p11prov_ed_match(const void *keydata1, const void *keydata2,
@@ -2185,7 +2186,8 @@ static void p11prov_mldsa_free(void *key)
 static void *p11prov_mldsa_load(const void *reference, size_t reference_sz)
 {
     P11PROV_debug("mldsa load %p, %ld", reference, reference_sz);
-    return p11prov_common_load(reference, reference_sz, CKK_ML_DSA);
+    return p11prov_obj_from_typed_reference(reference, reference_sz,
+                                            CKK_ML_DSA);
 }
 
 static int p11prov_mldsa_has(const void *keydata, int selection)

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -530,28 +530,6 @@ static void p11prov_common_gen_cleanup(void *genctx)
     OPENSSL_clear_free(genctx, sizeof(struct key_generator));
 }
 
-void *p11prov_common_load(const void *reference, size_t reference_sz,
-                          CK_KEY_TYPE key_type)
-{
-    P11PROV_OBJ *key;
-
-    /* the contents of the reference is the address to our object */
-    key = p11prov_obj_from_reference(reference, reference_sz);
-    if (key) {
-        CK_KEY_TYPE type = CK_UNAVAILABLE_INFORMATION;
-
-        type = p11prov_obj_get_key_type(key);
-        if (type == key_type) {
-            /* add ref count */
-            key = p11prov_obj_ref_no_cache(key);
-        } else {
-            key = NULL;
-        }
-    }
-
-    return key;
-}
-
 static int p11prov_common_match(const void *keydata1, const void *keydata2,
                                 CK_KEY_TYPE type, int selection)
 {

--- a/src/keymgmt.c
+++ b/src/keymgmt.c
@@ -530,8 +530,8 @@ static void p11prov_common_gen_cleanup(void *genctx)
     OPENSSL_clear_free(genctx, sizeof(struct key_generator));
 }
 
-static void *p11prov_common_load(const void *reference, size_t reference_sz,
-                                 CK_KEY_TYPE key_type)
+void *p11prov_common_load(const void *reference, size_t reference_sz,
+                          CK_KEY_TYPE key_type)
 {
     P11PROV_OBJ *key;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -699,7 +699,7 @@ void p11prov_obj_to_store_reference(P11PROV_OBJ *obj, void **reference,
     /* The store context keeps reference to this object so we will not free
      * it while the store context is alive. When the applications wants to
      * reference the object, it will get its own reference through
-     * p11prov_common_load(). After closing the store, the user should
+     * p11prov_obj_from_typed_reference(). After closing the store, the user should
      * not be able to use this reference anymore. */
     *reference = obj;
     *reference_sz = sizeof(P11PROV_OBJ);
@@ -752,8 +752,9 @@ const char *p11prov_obj_get_public_uri(P11PROV_OBJ *obj)
     return obj->public_uri;
 }
 
-void *p11prov_common_load(const void *reference, size_t reference_sz,
-                          CK_KEY_TYPE key_type)
+void *p11prov_obj_from_typed_reference(const void *reference,
+                                       size_t reference_sz,
+                                       CK_KEY_TYPE key_type)
 {
     P11PROV_OBJ *key;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -578,9 +578,7 @@ CK_KEY_TYPE p11prov_obj_get_key_type(P11PROV_OBJ *obj)
         case CKO_PRIVATE_KEY:
         case CKO_PUBLIC_KEY:
         case CKO_DOMAIN_PARAMETERS:
-#ifdef OSSL_OBJECT_SKEY
         case CKO_SECRET_KEY:
-#endif
             return obj->data.key.type;
         }
     }
@@ -661,6 +659,7 @@ CK_ULONG p11prov_obj_get_key_bit_size(P11PROV_OBJ *obj)
         case CKO_PRIVATE_KEY:
         case CKO_PUBLIC_KEY:
         case CKO_DOMAIN_PARAMETERS:
+        case CKO_SECRET_KEY:
             return obj->data.key.bit_size;
         }
     }
@@ -674,6 +673,7 @@ CK_ULONG p11prov_obj_get_key_size(P11PROV_OBJ *obj)
         case CKO_PRIVATE_KEY:
         case CKO_PUBLIC_KEY:
         case CKO_DOMAIN_PARAMETERS:
+        case CKO_SECRET_KEY:
             return obj->data.key.size;
         }
     }
@@ -1544,7 +1544,7 @@ static void p11prov_obj_refresh(P11PROV_OBJ *obj)
 
     P11PROV_debug("Refresh object %p", obj);
 
-    if (obj->class == CKO_PRIVATE_KEY) {
+    if (obj->class == CKO_PRIVATE_KEY || obj->class == CKO_SECRET_KEY) {
         login = true;
     }
     login_behavior = p11prov_ctx_login_behavior(obj->ctx);

--- a/src/objects.c
+++ b/src/objects.c
@@ -752,6 +752,28 @@ const char *p11prov_obj_get_public_uri(P11PROV_OBJ *obj)
     return obj->public_uri;
 }
 
+void *p11prov_common_load(const void *reference, size_t reference_sz,
+                          CK_KEY_TYPE key_type)
+{
+    P11PROV_OBJ *key;
+
+    /* the contents of the reference is the address to our object */
+    key = p11prov_obj_from_reference(reference, reference_sz);
+    if (key) {
+        CK_KEY_TYPE type = CK_UNAVAILABLE_INFORMATION;
+
+        type = p11prov_obj_get_key_type(key);
+        if (type == key_type) {
+            /* add ref count */
+            key = p11prov_obj_ref_no_cache(key);
+        } else {
+            key = NULL;
+        }
+    }
+
+    return key;
+}
+
 /* CKA_ID
  * CKA_LABEL
  * CKA_ALWAYS_AUTHENTICATE

--- a/src/objects.h
+++ b/src/objects.h
@@ -37,6 +37,8 @@ P11PROV_CTX *p11prov_obj_get_prov_ctx(P11PROV_OBJ *obj);
 P11PROV_OBJ *p11prov_obj_get_associated(P11PROV_OBJ *obj);
 void p11prov_obj_set_associated(P11PROV_OBJ *obj, P11PROV_OBJ *assoc);
 const char *p11prov_obj_get_public_uri(P11PROV_OBJ *obj);
+void *p11prov_common_load(const void *reference, size_t reference_sz,
+                          CK_KEY_TYPE key_type);
 
 typedef CK_RV (*store_obj_callback)(void *, P11PROV_OBJ *);
 CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,

--- a/src/objects.h
+++ b/src/objects.h
@@ -37,8 +37,9 @@ P11PROV_CTX *p11prov_obj_get_prov_ctx(P11PROV_OBJ *obj);
 P11PROV_OBJ *p11prov_obj_get_associated(P11PROV_OBJ *obj);
 void p11prov_obj_set_associated(P11PROV_OBJ *obj, P11PROV_OBJ *assoc);
 const char *p11prov_obj_get_public_uri(P11PROV_OBJ *obj);
-void *p11prov_common_load(const void *reference, size_t reference_sz,
-                          CK_KEY_TYPE key_type);
+void *p11prov_obj_from_typed_reference(const void *reference,
+                                       size_t reference_sz,
+                                       CK_KEY_TYPE key_type);
 
 typedef CK_RV (*store_obj_callback)(void *, P11PROV_OBJ *);
 CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,

--- a/src/provider.h
+++ b/src/provider.h
@@ -273,8 +273,6 @@ bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx);
 
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx);
 
-void *p11prov_common_load(const void *reference, size_t reference_sz,
-                          CK_KEY_TYPE key_type);
 #include "debug.h"
 
 /* Errors */

--- a/src/provider.h
+++ b/src/provider.h
@@ -273,6 +273,8 @@ bool p11prov_ctx_no_session_callbacks(P11PROV_CTX *ctx);
 
 CK_INFO p11prov_ctx_get_ck_info(P11PROV_CTX *ctx);
 
+void *p11prov_common_load(const void *reference, size_t reference_sz,
+                          CK_KEY_TYPE key_type);
 #include "debug.h"
 
 /* Errors */

--- a/src/skeymgmt.c
+++ b/src/skeymgmt.c
@@ -63,7 +63,8 @@ static void *p11prov_aes_import(void *provctx, int selection,
             P11PROV_raise(ctx, CKR_KEY_INDIGESTIBLE, "Invalid data");
             return NULL;
         }
-        return p11prov_common_load(reference, reference_sz, CKK_AES);
+        return p11prov_obj_from_typed_reference(reference, reference_sz,
+                                                CKK_AES);
     }
 
     /* Not a digestible secret key */


### PR DESCRIPTION
... and deal wit it using `p11prov_common_load` 

#### Description

A counterpart to https://github.com/openssl/openssl/pull/28278
Superseds #618 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [x] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
