### PR TITLE
Remove CKA_VALUE_LEN from ML-KEM key templates

### DIFF
--- a/src/kem.c
+++ b/src/kem.c
@@ -201,13 +201,11 @@ static int p11prov_mlkem_encapsulate(void *vctx, unsigned char *ct,
 
     CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
     CK_KEY_TYPE key_type = CKK_GENERIC_SECRET;
-    CK_ULONG value_len = mlkem_ss_len;
     CK_BBOOL val_false = CK_FALSE;
     CK_BBOOL val_true = CK_TRUE;
     CK_ATTRIBUTE key_template[] = {
         { CKA_CLASS, &key_class, sizeof(key_class) },
         { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
-        { CKA_VALUE_LEN, &value_len, sizeof(value_len) },
         { CKA_SENSITIVE, &val_false, sizeof(val_false) },
         { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
         { CKA_TOKEN, &val_false, sizeof(val_false) },
@@ -304,13 +302,11 @@ static int p11prov_mlkem_decapsulate(void *vctx, unsigned char *ss,
 
     CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
     CK_KEY_TYPE key_type = CKK_GENERIC_SECRET;
-    CK_ULONG value_len = mlkem_ss_len;
     CK_BBOOL val_false = CK_FALSE;
     CK_BBOOL val_true = CK_TRUE;
     CK_ATTRIBUTE key_template[] = {
         { CKA_CLASS, &key_class, sizeof(key_class) },
         { CKA_KEY_TYPE, &key_type, sizeof(key_type) },
-        { CKA_VALUE_LEN, &value_len, sizeof(value_len) },
         { CKA_SENSITIVE, &val_false, sizeof(val_false) },
         { CKA_EXTRACTABLE, &val_true, sizeof(val_true) },
         { CKA_TOKEN, &val_false, sizeof(val_false) },


### PR DESCRIPTION
#### Description

Remove the explicit CKA_VALUE_LEN attribute from the key templates used in ML- KEM encapsulation and decapsulation. The shared secret length is inherent to the mechanism and should not be explicitly set during the key creation process.

Fixes #692 

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
