### PR TITLE
gh: Remove non-relevant checkbox from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,3 @@ want to know about year later when sorting thorough as commits are the changelog
 - [ ] This feature/change has adequate documentation added
 - [ ] Code conform to coding style that today cannot yet be enforced via the check style test
 - [ ] Commits have short titles and sensible commit messages
-- [ ] Coverity Scan has run if needed (code PR) and no new defects were found


### PR DESCRIPTION
#### Description

Follow-up from #683, where I forgot to remove the checkbox.

#### Checklist
- [ ] no code PR

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
