### PR TITLE
Improve session handling

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -18,7 +18,7 @@ jobs:
         # , debian]
         include:
           - name: fedora
-            container: fedora:latest
+            container: quay.io/fedora/fedora:latest
         #  - name: debian
         #    container: debian:sid
     container: ${{ matrix.container }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: CI with software token
+    name: CI
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -160,9 +160,8 @@ jobs:
           name: Test logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
           path: |
             builddir/meson-logs/
-            builddir/tests/${{ matrix.token }}/p11prov-debug.log
-            builddir/tests/${{ matrix.token }}/testvars
-            builddir/tests/${{ matrix.token }}/openssl.cnf
+            builddir/tests/*.log
+            builddir/tests/${{ matrix.token }}
 
       - name: Run tests with valgrind
         if : ( steps.skip-check.outputs.skiptest != 'true' && matrix.compiler == 'gcc' )
@@ -191,9 +190,8 @@ jobs:
           name: Test valgrind logs ${{ matrix.name }}, ${{ matrix.compiler }}, ${{ matrix.token }}
           path: |
             builddir/meson-logs/
+            builddir/tests/*.log
             builddir/tests/${{ matrix.token }}/p11prov-debug.log
-            builddir/tests/${{ matrix.token }}/testvars
-            builddir/tests/${{ matrix.token }}/openssl.cnf
 
       #- name: Run tests in FIPS Mode (on CentOS + gcc only)
       #  if : ( steps.skip-check.outputs.skiptest != 'true' )
@@ -215,7 +213,7 @@ jobs:
 
 
   build-macos:
-    name: CI with software token
+    name: CI
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -269,6 +267,4 @@ jobs:
           path: |
             builddir/meson-logs/*
             builddir/tests/*.log
-            builddir/tests/${{ matrix.token }}/p11prov-debug.log
-            builddir/tests/${{ matrix.token }}/testvars
-            builddir/tests/${{ matrix.token }}/openssl.cnf
+            builddir/tests/${{ matrix.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,17 @@ jobs:
         token: [softokn, softhsm, kryoptic]
         include:
           - name: fedora
-            container: fedora:rawhide
+            container: quay.io/fedora/fedora:rawhide
           - name: debian
-            container: debian:sid
+            container: quay.io/opendevmirror/debian:trixie
           - name: centos9
             container: quay.io/centos/centos:stream9
           - name: centos10
             container: quay.io/centos/centos:stream10
           - name: ubuntu
-            container: ubuntu:latest
+            container: quay.io/opendevmirror/ubuntu:24.04
           - name: almalinux8
-            container: almalinux:8
+            container: quay.io/almalinuxorg/almalinux:8
         exclude:
           # Testing EL8 on a single compler (gcc) is sufficient.
           - name: almalinux8

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     name: Recurrent Coverity Scan
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Install Dependencies
         run: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -15,9 +15,9 @@ jobs:
         name: [fedora, debian, centos9, centos10]
         include:
           - name: fedora
-            container: fedora:latest
+            container: quay.io/fedora/fedora:latest
           - name: debian
-            container: debian:sid
+            container: quay.io/opendevmirror/debian:trixie
           - name: centos9
             container: quay.io/centos/centos:stream9
           - name: centos10

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         test: [libssh, httpd]
     name: ${{ matrix.test }}
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     env:
       PKCS11_MODULE: /usr/lib64/ossl-modules/pkcs11.so
     steps:
@@ -51,7 +51,7 @@ jobs:
   test-bind:
     name: bind
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Get Date for DNF cache entry
         id: get-date

--- a/.github/workflows/kryoptic.yml
+++ b/.github/workflows/kryoptic.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: CI with kryoptic token
     runs-on: ubuntu-22.04
-    container: fedora:rawhide
+    container: quay.io/fedora/fedora:rawhide
     steps:
       - name: Get Date for DNF cache entry
         id: get-date

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -14,7 +14,7 @@ jobs:
   setup:
     name: Build OpenSSL from master branch 
     runs-on: ubuntu-22.04
-    container: fedora:rawhide
+    container: quay.io/fedora/fedora:rawhide
     steps:
       - name: Get Date for DNF cache entry
         id: get-date-dnf
@@ -65,7 +65,7 @@ jobs:
     name: Build and test pkcs11-provider
     needs: setup
     runs-on: ubuntu-22.04
-    container: fedora:rawhide
+    container: quay.io/fedora/fedora:rawhide
     steps:
       - name: Get Date for DNF cache entry
         id: get-date-dnf

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: CI with softoken
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Install Dependencies
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Check Style
     runs-on: ubuntu-22.04
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Install Dependencies
         run: |

--- a/src/cipher.c
+++ b/src/cipher.c
@@ -333,15 +333,7 @@ static CK_RV p11prov_cipher_op_init(void *ctx, void *keydata, CK_FLAGS op,
 
 static CK_RV p11prov_cipher_session_init(struct p11prov_cipher_ctx *cctx)
 {
-    CK_SLOT_ID slotid;
     CK_RV rv;
-
-    slotid = p11prov_obj_get_slotid(cctx->key);
-    if (slotid == CK_UNAVAILABLE_INFORMATION) {
-        P11PROV_raise(cctx->provctx, CKR_SLOT_ID_INVALID,
-                      "Provided key has invalid slot");
-        return CKR_SLOT_ID_INVALID;
-    }
 
     if (cctx->tlsver != 0 && cctx->mech.mechanism == CKM_AES_CBC_PAD) {
         /* In the special TLS mode we handle de-padding and mac extraction
@@ -349,9 +341,8 @@ static CK_RV p11prov_cipher_session_init(struct p11prov_cipher_ctx *cctx)
         cctx->mech.mechanism = CKM_AES_CBC;
     }
 
-    rv = p11prov_get_session(cctx->provctx, &slotid, NULL, NULL,
-                             cctx->mech.mechanism, NULL, NULL, true, false,
-                             &cctx->session);
+    rv = p11prov_try_session_ref(cctx->key, cctx->mech.mechanism, true, false,
+                                 &cctx->session);
     if (rv != CKR_OK) {
         return rv;
     }

--- a/src/encoder.gen.c
+++ b/src/encoder.gen.c
@@ -14,8 +14,10 @@ extern P11PROV_RSA_PUBKEY *d2i_P11PROV_RSA_PUBKEY(P11PROV_RSA_PUBKEY **a,
 extern int i2d_P11PROV_RSA_PUBKEY(const P11PROV_RSA_PUBKEY *a,
                                   unsigned char **out);
 extern const ASN1_ITEM *P11PROV_RSA_PUBKEY_it(void);
-P11PROV_RSA_PUBKEY *d2i_P11PROV_RSA_PUBKEY(P11PROV_RSA_PUBKEY **a,
-                                           const unsigned char **in, long len)
+
+P11PROV_RSA_PUBKEY
+*d2i_P11PROV_RSA_PUBKEY(P11PROV_RSA_PUBKEY **a, const unsigned char **in,
+                        long len)
 {
     return (P11PROV_RSA_PUBKEY *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
                                                (P11PROV_RSA_PUBKEY_it()));
@@ -24,7 +26,8 @@ int i2d_P11PROV_RSA_PUBKEY(const P11PROV_RSA_PUBKEY *a, unsigned char **out)
 {
     return ASN1_item_i2d((const ASN1_VALUE *)a, out, (P11PROV_RSA_PUBKEY_it()));
 }
-P11PROV_RSA_PUBKEY *P11PROV_RSA_PUBKEY_new(void)
+P11PROV_RSA_PUBKEY
+*P11PROV_RSA_PUBKEY_new(void)
 {
     return (P11PROV_RSA_PUBKEY *)ASN1_item_new((P11PROV_RSA_PUBKEY_it()));
 }
@@ -34,8 +37,10 @@ void P11PROV_RSA_PUBKEY_free(P11PROV_RSA_PUBKEY *a)
 }
 
 static const ASN1_TEMPLATE P11PROV_RSA_PUBKEY_seq_tt[] = {
+
     { (0), (0), __builtin_offsetof(P11PROV_RSA_PUBKEY, n), "n",
       (ASN1_INTEGER_it) },
+
     { (0), (0), __builtin_offsetof(P11PROV_RSA_PUBKEY, e), "e",
       (ASN1_INTEGER_it) },
 };

--- a/src/exchange.c
+++ b/src/exchange.c
@@ -245,9 +245,7 @@ static void *p11prov_ecdh_derive_skey(void *ctx, const char *key_type,
     };
     size_t key_tmpl_size = sizeof(key_template) / sizeof(CK_ATTRIBUTE);
     CK_MECHANISM mechanism;
-    CK_OBJECT_HANDLE handle;
     CK_OBJECT_HANDLE secret_handle;
-    CK_SLOT_ID slotid;
     P11PROV_OBJ *skey = NULL;
     CK_RV ret;
 
@@ -289,23 +287,8 @@ static void *p11prov_ecdh_derive_skey(void *ctx, const char *key_type,
         }
     }
 
-    handle = p11prov_obj_get_handle(ecdhctx->key);
-    if (handle == CK_INVALID_HANDLE) {
-        P11PROV_raise(ecdhctx->provctx, CKR_KEY_HANDLE_INVALID,
-                      "Provided key has invalid handle");
-        return NULL;
-    }
-
-    slotid = p11prov_obj_get_slotid(ecdhctx->key);
-    if (slotid == CK_UNAVAILABLE_INFORMATION) {
-        P11PROV_raise(ecdhctx->provctx, CKR_SLOT_ID_INVALID,
-                      "Provided key has invalid slot");
-        return NULL;
-    }
-
-    ret = p11prov_derive_key(ecdhctx->provctx, slotid, &mechanism, handle,
-                             key_template, key_tmpl_size, &ecdhctx->session,
-                             &secret_handle);
+    ret = p11prov_derive_key(ecdhctx->key, &mechanism, key_template,
+                             key_tmpl_size, &ecdhctx->session, &secret_handle);
     if (ret != CKR_OK) {
         return NULL;
     }

--- a/src/interface.c
+++ b/src/interface.c
@@ -80,6 +80,7 @@ struct p11prov_interface {
     CK_C_SeedRandom SeedRandom;
     CK_C_GenerateRandom GenerateRandom;
     CK_C_GetInterface GetInterface;
+    CK_C_SessionCancel SessionCancel;
 };
 
 #include "interface.gen.c"
@@ -160,6 +161,7 @@ static void populate_interface(P11PROV_INTERFACE *intf, CK_INTERFACE *ck_intf)
     ASSIGN_FN(GenerateRandom);
     if (intf->version.major == 3) {
         ASSIGN_FN_3_0(GetInterface);
+        ASSIGN_FN_3_0(SessionCancel);
     }
 }
 

--- a/src/interface.gen.c
+++ b/src/interface.gen.c
@@ -1384,3 +1384,31 @@ CK_RV p11prov_GenerateRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
     }
     return ret;
 }
+
+CK_RV p11prov_SessionCancel(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                            CK_FLAGS flags)
+{
+    P11PROV_INTERFACE *intf = p11prov_ctx_get_interface(ctx);
+    CK_RV ret = CKR_GENERAL_ERROR;
+    if (!intf) {
+        P11PROV_raise(ctx, ret, "Can't get module interfaces");
+        return ret;
+    }
+    if (p11prov_ctx_is_call_blocked(ctx, P11PROV_BLOCK_SessionCancel)) {
+        P11PROV_debug("C_%s is blocked", "SessionCancel");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
+    if (!intf->SessionCancel) {
+        P11PROV_debug("C_%s is not available", "SessionCancel");
+        return CKR_FUNCTION_NOT_SUPPORTED;
+    }
+    P11PROV_debug("Calling C_"
+                  "SessionCancel");
+    ret = intf->SessionCancel(hSession, flags);
+    if (ret != CKR_OK) {
+        P11PROV_debug("Error %ld returned by C_"
+                      "SessionCancel",
+                      ret);
+    }
+    return ret;
+}

--- a/src/interface.h
+++ b/src/interface.h
@@ -143,6 +143,8 @@ CK_RV p11prov_SeedRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                          CK_BYTE_PTR SeedData, CK_ULONG ulSeedLen);
 CK_RV p11prov_GenerateRandom(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
                              CK_BYTE_PTR RandomData, CK_ULONG ulRandomLen);
+CK_RV p11prov_SessionCancel(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
+                            CK_FLAGS flags);
 
 /* Special side-channel free path against PKCS#1 1.5 side channel leaking */
 CK_RV side_channel_free_Decrypt(P11PROV_CTX *ctx, CK_SESSION_HANDLE hSession,
@@ -211,5 +213,6 @@ CK_INFO p11prov_module_ck_info(P11PROV_MODULE *mctx);
 #define P11PROV_BLOCK_GenerateRandom 0b0000000000000000
 /* 3.x  functions: */
 #define P11PROV_BLOCK_GetInterface 0b0000000000000000
+#define P11PROV_BLOCK_SessionCancel 0b0000000000000000
 
 #endif /* _INTERFACE_H */

--- a/src/interface.pre
+++ b/src/interface.pre
@@ -242,3 +242,6 @@ IMPL_INTERFACE_FN_3_ARG(SeedRandom, CK_SESSION_HANDLE, hSession,
 
 IMPL_INTERFACE_FN_3_ARG(GenerateRandom, CK_SESSION_HANDLE, hSession,
                         CK_BYTE_PTR, RandomData, CK_ULONG, ulRandomLen)
+
+IMPL_INTERFACE_FN_2_ARG(SessionCancel, CK_SESSION_HANDLE, hSession,
+                        CK_FLAGS, flags)

--- a/src/kdf.c
+++ b/src/kdf.c
@@ -179,8 +179,6 @@ static int inner_derive_key(P11PROV_CTX *ctx, P11PROV_OBJ *key,
         { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
     };
     CK_ULONG key_tmpl_len = 0;
-    CK_OBJECT_HANDLE pkey_handle;
-    CK_SLOT_ID slotid;
     CK_RV ret;
 
     if (mechanism->mechanism == CKM_HKDF_DERIVE) {
@@ -196,22 +194,8 @@ static int inner_derive_key(P11PROV_CTX *ctx, P11PROV_OBJ *key,
         return ret;
     }
 
-    pkey_handle = p11prov_obj_get_handle(key);
-    if (pkey_handle == CK_INVALID_HANDLE) {
-        ret = CKR_KEY_HANDLE_INVALID;
-        P11PROV_raise(ctx, ret, "Invalid key handle");
-        return ret;
-    }
-
-    slotid = p11prov_obj_get_slotid(key);
-    if (slotid == CK_UNAVAILABLE_INFORMATION) {
-        ret = CKR_SLOT_ID_INVALID;
-        P11PROV_raise(ctx, ret, "Invalid key slotid");
-        return ret;
-    }
-
-    return p11prov_derive_key(ctx, slotid, mechanism, pkey_handle, key_template,
-                              key_tmpl_len, session, dkey_handle);
+    return p11prov_derive_key(key, mechanism, key_template, key_tmpl_len,
+                              session, dkey_handle);
 }
 
 static int p11prov_hkdf_format_params(P11PROV_KDF_CTX *hkdfctx,

--- a/src/objects.c
+++ b/src/objects.c
@@ -4115,8 +4115,8 @@ static CK_RV p11prov_store_rsa_public_key(P11PROV_OBJ *key)
     }
 
     rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
-                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
-                             &session);
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4263,8 +4263,8 @@ static CK_RV p11prov_store_mldsa_public_key(P11PROV_OBJ *key)
     }
 
     rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
-                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
-                             &session);
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4462,8 +4462,8 @@ static CK_RV p11prov_store_rsa_private_key(P11PROV_OBJ *key,
     }
 
     rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
-                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
-                             &session);
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4565,8 +4565,8 @@ static CK_RV p11prov_store_ec_private_key(P11PROV_OBJ *key,
     }
 
     rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
