### PR TITLE
test: skip ml-dsa pkey tests on demand (fixed)

### DIFF
--- a/tests/tpkey.c
+++ b/tests/tpkey.c
@@ -318,11 +318,15 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        /* ML-DSA is handled only in kryoptic so far */
-        if (strncmp(tests[i].key_type, "ML-DSA", 6) == 0
-            && strcmp(driver, "kryoptic") != 0 && support_ml_dsa != NULL
-            && strcmp(support_ml_dsa, "1")) {
-            continue;
+        if (strncmp(tests[i].key_type, "ML-DSA", 6) == 0) {
+            /* ML-DSA is handled only in kryoptic so far */
+            if (strcmp(driver, "kryoptic") != 0) {
+                continue;
+            }
+            /* ML-DSA tests can be disabled on demand */
+            if (support_ml_dsa != NULL && strcmp(support_ml_dsa, "0") == 0) {
+                continue;
+            }
         }
 
         PRINTERR("Testing key type %s\n", tests[i].key_type);


### PR DESCRIPTION
#### Description

This is a fixup of of #625 that only worked for non-kryoptic tokens (now SUPPORT_ML_DSA variable check is done regardless of the token in use). 

#### Checklist

N/A

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
