### PR TITLE
util: ensure that exact 32 character PIN works

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -274,7 +274,7 @@ done:
 static int get_pin_file(P11PROV_CTX *ctx, const char *str, size_t len,
                         void **output)
 {
-    char pin[MAX_PIN_LENGTH + 1];
+    char pin[MAX_PIN_LENGTH + 1] = { 0 };
     char *pinfile;
     char *filename;
     BIO *fp;
@@ -301,7 +301,7 @@ static int get_pin_file(P11PROV_CTX *ctx, const char *str, size_t len,
         ret = ENOENT;
         goto done;
     }
-    ret = BIO_gets(fp, pin, MAX_PIN_LENGTH);
+    ret = BIO_gets(fp, pin, sizeof(pin));
     if (ret <= 0) {
         P11PROV_debug("Failed to get pin from %s (%d)", filename, ret);
         ret = EINVAL;

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -53,9 +53,9 @@ if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips
     export NSS_FIPS=1
 
     # NSS softokn requires stronger PIN in FIPS mode
-    PINVALUE="fo0m4nchU"
+    PINVALUE="fo0m4nchU-p4sSw0rd-iS-Str0ng1234"
 else
-    PINVALUE="12345678"
+    PINVALUE="0123456789ABCDEFFEDCBA9876543210"
 fi
 
 # Check if openssl supports skey


### PR DESCRIPTION
From the manpage of BIO_gets:

> BIO_gets() performs the BIOs "gets" operation and places the data in
> buf.  Usually this operation will attempt to read a line of data from
> the BIO of maximum length size - 1. [...]
>
> The returned string is always NUL-terminated and the '\n' is preserved
> if present in the input data.

It follows that we should pass the max pin length + 1 to BIO_gets, so the last byte isn't replaced by a NUL.

(This was reproducible in the tests, so update the tests).

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