-                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
-                             &session);
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4670,8 +4670,8 @@ static CK_RV p11prov_store_mldsa_private_key(P11PROV_OBJ *key,
     }
 
     rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
-                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
-                             &session);
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }

--- a/src/objects.c
+++ b/src/objects.c
@@ -4114,7 +4114,9 @@ static CK_RV p11prov_store_rsa_public_key(P11PROV_OBJ *key)
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4188,7 +4190,9 @@ static CK_RV p11prov_store_ec_public_key(P11PROV_OBJ *key)
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
+                             true, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4258,7 +4262,9 @@ static CK_RV p11prov_store_mldsa_public_key(P11PROV_OBJ *key)
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4455,7 +4461,9 @@ static CK_RV p11prov_store_rsa_private_key(P11PROV_OBJ *key,
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4556,7 +4564,9 @@ static CK_RV p11prov_store_ec_private_key(P11PROV_OBJ *key,
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -4659,7 +4669,9 @@ static CK_RV p11prov_store_mldsa_private_key(P11PROV_OBJ *key,
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_get_session(key->ctx, &slot, NULL, key->refresh_uri,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -5048,7 +5060,9 @@ static CK_RV p11prov_store_aes_key(P11PROV_CTX *provctx, P11PROV_OBJ **ret,
         goto done;
     }
 
-    rv = p11prov_take_login_session(provctx, slot, &session);
+    rv = p11prov_get_session(provctx, &slot, NULL, NULL,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -5138,7 +5152,9 @@ static CK_RV p11prov_store_generic_secret_key(P11PROV_CTX *provctx,
         goto done;
     }
 
-    rv = p11prov_take_login_session(provctx, slot, &session);
+    rv = p11prov_get_session(provctx, &slot, NULL, NULL,
+                             CK_UNAVAILABLE_INFORMATION, NULL, NULL, true, true,
+                             &session);
     if (rv != CKR_OK) {
         goto done;
     }

--- a/src/objects.h
+++ b/src/objects.h
@@ -55,10 +55,9 @@ P11PROV_OBJ *p11prov_create_secret_key(P11PROV_CTX *provctx,
                                        P11PROV_SESSION *session,
                                        bool session_key, unsigned char *secret,
                                        size_t secretlen);
-CK_RV p11prov_derive_key(P11PROV_CTX *ctx, CK_SLOT_ID slotid,
-                         CK_MECHANISM *mechanism, CK_OBJECT_HANDLE handle,
+CK_RV p11prov_derive_key(P11PROV_OBJ *key, CK_MECHANISM *mechanism,
                          CK_ATTRIBUTE *template, CK_ULONG nattrs,
-                         P11PROV_SESSION **session, CK_OBJECT_HANDLE *key);
+                         P11PROV_SESSION **_session, CK_OBJECT_HANDLE *dkey);
 CK_RV p11prov_obj_set_attributes(P11PROV_CTX *ctx, P11PROV_SESSION *session,
                                  P11PROV_OBJ *obj, CK_ATTRIBUTE *template,
                                  CK_ULONG tsize);

--- a/src/objects.h
+++ b/src/objects.h
@@ -41,6 +41,9 @@ const char *p11prov_obj_get_public_uri(P11PROV_OBJ *obj);
 void *p11prov_obj_from_typed_reference(const void *reference,
                                        size_t reference_sz,
                                        CK_KEY_TYPE key_type);
+P11PROV_SESSION *p11prov_obj_get_session_ref(P11PROV_OBJ *obj);
+void p11prov_obj_set_session_ref(P11PROV_OBJ *obj, P11PROV_SESSION *session);
+P11PROV_URI *p11prov_obj_get_refresh_uri(P11PROV_OBJ *obj);
 
 typedef CK_RV (*store_obj_callback)(void *, P11PROV_OBJ *);
 CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,

--- a/src/pk11_uri.gen.c
+++ b/src/pk11_uri.gen.c
@@ -7,8 +7,9 @@ extern P11PROV_PK11_URI *
 d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a, const unsigned char **in, long len);
 extern int i2d_P11PROV_PK11_URI(const P11PROV_PK11_URI *a, unsigned char **out);
 extern const ASN1_ITEM *P11PROV_PK11_URI_it(void);
-P11PROV_PK11_URI *d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a,
-                                       const unsigned char **in, long len)
+
+P11PROV_PK11_URI
+*d2i_P11PROV_PK11_URI(P11PROV_PK11_URI **a, const unsigned char **in, long len)
 {
     return (P11PROV_PK11_URI *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
                                              (P11PROV_PK11_URI_it()));
@@ -17,7 +18,8 @@ int i2d_P11PROV_PK11_URI(const P11PROV_PK11_URI *a, unsigned char **out)
 {
     return ASN1_item_i2d((const ASN1_VALUE *)a, out, (P11PROV_PK11_URI_it()));
 }
-P11PROV_PK11_URI *P11PROV_PK11_URI_new(void)
+P11PROV_PK11_URI
+*P11PROV_PK11_URI_new(void)
 {
     return (P11PROV_PK11_URI *)ASN1_item_new((P11PROV_PK11_URI_it()));
 }
@@ -27,8 +29,10 @@ void P11PROV_PK11_URI_free(P11PROV_PK11_URI *a)
 }
 
 static const ASN1_TEMPLATE P11PROV_PK11_URI_seq_tt[] = {
+
     { (0), (0), __builtin_offsetof(P11PROV_PK11_URI, desc), "desc",
       (ASN1_VISIBLESTRING_it) },
+
     { (0), (0), __builtin_offsetof(P11PROV_PK11_URI, uri), "uri",
       (ASN1_UTF8STRING_it) },
 };
@@ -57,8 +61,10 @@ extern P11PROV_PK11_URI *PEM_read_bio_P11PROV_PK11_URI(BIO *out,
                                                        P11PROV_PK11_URI **x,
                                                        pem_password_cb *cb,
                                                        void *u);
-P11PROV_PK11_URI *PEM_read_bio_P11PROV_PK11_URI(BIO *bp, P11PROV_PK11_URI **x,
-                                                pem_password_cb *cb, void *u)
+
+P11PROV_PK11_URI
+*PEM_read_bio_P11PROV_PK11_URI(BIO *bp, P11PROV_PK11_URI **x,
+                               pem_password_cb *cb, void *u)
 {
     return PEM_ASN1_read_bio((d2i_of_void *)d2i_P11PROV_PK11_URI,
                              P11PROV_PEM_LABEL, bp, (void **)x, cb, u);

--- a/src/session.c
+++ b/src/session.c
@@ -338,9 +338,11 @@ static CK_RV session_check(P11PROV_SESSION *session, CK_FLAGS flags)
                                  &session_info);
     if (ret == CKR_OK) {
         session->state = session_info.state;
-        if (flags == session_info.flags) {
+        if (flags == (session_info.flags & flags)) {
             return CKR_OK;
         }
+        P11PROV_debug("Checking session, flags not matching %lu != %lu", flags,
+                      session_info.flags);
         (void)p11prov_CloseSession(session->provctx, session->session);
         /* tell the caller that the session was closed so they can
          * keep up with accounting */

--- a/src/session.h
+++ b/src/session.h
@@ -17,9 +17,13 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_MECHANISM_TYPE mechtype,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
+CK_RV p11prov_try_session_ref(P11PROV_OBJ *obj, bool reqlogin, bool rw,
+                              P11PROV_SESSION **_session);
 CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
                                  P11PROV_SESSION **_session);
 void p11prov_return_session(P11PROV_SESSION *session);
+void p11prov_session_ref(P11PROV_SESSION *session);
+void p11prov_session_deref(P11PROV_SESSION *session);
 
 CK_RV p11prov_context_specific_login(P11PROV_SESSION *session, P11PROV_URI *uri,
                                      OSSL_PASSPHRASE_CALLBACK *pw_cb,

--- a/src/session.h
+++ b/src/session.h
@@ -17,7 +17,8 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           CK_MECHANISM_TYPE mechtype,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
-CK_RV p11prov_try_session_ref(P11PROV_OBJ *obj, bool reqlogin, bool rw,
+CK_RV p11prov_try_session_ref(P11PROV_OBJ *obj, CK_MECHANISM_TYPE mechtype,
+                              bool reqlogin, bool rw,
                               P11PROV_SESSION **_session);
 CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
                                  P11PROV_SESSION **_session);

--- a/src/session.h
+++ b/src/session.h
@@ -33,6 +33,7 @@ CK_RV p11prov_context_specific_login(P11PROV_SESSION *session, P11PROV_URI *uri,
 typedef CK_RV (*p11prov_session_callback_t)(void *cbarg);
 void p11prov_session_set_callback(P11PROV_SESSION *session,
                                   p11prov_session_callback_t cb, void *cbarg);
+void p11prov_session_mark_broken(P11PROV_SESSION *session);
 
 /* Some reasonable limit */
 #define MAX_CONCURRENT_SESSIONS 1024

--- a/src/sig/internal.h
+++ b/src/sig/internal.h
@@ -29,6 +29,7 @@ struct p11prov_sig_ctx {
 
     CK_FLAGS operation;
     P11PROV_SESSION *session;
+    enum { SESS_UNUSED = 0, SESS_INITIALIZED, SESS_FINALIZED } session_state;
 
     CK_RSA_PKCS_PSS_PARAMS pss_params;
 

--- a/src/sig/signature.c
+++ b/src/sig/signature.c
@@ -198,13 +198,27 @@ void p11prov_sig_freectx(void *ctx)
              * intentionally as errors can be returned if the operation was
              * internally finalized because of a previous internal token
              * error state and, in any case, not much to be done. */
+            CK_RV ret;
             CK_SESSION_HANDLE sess = p11prov_session_handle(sigctx->session);
             if (sigctx->operation == CKF_SIGN) {
-                p11prov_SignInit(sigctx->provctx, sess, NULL,
-                                 CK_INVALID_HANDLE);
+                ret = p11prov_SignInit(sigctx->provctx, sess, NULL,
+                                       CK_INVALID_HANDLE);
             } else {
-                p11prov_VerifyInit(sigctx->provctx, sess, NULL,
-                                   CK_INVALID_HANDLE);
+                ret = p11prov_VerifyInit(sigctx->provctx, sess, NULL,
+                                         CK_INVALID_HANDLE);
+            }
+            if (ret != CKR_OK) {
+                /* NSS softokn has a broken interface and is incapable of
+                 * dropping operations on sessions returning a generic
+                 * CKR_MECHANISM_PARAM_INVALID when the mechanism is set to
+                 * NULL. Attempt to force cancellation via C_SessionCancel. */
+                ret = p11prov_SessionCancel(sigctx->provctx, sess,
+                                            sigctx->operation);
+            }
+            if (ret != CKR_OK) {
+                /* When this happens the session becomes broken as
+                 * we can't initialize operations on it anymore */
+                p11prov_session_mark_broken(sigctx->session);
             }
             sigctx->session_state = SESS_FINALIZED;
         }

--- a/src/skeymgmt.c
+++ b/src/skeymgmt.c
@@ -405,16 +405,14 @@ static int p11prov_generic_secret_export(void *keydata, int selection,
 
     if (extractable == CK_TRUE && sensitive == CK_FALSE) {
         P11PROV_SESSION *session = NULL;
-        CK_SLOT_ID slotid = p11prov_obj_get_slotid(key);
         CK_ATTRIBUTE value_attr = { CKA_VALUE, NULL_PTR, 0 };
         OSSL_PARAM params[2];
         CK_RV rv;
         int ret = RET_OSSL_ERR;
         CK_ULONG key_size;
 
-        rv = p11prov_get_session(ctx, &slotid, NULL, NULL,
-                                 CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
-                                 false, &session);
+        rv = p11prov_try_session_ref(key, CK_UNAVAILABLE_INFORMATION, false,
+                                     false, &session);
         if (rv != CKR_OK) {
             P11PROV_raise(ctx, rv, "Failed to get session for export");
             return RET_OSSL_ERR;


### PR DESCRIPTION
#### Description

This patchset comes out of a review oh how sessions are used after the EVP_SKEY facilities introduction.

One of the things I notices was that we had overly complicated code around handling two items on the session pool, login_session and open_sessions. Manipulating these attributes required, potentially costly, locking of pools every time a session is taken.

Additionally I noticed that in repeat operations session could be passed around which is not optimal on tokens that cache or otherwise internally tie ephemeral keys to sessions.

By adding a simple reference counter that prevents session from being closed and saving a pointer to those sessions on objects that have been created, it was possible to remove a bunch of locking and simplify other calls.

All this also ensures that ephemeral keys are not inadvertently discarded by closing the session they were created on.

Fixes #636 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite already covers the code
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
