### PR TITLE
Fix 32bit build

### DIFF
--- a/src/cipher.c
+++ b/src/cipher.c
@@ -867,7 +867,7 @@ static CK_RV tls_aead_get_data(CK_MECHANISM_PTR mech, data_buffer *explicitiv,
 
 static CK_RV tls_pre_aead(struct p11prov_cipher_ctx *cctx,
                           const unsigned char **in, size_t *inl,
-                          unsigned char **out, size_t *outl)
+                          unsigned char **out, CK_ULONG *outl)
 {
     data_buffer iv = { 0 };
     data_buffer tag = { 0 };
@@ -906,7 +906,7 @@ static CK_RV tls_pre_aead(struct p11prov_cipher_ctx *cctx,
 }
 
 static CK_RV tls_post_aead(struct p11prov_cipher_ctx *cctx, unsigned char *out,
-                           size_t *outl)
+                           CK_ULONG *outl)
 {
     data_buffer explicitiv = { 0 };
     data_buffer tag = { 0 };
@@ -1475,8 +1475,9 @@ static int p11prov_common_set_ctx_params(void *vctx, const OSSL_PARAM params[])
                 return RET_OSSL_ERR;
             }
 
-            int ret = OSSL_PARAM_get_octet_string(
-                p, (void **)&gcm->pIv, gcm->ulIvLen, &gcm->ulIvFixedBits);
+            int ret =
+                OSSL_PARAM_get_octet_string(p, (void **)&gcm->pIv, gcm->ulIvLen,
+                                            (size_t *)&gcm->ulIvFixedBits);
             if (ret != RET_OSSL_OK || gcm->pIv == NULL) {
                 P11PROV_raise(ctx->provctx, CKR_HOST_MEMORY,
                               "Memory allocation failed");


### PR DESCRIPTION
```
../src/cipher.c: In function ‘p11prov_cipher_update’: ../src/cipher.c:1069:54: error: passing argument 5 of ‘tls_pre_aead’ from incompatible pointer type [-Wincompatible-pointer-types]
 1069 |             rv = tls_pre_aead(cctx, &in, &inl, &out, &outlen);
      |                                                      ^~~~~~~
      |                                                      |
      |                                                      CK_ULONG * {aka long unsigned int *}
../src/cipher.c:870:56: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
  870 |                           unsigned char **out, size_t *outl)
      |                                                ~~~~~~~~^~~~
../src/cipher.c:1082:43: error: passing argument 3 of ‘tls_post_aead’ from incompatible pointer type [-Wincompatible-pointer-types]
 1082 |             rv = tls_post_aead(cctx, out, &outlen);
      |                                           ^~~~~~~
      |                                           |
      |                                           CK_ULONG * {aka long unsigned int *}
../src/cipher.c:909:36: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
  909 |                            size_t *outl)
      |                            ~~~~~~~~^~~~
../src/cipher.c:1091:54: error: passing argument 5 of ‘tls_pre_aead’ from incompatible pointer type [-Wincompatible-pointer-types]
 1091 |             rv = tls_pre_aead(cctx, &in, &inl, &out, &outlen);
      |                                                      ^~~~~~~
      |                                                      |
      |                                                      CK_ULONG * {aka long unsigned int *}
../src/cipher.c:870:56: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
  870 |                           unsigned char **out, size_t *outl)
      |                                                ~~~~~~~~^~~~
../src/cipher.c: In function ‘p11prov_common_set_ctx_params’:
../src/cipher.c:1479:54: error: passing argument 4 of ‘OSSL_PARAM_get_octet_string’ from incompatible pointer type [-Wincompatible-pointer-types]
 1479 |                 p, (void **)&gcm->pIv, gcm->ulIvLen, &gcm->ulIvFixedBits);
      |                                                      ^~~~~~~~~~~~~~~~~~~
      |                                                      |
      |                                                      CK_ULONG * {aka long unsigned int *}
In file included from /usr/include/openssl/indicator.h:18,
                 from /usr/include/openssl/core_dispatch.h:16,
                 from ../src/provider.h:16,
                 from ../src/cipher.c:5:
/usr/include/openssl/params.h:138:13: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
  138 |     size_t *used_len);
      |     ~~~~~~~~^~~~~~~~
```