### PR TITLE
Cast precision argument to int in debug log

### DIFF
--- a/src/obj/fetch.c
+++ b/src/obj/fetch.c
@@ -488,7 +488,8 @@ CK_RV p11prov_obj_find(P11PROV_CTX *provctx, P11PROV_SESSION *session,
     CK_RV ret;
 
     P11PROV_debug("Find objects [class=%lu, id-len=%lu, label=%.*s]", class,
-                  id.ulValueLen, label.type == CKA_LABEL ? label.ulValueLen : 4,
+                  id.ulValueLen,
+                  label.type == CKA_LABEL ? (int)label.ulValueLen : 4,
                   label.type == CKA_LABEL ? (char *)label.pValue : "None");
 
     switch (class) {


### PR DESCRIPTION
#### Description

The `%.*s` format specifier expects an int for the precision argument, but `label.ulValueLen` is a CK_ULONG. Cast the length to int to prevent type mismatch.

Fixes CID 643611 from Coverity.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
