### PR TITLE
Workardound new bug in softhsm 2.7.0

### DIFF
--- a/tests/softhsm-init.sh
+++ b/tests/softhsm-init.sh
@@ -51,6 +51,9 @@ cat >"$TMPPDIR/softhsm.conf" <<EOF
 directories.tokendir = $TOKDIR
 objectstore.backend = file
 log.level = DEBUG
+# The hashed ECDSA mechanisms wrongly do not support multi-part operations
+# https://github.com/softhsm/SoftHSMv2/pull/683
+slots.mechanisms = -CKM_ECDSA_SHA1,CKM_ECDSA_SHA224,CKM_ECDSA_SHA256,CKM_ECDSA_SHA384,CKM_ECDSA_SHA512
 EOF
 
 export SOFTHSM2_CONF=$TMPPDIR/softhsm.conf


### PR DESCRIPTION
#### Description

See the analysis in #668 -- the softhsm 2.7.0 implemented hashed ECDSA mechanisms, but they wrongly do not have bAllowMultiPartOp flag so they fail in multi-part operation.

#### Checklist

- [~] Code modified for feature
- [~] Test suite updated with functionality tests
- [~] Test suite updated with negative tests
- [~] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
