### PR TITLE
Fix i686 build failures in cipher.c

### DIFF
--- a/src/cipher.c
+++ b/src/cipher.c
@@ -867,7 +867,7 @@ static CK_RV tls_aead_get_data(CK_MECHANISM_PTR mech, data_buffer *explicitiv,
 
 static CK_RV tls_pre_aead(struct p11prov_cipher_ctx *cctx,
                           const unsigned char **in, size_t *inl,
-                          unsigned char **out, size_t *outl)
+                          unsigned char **out, CK_ULONG *outl)
 {
     data_buffer iv = { 0 };
     data_buffer tag = { 0 };
@@ -906,7 +906,7 @@ static CK_RV tls_pre_aead(struct p11prov_cipher_ctx *cctx,
 }
 
 static CK_RV tls_post_aead(struct p11prov_cipher_ctx *cctx, unsigned char *out,
-                           size_t *outl)
+                           CK_ULONG *outl)
 {
     data_buffer explicitiv = { 0 };
     data_buffer tag = { 0 };
@@ -1475,15 +1475,16 @@ static int p11prov_common_set_ctx_params(void *vctx, const OSSL_PARAM params[])
                 return RET_OSSL_ERR;
             }
 
-            int ret = OSSL_PARAM_get_octet_string(
-                p, (void **)&gcm->pIv, gcm->ulIvLen, &gcm->ulIvFixedBits);
+            size_t iv_size;
+            int ret = OSSL_PARAM_get_octet_string(p, (void **)&gcm->pIv,
+                                                  gcm->ulIvLen, &iv_size);
             if (ret != RET_OSSL_OK || gcm->pIv == NULL) {
                 P11PROV_raise(ctx->provctx, CKR_HOST_MEMORY,
                               "Memory allocation failed");
                 return RET_OSSL_ERR;
             }
 
-            gcm->ulIvFixedBits = BYTES_TO_BITS(gcm->ulIvFixedBits);
+            gcm->ulIvFixedBits = BYTES_TO_BITS(iv_size);
             gcm->ivGenerator = CKG_GENERATE_COUNTER;
         } else {
             P11PROV_raise(ctx->provctx, CKR_MECHANISM_PARAM_INVALID,


### PR DESCRIPTION
#### Description

Update AEAD functions to use CK_ULONG pointers for lengths and introduce a temporary size_t variable for OSSL_PARAM calls. This corrects pointer type mismatches that caused build failures in Fedora Rawhide i686 scratch builds.

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
